### PR TITLE
#91: Gate Clarity behind consent banner; add Privacy section

### DIFF
--- a/about.html
+++ b/about.html
@@ -94,6 +94,17 @@
             </div>
         </article>
 
+        <article class="day-card" id="privacy">
+            <header class="day-card__header">
+                <h2 class="day-card__day">Privacy</h2>
+            </header>
+            <div class="day-card__content">
+                <p>This site uses <a href="https://clarity.microsoft.com" target="_blank" rel="noopener noreferrer">Microsoft Clarity</a> to understand how visitors use the directory &mdash; what pages get viewed, where people click, how they scroll. The data is anonymous and aggregated; no personal information is collected.</p>
+                <p>The first time you visit, a banner asks for your consent. Clarity does not run until you click Accept. To revisit your choice, clear this site's data in your browser settings and reload.</p>
+                <p>No accounts, no email addresses, no profile tracking. Just karaoke.</p>
+            </div>
+        </article>
+
         <article class="day-card">
             <header class="day-card__header">
                 <h2 class="day-card__day">For Developers</h2>
@@ -152,12 +163,6 @@
             &copy; 2025 Austin Karaoke Directory
         </p>
     </footer>
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "x1sfnv6zu4");
-    </script>
+    <script src="js/analytics.js" defer></script>
 </body>
 </html>

--- a/bday.html
+++ b/bday.html
@@ -657,12 +657,6 @@
             }
         });
     </script>
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "x1sfnv6zu4");
-    </script>
+    <script src="js/analytics.js" defer></script>
 </body>
 </html>

--- a/bingo.html
+++ b/bingo.html
@@ -77,12 +77,6 @@
     </footer>
 
     <script src="js/bingo.js"></script>
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "x1sfnv6zu4");
-    </script>
+    <script src="js/analytics.js" defer></script>
 </body>
 </html>

--- a/css/components.css
+++ b/css/components.css
@@ -966,3 +966,84 @@
 .debug-indicator i {
     font-size: var(--font-size-sm);
 }
+
+/* ============================================================================
+   Analytics consent banner
+   Rendered by js/analytics.js on first visit; gates Microsoft Clarity loading
+   ============================================================================ */
+
+.consent-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    z-index: 9999;
+    background: var(--bg-card);
+    border-top: 1px solid var(--border-color);
+    padding: var(--spacing-md);
+    box-shadow: 0 -2px 12px rgba(0, 0, 0, 0.15);
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.consent-banner__text {
+    margin: 0;
+    font-size: var(--font-size-sm);
+    line-height: 1.4;
+    color: var(--text-primary);
+}
+
+.consent-banner__text a {
+    text-decoration: underline;
+}
+
+.consent-banner__actions {
+    display: flex;
+    gap: var(--spacing-sm);
+    justify-content: flex-end;
+}
+
+.consent-banner__btn {
+    padding: var(--spacing-xs) var(--spacing-md);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+    background: transparent;
+    color: var(--text-primary);
+    cursor: pointer;
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    transition: all var(--transition-fast);
+}
+
+.consent-banner__btn:hover {
+    background: var(--color-gray-700);
+}
+
+.consent-banner__btn--accept {
+    background: var(--color-primary);
+    color: var(--color-white);
+    border-color: var(--color-primary);
+}
+
+.consent-banner__btn--accept:hover {
+    background: var(--color-primary-dark);
+}
+
+@media (min-width: 768px) {
+    .consent-banner {
+        flex-direction: row;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--spacing-md) var(--spacing-lg);
+    }
+
+    .consent-banner__text {
+        flex: 1;
+        max-width: 70%;
+    }
+
+    .consent-banner__actions {
+        flex-shrink: 0;
+    }
+}

