### PR TITLE
#89: Add Microsoft Clarity analytics for daily traffic visibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@
 **Name:** Austin Karaoke Directory
 **Purpose:** A mobile-friendly web application helping users discover karaoke venues in and around Austin, Texas
 **Target Users:** Karaoke enthusiasts looking for venues, schedules, and event details
-**Live Site:** [Add deployment URL when available]
+**Live Site:** https://www.karaokedirectory.com
+**Analytics:** Microsoft Clarity (project ID `x1sfnv6zu4`) — see snippet before `</body>` on all public HTML pages
 
 ## Architecture
 

--- a/about.html
+++ b/about.html
@@ -152,5 +152,12 @@
             &copy; 2025 Austin Karaoke Directory
         </p>
     </footer>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x1sfnv6zu4");
+    </script>
 </body>
 </html>

--- a/bday.html
+++ b/bday.html
@@ -657,5 +657,12 @@
             }
         });
     </script>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x1sfnv6zu4");
+    </script>
 </body>
 </html>

--- a/bingo.html
+++ b/bingo.html
@@ -77,5 +77,12 @@
     </footer>
 
     <script src="js/bingo.js"></script>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x1sfnv6zu4");
+    </script>
 </body>
 </html>

--- a/editor.html
+++ b/editor.html
@@ -322,5 +322,12 @@
 
     <script src="js/data.js"></script>
     <script type="module" src="editor/editor.js"></script>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x1sfnv6zu4");
+    </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -254,5 +254,12 @@
             setTimeout(showLyrics, TITLE_DISPLAY_TIME);
         })();
     </script>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x1sfnv6zu4");
+    </script>
 </body>
 </html>

--- a/submit.html
+++ b/submit.html
@@ -1098,5 +1098,12 @@
             submitToAPI(payload, subject, emailBody, submitBtn);
         });
     </script>
+    <script type="text/javascript">
+        (function(c,l,a,r,i,t,y){
+            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+        })(window, document, "clarity", "script", "x1sfnv6zu4");
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Adds the Microsoft Clarity beacon (project `x1sfnv6zu4`) before `</body>` on all six public HTML pages: `index.html`, `about.html`, `bingo.html`, `submit.html`, `bday.html`, `editor.html`
- Records the live site URL (`https://www.karaokedirectory.com`) and analytics provider in `CLAUDE.md` so future sessions don't lose them
- Free, no usage limits, no cookie/consent banner required

## Verification
Confirmed locally via the dev server:
- `GET https://www.clarity.ms/tag/x1sfnv6zu4` → 200
- `GET https://scripts.clarity.ms/0.8.64/clarity.js` → 200
- `POST https://o.clarity.ms/collect` → 204 (telemetry firing)
- No new console errors

## Test plan
- [ ] Merge to main and confirm www.karaokedirectory.com loads without errors in DevTools console
- [ ] Visit a couple of pages (`/`, `/about.html`, `/bingo.html`) to seed data
- [ ] Within ~2 hours, confirm pageviews show up at https://clarity.microsoft.com under the Karaoke Directory project

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)