--- a/editor.html
+++ b/editor.html
@@ -322,12 +322,6 @@
 
     <script src="js/data.js"></script>
     <script type="module" src="editor/editor.js"></script>
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "x1sfnv6zu4");
-    </script>
+    <script src="js/analytics.js" defer></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -254,12 +254,6 @@
             setTimeout(showLyrics, TITLE_DISPLAY_TIME);
         })();
     </script>
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "x1sfnv6zu4");
-    </script>
+    <script src="js/analytics.js" defer></script>
 </body>
 </html>

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -1,0 +1,67 @@
+/**
+ * Consent-gated Microsoft Clarity loader.
+ *
+ * Why this lives in its own file:
+ * Clarity sets non-essential cookies, so loading it before consent would
+ * violate GDPR/ePrivacy. We render a banner on first visit and only
+ * load the tag if the visitor clicks Accept. Choice persists in
+ * localStorage so the banner only appears once.
+ */
+(function () {
+    'use strict';
+
+    var STORAGE_KEY = 'kd_analytics_consent';
+    var CLARITY_ID = 'x1sfnv6zu4';
+
+    function getConsent() {
+        try { return localStorage.getItem(STORAGE_KEY); } catch (e) { return null; }
+    }
+
+    function setConsent(value) {
+        try { localStorage.setItem(STORAGE_KEY, value); } catch (e) { /* private mode etc. */ }
+    }
+
+    function loadClarity() {
+        (function (c, l, a, r, i, t, y) {
+            c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };
+            t = l.createElement(r); t.async = 1; t.src = 'https://www.clarity.ms/tag/' + i;
+            y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+        })(window, document, 'clarity', 'script', CLARITY_ID);
+    }
+
+    function renderBanner() {
+        var banner = document.createElement('div');
+        banner.className = 'consent-banner';
+        banner.setAttribute('role', 'dialog');
+        banner.setAttribute('aria-label', 'Analytics consent');
+        banner.innerHTML =
+            '<p class="consent-banner__text">' +
+                'This site uses Microsoft Clarity for anonymous traffic analytics ' +
+                '(pageviews, clicks, scrolling). No personal information is collected. ' +
+                '<a href="about.html#privacy">Learn more</a>.' +
+            '</p>' +
+            '<div class="consent-banner__actions">' +
+                '<button type="button" class="consent-banner__btn consent-banner__btn--decline" data-consent="declined">Decline</button>' +
+                '<button type="button" class="consent-banner__btn consent-banner__btn--accept" data-consent="accepted">Accept</button>' +
+            '</div>';
+        banner.addEventListener('click', function (e) {
+            var choice = e.target && e.target.getAttribute('data-consent');
+            if (!choice) return;
+            setConsent(choice);
+            banner.remove();
+            if (choice === 'accepted') loadClarity();
+        });
+        document.body.appendChild(banner);
+    }
+
+    var consent = getConsent();
+    if (consent === 'accepted') {
+        loadClarity();
+    } else if (consent !== 'declined') {
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', renderBanner);
+        } else {
+            renderBanner();
+        }
+    }
+})();

--- a/submit.html
+++ b/submit.html
@@ -1098,12 +1098,6 @@
             submitToAPI(payload, subject, emailBody, submitBtn);
         });
     </script>
-    <script type="text/javascript">
-        (function(c,l,a,r,i,t,y){
-            c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
-            t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
-            y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
-        })(window, document, "clarity", "script", "x1sfnv6zu4");
-    </script>
+    <script src="js/analytics.js" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Extracts Clarity into shared `js/analytics.js`, gated on visitor consent
- First-visit banner asks Accept/Decline; choice persists in `localStorage`; Clarity only loads on Accept
- Adds Privacy section to `about.html` anchored at `#privacy`, linked from the banner

## Why a follow-up PR
PR #90 shipped the analytics beacon ahead of this commit, so the live site is currently tracking visitors without consent. This PR closes the gap.

## Verification (local preview)
- First visit → banner rendered, zero `clarity.ms` network calls
- Click Accept → banner removed, `kd_analytics_consent = "accepted"`, `clarity.js` loads, `POST o.clarity.ms/collect → 204`
- Click Decline → banner removed, `kd_analytics_consent = "declined"`, zero `clarity.ms` calls
- Reload after Decline → no banner re-render, no Clarity calls
- `/about.html#privacy` renders the new Privacy section

## Test plan
- [ ] After merge: load the site in a clean browser (or `localStorage.clear()`), confirm the banner appears
- [ ] Click Accept → confirm pageviews start showing up in Clarity dashboard
- [ ] In another clean browser, click Decline → confirm no Clarity requests fire in DevTools Network

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)