### PR TITLE
#93: Curator master + build step (gitignored authoritative data, generated public js/data.js)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 js/data.js.backup
 
+# Curator master data (private — gitignored, derives js/data.js via build script)
+/_curator/
+
 # Taiga export archive
 taigaexport/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@
 - Event bus for component communication (`js/core/events.js`)
 
 ### 5. Data Layer
-- All venue data in `js/data.js` (currently 79 venues) — the active runtime source, plus canonical authoring source
+- Public venue data in `js/data.js` (currently 77 venues) — the runtime source for the deployed site. **Generated** by `scripts/build-public-data.js` from the gitignored curator master (`_curator/data.js`). See ADR-005.
 - Supabase wiring exists (`js/services/supabase.js`, JSONB-heavy 2-table schema in `supabase/migrations/`) but is currently **disabled** via `useSupabase: false` in `js/config.js`. See spec §11 *Storage and Data Flow*.
 - Service layer abstracts data access (`js/services/venues.js`) — data-source agnostic, so the swap is a one-flag change
 - Schedule matching logic handles complex recurrence patterns
@@ -144,9 +144,22 @@ karaokedirectory/
 │   └── editor.js          # Venue editor functionality
 │
 ├── scripts/               # Developer tools
-│   ├── geocode-venues.js  # Add coordinates to venues
-│   ├── validate-data.js   # Validate venue data integrity
-│   └── audit-for-supabase.js  # Pre-seed validation against logical rules
+│   ├── geocode-venues.js       # Add coordinates to venues
+│   ├── validate-data.js        # Validate venue data integrity
+│   ├── audit-for-supabase.js   # Pre-seed validation against logical rules
+│   ├── build-public-data.js    # Curator master → js/data.js (strips _curatorMeta; ADR-005)
+│   ├── bootstrap-curator.js    # One-time: js/data.js → _curator/data.js
+│   ├── install-hooks.js        # Installs the pre-commit hook (one-time per checkout)
+│   ├── precommit.js            # Pre-commit hook callback (runs the build, stages js/data.js)
+│   └── watch-master.js         # Optional: rebuild on master save during a curation session
+│
+├── _curator.example/      # Curator dashboard template (committed; copy to _curator/ on bootstrap)
+│   ├── index.html              # Plain data-table dashboard (NOT styled like the public app)
+│   ├── data.js                 # Empty master template
+│   └── README.md               # Bootstrap + day-to-day cycle docs
+│
+├── _curator/              # Curator master + dashboard instance (gitignored — see ADR-005)
+│   └── data.js                 # Authoritative venue data + private _curatorMeta annotations
 │
 ├── supabase/              # Supabase schema + seed pipeline
 │   ├── migrations/        # SQL migrations (001–004; 004 is the current JSONB schema)
@@ -166,7 +179,7 @@ karaokedirectory/
 
 ## Venue Data Format
 
-When adding or modifying venues in `js/data.js`, follow this structure:
+When adding or modifying venues in the curator master (`_curator/data.js` — see ADR-005), follow this structure. The same shape applies to public listings in the generated `js/data.js`; the only difference is that master entries may carry an optional `_curatorMeta` field that the build strips.
 
 ```javascript
 {
@@ -220,6 +233,29 @@ When adding or modifying venues in `js/data.js`, follow this structure:
     tiktok: "https://tiktok.com/...",
     youtube: "https://youtube.com/...",
     bluesky: "https://bsky.app/..."
+  }
+}
+```
+
+### Curator metadata (master-only, never published)
+
+In the master (`_curator/data.js`) only, a listing may carry an optional `_curatorMeta` field. The build script strips this from `js/data.js` and refuses to write if any `_curatorMeta` slips through. Never edit this in `js/data.js` directly — it has no business being there.
+
+```javascript
+{
+  id: "venue-slug",
+  // ...all the public fields above...
+  _curatorMeta: {                  // optional, master-only
+    source: "https://...",         // URL where you learned about this venue
+    sourceNotes: "Saw March post", // free-text qualifier
+    contact: {                     // all sub-fields optional
+      name: "Sarah Manager",
+      role: "Owner",
+      phone: "512-555-1234",
+      email: "sarah@example.com"
+    },
+    notes: "Quiet on holidays. Best to call to confirm.",
+    lastVerified: "2026-05-15"     // YYYY-MM-DD; dashboard flags rows past the overdue threshold
   }
 }
 ```
@@ -350,10 +386,34 @@ Use these semantic elements consistently:
 ## Common Development Tasks
 
 ### Adding a New Venue
-1. Edit `js/data.js` (or use the venue editor at `editor.html`)
-2. Add venue object to `listings` array
-3. Run `scripts/validate-data.js` to check format
-4. Add coordinates using the "Geocode Address" button in the editor, or via `scripts/geocode-venues.js` (Node.js batch)
+
+**Edit the curator master**, not `js/data.js` directly. `js/data.js` is now a generated artifact (see ADR-005).
+
+1. Open `editor.html` locally — it auto-detects Master mode when `_curator/data.js` is present (badge in the header reads "Master mode (local)").
+2. Fill in venue fields. Add source / contact / notes in the Curator Notes fieldset if you have them.
+3. Click "Copy JSON" — output is wrapped as `const curatorMasterData = ...` with the dual-export footer.
+4. Paste into `_curator/data.js`, overwriting the file.
+5. Run `node scripts/build-public-data.js` (or let the pre-commit hook do it) — `js/data.js` is regenerated with `_curatorMeta` stripped.
+6. Reload `localhost:8000/index.html` to verify the public app renders correctly.
+7. `git commit` — hook re-runs the build for safety and stages `js/data.js`.
+
+**On the deployed site**, `editor.html` lands in Public mode (no `_curator/data.js` to load), curator fields hide, and "Copy JSON" emits a public-only object — exactly as before ADR-005.
+
+For batch coordinate updates, `scripts/geocode-venues.js` still works (it modifies `js/data.js` in place); after running it, copy the changed listings back into `_curator/data.js` to keep the master in sync.
+
+### Curator master / build step (read before editing js/data.js)
+
+Per [ADR-005](docs/adr/005-curator-master-build-step.md), `js/data.js` is now a **generated artifact**. The authoritative venue data — public fields plus optional private `_curatorMeta` per listing — lives in a gitignored `_curator/data.js`. A Node script regenerates `js/data.js` from the master with `_curatorMeta` stripped and validates strictly before writing.
+
+Key implications for any session that touches venue data:
+
+- **Don't hand-edit `js/data.js`.** Edits will be clobbered by the next build. Edit `_curator/data.js` (master) instead. The exception is `scripts/geocode-venues.js` (the existing batch tool); after it runs, re-sync coordinates back into the master.
+- **`editor.html` auto-detects mode** by checking whether `window.curatorMasterData` is defined. Master mode (local, `_curator/data.js` present) shows the Curator Notes fieldset and emits `_curatorMeta`. Public mode (deployed site, no master) hides curator fields and never emits private fields — even if the curator-fieldset DOM is forced visible via DevTools.
+- **A pre-commit hook** (`.git/hooks/pre-commit`, installed by `node scripts/install-hooks.js`) runs the build on every commit. It blocks the commit if validation fails, and stages `js/data.js` if it changed.
+- **Curator dashboard** at `_curator/index.html` is a plain table view for scanning sources / contacts / overdue verifications. Deliberately NOT styled like the public app. Read-only — editing happens in `editor.html`.
+- **Safety guarantees**: the build's safety check (`if serialized output contains "_curatorMeta", refuse to write`) is structural — not procedural discipline. Combined with `/_curator/` in `.gitignore`, private data has no path to the public repo.
+
+Bootstrap a new checkout: `node scripts/bootstrap-curator.js` then `node scripts/install-hooks.js`. See `_curator.example/README.md` for the day-to-day cycle.
 
 ### Adding a New View
 1. Create `js/views/NewView.js` extending Component
@@ -455,6 +515,7 @@ Current ADRs:
 - [ADR-002](docs/adr/002-vanilla-js-no-build.md) — Vanilla JS, no framework, no build step
 - [ADR-003](docs/adr/003-github-pages-deploy.md) — GitHub Pages as deploy target
 - [ADR-004](docs/adr/004-parallel-data-source-flag.md) — Parallel data source via URL flag
+- [ADR-005](docs/adr/005-curator-master-build-step.md) — Curator-side data transformation; deploy stays build-free
 
 ## Security Considerations
 - Always use `escapeHtml()` when rendering user-provided content

--- a/_curator.example/README.md
+++ b/_curator.example/README.md
@@ -1,0 +1,57 @@
+# Curator Dashboard
+
+This folder is the **template** for the curator's private workspace. The real instance lives at `_curator/` (gitignored), which you create by copying this folder.
+
+## What it does
+
+You edit one file — `_curator/data.js` — which contains every venue plus any private notes you want to attach (source URL, contact info, last-verified date, free-text notes). A small Node script reads it, strips the private fields, and writes the public `js/data.js`. A git pre-commit hook runs the build automatically so you can't forget.
+
+Your private notes never reach the public repo. `_curator/` is gitignored as a folder; you'd need `git add -f` to commit anything in it.
+
+## One-time setup
+
+Two steps. The first creates `_curator/data.js` (your authoritative master) by transforming the current public `js/data.js`. The second wires up the pre-commit hook that runs the build for you.
+
+```
+node scripts/bootstrap-curator.js
+node scripts/install-hooks.js
+```
+
+That's it. After this, `js/data.js` becomes a generated artifact — you never edit it by hand again. The `_curator.example/` folder you're reading is no longer involved; the live workspace is `_curator/`.
+
+Smoke test the build (optional, just to confirm):
+
+```
+node scripts/build-public-data.js
+```
+
+This should report "up to date" — the bootstrap leaves the master in a state where the next build produces no changes.
+
+## Day-to-day cycle
+
+1. Edit master via `editor.html` (it auto-detects Master mode when `_curator/data.js` is present and shows a curator-notes fieldset) or by opening `_curator/data.js` in a text editor.
+2. Save. If you have `node scripts/watch-master.js` running, the rebuild happens automatically; otherwise run `node scripts/build-public-data.js`.
+3. Reload `http://localhost:8000/index.html` (your dev server) to preview the public app with the fresh data.
+4. When it looks right, `git commit`. The pre-commit hook re-runs the build and stages `js/data.js` for you.
+5. `git push`.
+
+## The dashboard
+
+Open `_curator/index.html` in your browser (double-click works — it runs over `file://` with no server needed). You'll see a plain table view of every venue and every show, including your private notes. Use it to scan coverage, spot venues that need sources, and find contacts quickly.
+
+The dashboard is read-only. Edits happen in `editor.html`.
+
+## Files in this folder
+
+- **`data.js`** — the master template. After copying, this becomes your authoritative venue data with private annotations.
+- **`index.html`** — the dashboard (data-table view of everything).
+- **`README.md`** — this file.
+
+## Why this is safe
+
+- `/_curator/` is in `.gitignore` — your private notes never enter the repo.
+- The build script validates strictly: if any `_curatorMeta` would survive into `js/data.js`, the build refuses to write.
+- The pre-commit hook re-runs the build before every commit, so a forgotten manual step can't lag the live site.
+- The editor on the deployed public site has no `_curator/data.js` to load, so it lands in Public mode with curator fields hidden — same behavior as before this folder existed.
+
+See `docs/adr/005-curator-master-build-step.md` for the architectural rationale.

--- a/_curator.example/data.js
+++ b/_curator.example/data.js
@@ -1,0 +1,41 @@
+/**
+ * Curator master data — TEMPLATE.
+ *
+ * Copy this file (along with the rest of _curator.example/) to a new
+ * _curator/ folder, then replace the empty objects below with the contents
+ * of the current js/data.js. After bootstrap, this is your single source of
+ * truth — edit here, then run `node scripts/build-public-data.js` (or just
+ * commit; the pre-commit hook runs the build for you) to regenerate js/data.js
+ * with all _curatorMeta fields stripped.
+ *
+ * Each listing may carry an optional _curatorMeta field with your private
+ * notes (source, contact, lastVerified, etc.). The build strips these from
+ * the public output. They never leave your machine.
+ *
+ * Example _curatorMeta shape:
+ *   _curatorMeta: {
+ *     source: "https://facebook.com/venue/posts/12345",
+ *     sourceNotes: "Saw their March 2025 announcement",
+ *     contact: {
+ *       name: "Sarah Manager",
+ *       role: "Owner",
+ *       phone: "512-555-1234",
+ *       email: "sarah@example.com"
+ *     },
+ *     notes: "Confirmed via phone 5/15/26. Quiet on holidays.",
+ *     lastVerified: "2026-05-15"
+ *   }
+ */
+const curatorMasterData = {
+    tagDefinitions: {
+        // Paste tagDefinitions from js/data.js here on bootstrap
+    },
+    listings: [
+        // Paste listings from js/data.js here on bootstrap; add _curatorMeta as you go
+    ]
+};
+
+// Dual export so this file works in both the browser (editor.html, dashboard)
+// and Node (build script, hook).
+if (typeof window !== 'undefined') window.curatorMasterData = curatorMasterData;
+if (typeof module !== 'undefined') module.exports = curatorMasterData;

--- a/_curator.example/index.html
+++ b/_curator.example/index.html
@@ -1,0 +1,511 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>Curator Dashboard — Karaoke Directory</title>
+    <style>
+        /* Deliberately plain — NOT the public app's look. Spreadsheet-like. */
+        * { box-sizing: border-box; }
+        html, body {
+            margin: 0;
+            padding: 0;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            font-size: 13px;
+            color: #1a1a1a;
+            background: #f5f5f5;
+        }
+        header {
+            background: #2c3e50;
+            color: #fff;
+            padding: 10px 16px;
+            display: flex;
+            align-items: center;
+            gap: 16px;
+            position: sticky;
+            top: 0;
+            z-index: 10;
+        }
+        header h1 {
+            margin: 0;
+            font-size: 16px;
+            font-weight: 600;
+        }
+        .header__stats {
+            font-size: 12px;
+            opacity: 0.85;
+        }
+        .header__source {
+            margin-left: auto;
+            font-size: 11px;
+            font-family: monospace;
+            opacity: 0.6;
+        }
+        nav {
+            background: #fff;
+            border-bottom: 1px solid #ccc;
+            padding: 0 16px;
+            display: flex;
+            gap: 0;
+            align-items: stretch;
+            position: sticky;
+            top: 42px;
+            z-index: 9;
+        }
+        .tab {
+            background: none;
+            border: none;
+            padding: 8px 14px;
+            font-size: 13px;
+            cursor: pointer;
+            color: #555;
+            border-bottom: 2px solid transparent;
+        }
+        .tab:hover { background: #f8f8f8; }
+        .tab.is-active {
+            color: #1a1a1a;
+            border-bottom-color: #2c3e50;
+            font-weight: 600;
+        }
+        .tab__count {
+            opacity: 0.5;
+            margin-left: 4px;
+            font-variant-numeric: tabular-nums;
+        }
+        .toolbar {
+            background: #fff;
+            border-bottom: 1px solid #e0e0e0;
+            padding: 8px 16px;
+            display: flex;
+            gap: 12px;
+            align-items: center;
+            position: sticky;
+            top: 78px;
+            z-index: 8;
+        }
+        .toolbar input[type=search] {
+            flex: 1;
+            max-width: 400px;
+            padding: 5px 8px;
+            font-size: 13px;
+            border: 1px solid #bbb;
+            border-radius: 3px;
+        }
+        .toolbar label {
+            font-size: 12px;
+            color: #555;
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .toolbar select {
+            padding: 4px 6px;
+            font-size: 12px;
+            border: 1px solid #bbb;
+            border-radius: 3px;
+            background: #fff;
+        }
+        main { padding: 0; }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            background: #fff;
+            font-size: 12px;
+        }
+        thead th {
+            background: #ecf0f1;
+            text-align: left;
+            padding: 6px 10px;
+            border-bottom: 1px solid #bbb;
+            font-weight: 600;
+            position: sticky;
+            top: 119px;
+            z-index: 5;
+            cursor: pointer;
+            user-select: none;
+            white-space: nowrap;
+        }
+        thead th:hover { background: #d5dde0; }
+        thead th .sort-arrow {
+            opacity: 0.25;
+            font-size: 10px;
+            margin-left: 2px;
+        }
+        thead th.is-sorted .sort-arrow { opacity: 1; }
+        tbody td {
+            padding: 5px 10px;
+            border-bottom: 1px solid #eee;
+            vertical-align: top;
+        }
+        tbody tr:nth-child(even) { background: #fafafa; }
+        tbody tr:hover { background: #fff8e1; }
+        tbody tr.is-stale td { color: #a00; }
+        tbody tr.is-needs-source td { background: #fff3cd; }
+        tbody tr.is-needs-source:nth-child(even) td { background: #fcefb8; }
+        .col-id { font-family: 'Cascadia Mono', Consolas, monospace; font-size: 11px; color: #555; max-width: 140px; word-break: break-all; }
+        .col-name { font-weight: 600; max-width: 220px; word-wrap: break-word; }
+        .col-key { font-family: 'Cascadia Mono', Consolas, monospace; font-size: 11px; color: #555; cursor: pointer; max-width: 320px; word-break: break-all; }
+        .col-key:hover { background: #eee; }
+        .col-link a { color: #1976d2; text-decoration: none; }
+        .col-link a:hover { text-decoration: underline; }
+        .col-link a:visited { color: #6a1b9a; }
+        .col-contact { line-height: 1.5; }
+        .col-contact a { color: #1976d2; text-decoration: none; }
+        .col-contact a:hover { text-decoration: underline; }
+        .col-notes { max-width: 280px; color: #555; font-style: italic; }
+        .col-narrow { white-space: nowrap; }
+        .badge {
+            display: inline-block;
+            padding: 1px 6px;
+            font-size: 10px;
+            border-radius: 2px;
+            background: #eee;
+            color: #666;
+            margin-right: 2px;
+            white-space: nowrap;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.3px;
+        }
+        .badge--warn { background: #fff3cd; color: #856404; }
+        .badge--ok { background: #d4edda; color: #155724; }
+        .badge--stale { background: #f8d7da; color: #721c24; }
+        .empty {
+            padding: 60px 16px;
+            text-align: center;
+            color: #999;
+            font-style: italic;
+        }
+        .error {
+            margin: 16px;
+            padding: 12px 16px;
+            background: #ffebee;
+            border: 1px solid #ef9a9a;
+            color: #b71c1c;
+            border-radius: 3px;
+            font-family: monospace;
+            white-space: pre-wrap;
+        }
+        .copy-hint {
+            position: fixed;
+            bottom: 16px;
+            right: 16px;
+            background: #323232;
+            color: #fff;
+            padding: 8px 14px;
+            border-radius: 4px;
+            font-size: 12px;
+            opacity: 0;
+            transition: opacity 0.2s;
+            pointer-events: none;
+            z-index: 20;
+        }
+        .copy-hint.is-visible { opacity: 1; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Curator Dashboard</h1>
+        <div class="header__stats" id="stats">Loading…</div>
+        <div class="header__source">file: _curator/data.js</div>
+    </header>
+    <nav>
+        <button class="tab is-active" data-tab="venues">By Venue <span class="tab__count" id="count-venues"></span></button>
+        <button class="tab" data-tab="shows">By KJ Show <span class="tab__count" id="count-shows"></span></button>
+        <button class="tab" data-tab="needs">Needs Sources <span class="tab__count" id="count-needs"></span></button>
+        <button class="tab" data-tab="overdue">Overdue <span class="tab__count" id="count-overdue"></span></button>
+    </nav>
+    <div class="toolbar">
+        <input type="search" id="search" placeholder="Filter rows by any field…">
+        <label>
+            Overdue threshold:
+            <select id="overdue-days">
+                <option value="60">60 days</option>
+                <option value="90" selected>90 days</option>
+                <option value="180">180 days</option>
+                <option value="365">1 year</option>
+            </select>
+        </label>
+    </div>
+    <main id="main"></main>
+    <div class="copy-hint" id="copy-hint">Copied</div>
+
+    <script src="data.js"></script>
+    <script>
+        (function () {
+            'use strict';
+
+            const main = document.getElementById('main');
+            if (typeof curatorMasterData === 'undefined') {
+                main.innerHTML = '<div class="error">data.js did not load or did not define curatorMasterData.\n\nCheck that _curator/data.js exists and follows the template format.</div>';
+                return;
+            }
+
+            const listings = curatorMasterData.listings || [];
+
+            // ---- Derive show rows ------------------------------------------------
+            // A show is one (venue, day, KJ) tuple. The key is canonical so the curator
+            // can paste it elsewhere if needed.
+            function deriveShows(venues) {
+                const rows = [];
+                for (const v of venues) {
+                    const kj = (v.host && v.host.name) || 'no-kj';
+                    const venueMeta = v._curatorMeta || null;
+                    for (const s of (v.schedule || [])) {
+                        const day = s.day || s.date || 'unknown';
+                        rows.push({
+                            showKey: v.id + '::' + day + '::' + kj,
+                            venueId: v.id,
+                            venueName: v.name,
+                            venueCity: (v.address && v.address.city) || '',
+                            day,
+                            frequency: s.frequency || 'every',
+                            startTime: s.startTime || '',
+                            endTime: s.endTime || '',
+                            kj,
+                            // Per-show meta would live on s._curatorMeta; fall back to venue meta
+                            meta: s._curatorMeta || venueMeta
+                        });
+                    }
+                }
+                return rows;
+            }
+
+            const venueRows = listings.map(function (v) {
+                return {
+                    id: v.id,
+                    name: v.name,
+                    city: (v.address && v.address.city) || '',
+                    neighborhood: (v.address && v.address.neighborhood) || '',
+                    scheduleCount: (v.schedule || []).length,
+                    tags: (v.tags || []).join(', '),
+                    meta: v._curatorMeta || null
+                };
+            });
+
+            const showRows = deriveShows(listings);
+
+            // ---- Coverage stats --------------------------------------------------
+            const venuesWithSource = venueRows.filter(function (r) { return r.meta && r.meta.source; });
+            const showsWithSource = showRows.filter(function (r) { return r.meta && r.meta.source; });
+
+            function daysAgo(isoDate) {
+                if (!isoDate) return Infinity;
+                const t = new Date(isoDate).getTime();
+                if (isNaN(t)) return Infinity;
+                return Math.floor((Date.now() - t) / (1000 * 60 * 60 * 24));
+            }
+
+            function overdueVenues(thresholdDays) {
+                return venueRows.filter(function (r) {
+                    return r.meta && r.meta.lastVerified && daysAgo(r.meta.lastVerified) > thresholdDays;
+                });
+            }
+            function needsSourceVenues() {
+                return venueRows.filter(function (r) { return !r.meta || !r.meta.source; });
+            }
+
+            // ---- Rendering -------------------------------------------------------
+            function esc(s) {
+                if (s === null || s === undefined) return '';
+                return String(s).replace(/[&<>"]/g, function (c) {
+                    return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c];
+                });
+            }
+
+            function renderContact(meta) {
+                if (!meta || !meta.contact) return '';
+                const c = meta.contact;
+                const parts = [];
+                if (c.name) parts.push(esc(c.name) + (c.role ? ' <span style="opacity:0.6">(' + esc(c.role) + ')</span>' : ''));
+                if (c.phone) parts.push('<a href="tel:' + esc(c.phone) + '">' + esc(c.phone) + '</a>');
+                if (c.email) parts.push('<a href="mailto:' + esc(c.email) + '">' + esc(c.email) + '</a>');
+                return parts.join('<br>');
+            }
+
+            function renderSource(meta) {
+                if (!meta || !meta.source) return '<span class="badge badge--warn">no source</span>';
+                const note = meta.sourceNotes ? ' <span style="opacity:0.6">— ' + esc(meta.sourceNotes) + '</span>' : '';
+                return '<a href="' + esc(meta.source) + '" target="_blank" rel="noopener noreferrer">link</a>' + note;
+            }
+
+            function renderLastVerified(meta, thresholdDays) {
+                if (!meta || !meta.lastVerified) return '<span class="badge">never</span>';
+                const days = daysAgo(meta.lastVerified);
+                let cls = 'badge--ok';
+                if (days > thresholdDays) cls = 'badge--stale';
+                else if (days > thresholdDays / 2) cls = 'badge--warn';
+                return '<span class="badge ' + cls + '">' + esc(meta.lastVerified) + ' (' + days + 'd)</span>';
+            }
+
+            const TAB_DEFS = {
+                venues: {
+                    columns: [
+                        { key: 'id', label: 'ID', cls: 'col-id' },
+                        { key: 'name', label: 'Name', cls: 'col-name' },
+                        { key: 'city', label: 'City', cls: 'col-narrow' },
+                        { key: 'scheduleCount', label: '#Shows', cls: 'col-narrow', sortNumeric: true },
+                        { key: 'tags', label: 'Tags' },
+                        { key: 'source', label: 'Source', cls: 'col-link', sortable: false, render: function (r) { return renderSource(r.meta); } },
+                        { key: 'contact', label: 'Contact', cls: 'col-contact', sortable: false, render: function (r) { return renderContact(r.meta); } },
+                        { key: 'notes', label: 'Notes', cls: 'col-notes', sortable: false, render: function (r) { return r.meta && r.meta.notes ? esc(r.meta.notes) : ''; } },
+                        { key: 'lastVerified', label: 'Last Verified', cls: 'col-narrow', sortable: false, render: function (r) { return renderLastVerified(r.meta, getThreshold()); } }
+                    ],
+                    rowClass: function (r) { return r.meta && r.meta.source ? '' : 'is-needs-source'; }
+                },
+                shows: {
+                    columns: [
+                        { key: 'showKey', label: 'Show key', cls: 'col-key', render: function (r) { return '<span data-copy="' + esc(r.showKey) + '">' + esc(r.showKey) + '</span>'; } },
+                        { key: 'venueName', label: 'Venue', cls: 'col-name' },
+                        { key: 'day', label: 'Day', cls: 'col-narrow' },
+                        { key: 'frequency', label: 'Freq', cls: 'col-narrow' },
+                        { key: 'time', label: 'Time', cls: 'col-narrow', render: function (r) { return esc(r.startTime + (r.endTime ? '–' + r.endTime : '')); } },
+                        { key: 'kj', label: 'KJ', cls: 'col-narrow' },
+                        { key: 'source', label: 'Source', cls: 'col-link', sortable: false, render: function (r) { return renderSource(r.meta); } },
+                        { key: 'contact', label: 'Contact', cls: 'col-contact', sortable: false, render: function (r) { return renderContact(r.meta); } }
+                    ],
+                    rowClass: function (r) { return r.meta && r.meta.source ? '' : ''; }
+                }
+            };
+            TAB_DEFS.needs = Object.assign({}, TAB_DEFS.venues, { rowClass: function () { return 'is-needs-source'; } });
+            TAB_DEFS.overdue = Object.assign({}, TAB_DEFS.venues, { rowClass: function () { return 'is-stale'; } });
+
+            // ---- State -----------------------------------------------------------
+            let activeTab = 'venues';
+            let sortKey = 'name';
+            let sortDir = 1;
+            let searchQuery = '';
+
+            function getThreshold() {
+                return parseInt(document.getElementById('overdue-days').value, 10) || 90;
+            }
+
+            function rowsForTab(tab) {
+                if (tab === 'venues') return venueRows;
+                if (tab === 'shows') return showRows;
+                if (tab === 'needs') return needsSourceVenues();
+                if (tab === 'overdue') return overdueVenues(getThreshold());
+                return [];
+            }
+
+            function filterRows(rows, query) {
+                if (!query) return rows;
+                const q = query.toLowerCase();
+                return rows.filter(function (r) {
+                    // Flatten searchable fields including curator meta
+                    const meta = r.meta || {};
+                    const c = meta.contact || {};
+                    const blob = [
+                        r.id, r.name, r.city, r.neighborhood, r.tags, r.day, r.kj, r.venueName, r.showKey,
+                        meta.source, meta.sourceNotes, meta.notes, meta.lastVerified,
+                        c.name, c.role, c.phone, c.email
+                    ].filter(Boolean).join(' ').toLowerCase();
+                    return blob.indexOf(q) !== -1;
+                });
+            }
+
+            function sortRows(rows, key, dir) {
+                const def = (TAB_DEFS[activeTab].columns || []).find(function (c) { return c.key === key; });
+                const numeric = def && def.sortNumeric;
+                return rows.slice().sort(function (a, b) {
+                    const av = a[key]; const bv = b[key];
+                    if (numeric) return ((+av || 0) - (+bv || 0)) * dir;
+                    return String(av || '').localeCompare(String(bv || '')) * dir;
+                });
+            }
+
+            function render() {
+                const def = TAB_DEFS[activeTab];
+                const rows = sortRows(filterRows(rowsForTab(activeTab), searchQuery), sortKey, sortDir);
+
+                if (!rows.length) {
+                    main.innerHTML = '<div class="empty">No rows match.</div>';
+                    return;
+                }
+
+                const headHtml = '<tr>' + def.columns.map(function (c) {
+                    const sorted = (c.key === sortKey) ? ' is-sorted' : '';
+                    const arrow = (c.key === sortKey) ? (sortDir > 0 ? ' ▲' : ' ▼') : ' ▲';
+                    const sortable = (c.sortable !== false);
+                    return '<th' + (sortable ? ' data-sort="' + esc(c.key) + '"' : '') + ' class="' + sorted + '">' +
+                        esc(c.label) + '<span class="sort-arrow">' + arrow + '</span></th>';
+                }).join('') + '</tr>';
+
+                const bodyHtml = rows.map(function (r) {
+                    const cls = def.rowClass ? def.rowClass(r) : '';
+                    const tds = def.columns.map(function (c) {
+                        const cell = c.render ? c.render(r) : esc(r[c.key]);
+                        return '<td class="' + (c.cls || '') + '">' + cell + '</td>';
+                    }).join('');
+                    return '<tr class="' + cls + '">' + tds + '</tr>';
+                }).join('');
+
+                main.innerHTML = '<table><thead>' + headHtml + '</thead><tbody>' + bodyHtml + '</tbody></table>';
+            }
+
+            function updateStats() {
+                const threshold = getThreshold();
+                const overdue = overdueVenues(threshold);
+                const needs = needsSourceVenues();
+                document.getElementById('stats').textContent =
+                    venuesWithSource.length + '/' + venueRows.length + ' venues sourced · ' +
+                    showsWithSource.length + '/' + showRows.length + ' shows sourced';
+                document.getElementById('count-venues').textContent = '(' + venueRows.length + ')';
+                document.getElementById('count-shows').textContent = '(' + showRows.length + ')';
+                document.getElementById('count-needs').textContent = '(' + needs.length + ')';
+                document.getElementById('count-overdue').textContent = '(' + overdue.length + ')';
+            }
+
+            // ---- Wiring ---------------------------------------------------------
+            document.querySelectorAll('.tab').forEach(function (tab) {
+                tab.addEventListener('click', function () {
+                    document.querySelectorAll('.tab').forEach(function (t) { t.classList.remove('is-active'); });
+                    tab.classList.add('is-active');
+                    activeTab = tab.dataset.tab;
+                    // Reset sort to a sensible default per tab
+                    sortKey = (activeTab === 'shows') ? 'venueName' : 'name';
+                    sortDir = 1;
+                    render();
+                });
+            });
+
+            document.getElementById('search').addEventListener('input', function (e) {
+                searchQuery = e.target.value.trim();
+                render();
+            });
+
+            document.getElementById('overdue-days').addEventListener('change', function () {
+                updateStats();
+                if (activeTab === 'overdue' || activeTab === 'venues') render();
+            });
+
+            main.addEventListener('click', function (e) {
+                // Sort by column header
+                const th = e.target.closest('th[data-sort]');
+                if (th) {
+                    const key = th.dataset.sort;
+                    if (sortKey === key) sortDir = -sortDir;
+                    else { sortKey = key; sortDir = 1; }
+                    render();
+                    return;
+                }
+                // Copy show key on click
+                const copyable = e.target.closest('[data-copy]');
+                if (copyable) {
+                    const val = copyable.dataset.copy;
+                    navigator.clipboard.writeText(val).then(function () {
+                        const hint = document.getElementById('copy-hint');
+                        hint.textContent = 'Copied: ' + val;
+                        hint.classList.add('is-visible');
+                        setTimeout(function () { hint.classList.remove('is-visible'); }, 1200);
+                    });
+                }
+            });
+
+            updateStats();
+            render();
+        })();
+    </script>
+</body>
+</html>

--- a/css/editor.css
+++ b/css/editor.css
@@ -27,6 +27,54 @@
     gap: var(--spacing-sm);
 }
 
+/* Mode badge — shows whether editor is editing curator master or public data */
+.editor-mode-badge {
+    padding: 2px 10px;
+    border-radius: 10px;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    border: 1px solid transparent;
+    margin-left: var(--spacing-sm);
+    user-select: none;
+}
+
+.editor-mode-badge[data-mode="public"] {
+    background: var(--color-gray-700, #555);
+    color: #fff;
+    border-color: var(--color-gray-700, #555);
+}
+
+.editor-mode-badge[data-mode="master"] {
+    background: #d97706;
+    color: #fff;
+    border-color: #b45309;
+}
+
+/* Curator fieldset — visually distinct so the curator knows these fields are private */
+.form-section--curator {
+    border-left: 4px solid #d97706;
+    background: rgba(217, 119, 6, 0.04);
+}
+
+.form-section--curator legend {
+    color: #b45309;
+}
+
+.curator-badge {
+    display: inline-block;
+    margin-left: var(--spacing-xs);
+    padding: 1px 6px;
+    background: #d97706;
+    color: #fff;
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    border-radius: 3px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
 .editor-header__actions .btn-label {
     display: inline;
 }

--- a/docs/adr/005-curator-master-build-step.md
+++ b/docs/adr/005-curator-master-build-step.md
@@ -1,0 +1,87 @@
+# ADR-005: Curator-side data transformation; deploy stays build-free
+
+- **Status:** Accepted
+- **Date:** 2026-06-05
+- **Issue:** [#93](https://github.com/Johnesco/karaokedirectory/issues/93)
+- **Supersedes:** None
+- **Amends:** [ADR-002](002-vanilla-js-no-build.md) (clarifies scope: "no build step" applies to the deploy pipeline, not curator-side data prep)
+
+## Context
+
+The curator needs to track per-venue private metadata — source URL, contact info, last-verified date, free-text notes — for venue and KJ-show provenance. Three constraints:
+
+1. **No leak risk.** Private fields must never reach the public repo, the deployed site, or any visitor's browser.
+2. **No duplication of public data.** Maintaining two parallel files (public + private) keyed by name leads to drift and "lost track of what corresponds to what" — a problem the user explicitly raised during planning.
+3. **Honor ADR-002's spirit.** The deployed site should stay free of any build pipeline between `git push` and what visitors see.
+
+A pure overlay design (keep `js/data.js` as master, add a small annotation file) was considered and rejected because the curator's natural flow is to write source/contact info *first* when discovering a venue — splitting it across two files at write time was friction the user pushed back on.
+
+Inverting the dependency (curator file is master, public file derived) requires a transformation step. The question: where does that step run?
+
+## Decision
+
+A small **Node build script** runs **on the curator's machine** (manually via `node scripts/build-public-data.js`, automatically via a git pre-commit hook installed by `scripts/install-hooks.js`). It reads a gitignored master at `_curator/data.js`, deep-clones the listings while stripping every `_curatorMeta` field, validates the output strictly, and writes `js/data.js`.
+
+The deployed site loads `js/data.js` exactly as before. **Nothing changes between `git push` and what visitors see** — the static files in `main` are served as-is by GitHub Pages. The build step is a developer-side transformation, not a deploy-side one. ADR-002's spirit is preserved.
+
+`editor.html` auto-detects which file is loaded: if `_curator/data.js` is present (`window.curatorMasterData` defined), it enters Master mode with curator-fields visible; otherwise it falls back to Public mode and behaves identically to today. The public deploy has no master, so it's always Public mode there.
+
+A read-only dashboard at `_curator/index.html` renders the master in a plain table view for quick lookup — deliberately not styled to match the public app.
+
+## Consequences
+
+**Positive**
+- **Single source of truth for the curator.** They write everything in one place; the public file is generated.
+- **Strict validation refuses to leak.** The build script's safety check (`if serialized output contains "_curatorMeta", refuse to write`) is a hard structural guarantee, not procedural discipline.
+- **Pre-commit hook closes the "forgot to build" trap.** Edits to the master trigger an automatic rebuild + stage of `js/data.js` at commit time.
+- **No npm runtime dependencies.** The build script uses only Node's standard library (`fs`, `path`, `child_process`). No `package.json` required (it's gitignored anyway per ADR-002), no lockfile, no Dependabot churn.
+- **Existing `editor.html` workflow preserved.** On the public site it behaves identically to today. The mode switch is invisible to anyone not curating.
+- **Reversible.** If we ever want to abandon the master/build architecture, the master file is the union of public + private data — deleting `_curator/` and reverting the editor changes lands us back at the pre-ADR-005 state.
+
+**Negative / accepted tradeoffs**
+- **Contributors need Node installed** to run the build locally. Mitigated: the build is only needed by the curator; contributors who don't touch venue data don't need it. The deploy pipeline still doesn't need Node.
+- **`js/data.js` is now a generated artifact.** It's still committed (so GitHub Pages can serve it) and still reviewable in PRs, but hand-edits to it will be clobbered by the next build. Documented in CLAUDE.md and the file header.
+- **One extra file (`_curator/data.js`) lives on the curator's machine.** Loss is recoverable: every venue exists in the public `js/data.js`; only `_curatorMeta` annotations would be lost.
+- **The mode switch in `editor.html` adds a small amount of conditional code** to detect which file is loaded and render accordingly.
+
+**Future revisit triggers**
+- Build script grows beyond pure stripping (e.g., schema migrations, derived fields). At that point we'd reconsider whether a "no runtime build" rule is still cost-effective.
+- A second contributor regularly curates and the per-machine master becomes painful (would imply we need a shared private store).
+- File System Access API support stabilizes enough to replace the paste-based editor flow.
+
+## Options considered
+
+### Option A — Overlay by ID (rejected)
+
+Keep `js/data.js` as master; add `_curator/data.js` with annotations keyed by venue ID. Dashboard joins the two; editor never touches curator data. Same safety properties (curator file gitignored), no build step, no editor retrofit needed.
+
+Rejected because the curator's natural editing flow is "discover venue → record source → record details" — all in one place. Splitting source/contact into a different file at write time was friction the user pushed back on. Overlay-by-ID would also require manually inventing show keys; the curator wanted the master to *be* the canonical record so keys are inherent.
+
+### Option B — Curator-master + build step (accepted)
+
+What we picked. Single editing surface, strict-validated build, automated hook to close the "forgot to run" trap.
+
+### Option C — Runtime stripping in the public app (rejected)
+
+Both files exist; the public app loads master if available, strips private fields client-side at boot. No build step.
+
+Rejected because the master would have to be in a path the deployed site could load — which means committing it — which means private data in the public repo. Even if filtered before display, it's in DevTools-readable memory and in `view-source`. Defeats the leak-safety goal.
+
+### Option D — Separate gitignored note files per venue (rejected)
+
+`_curator/blackheart.md`, `_curator/the-tavern.md`, etc. Markdown per venue. Pure documentation, no integration with the editor or dashboard.
+
+Rejected because the user wanted a structured view ("by venue / by KJ show") with searchable fields. Loose markdown doesn't give that.
+
+## Implementation notes
+
+- **Master file format:** mirrors `js/data.js` exactly — `tagDefinitions` + `listings` — with each listing optionally carrying `_curatorMeta`. Dual-export footer (`window.curatorMasterData` for the browser, `module.exports` for Node).
+- **Build script:** `scripts/build-public-data.js`. Validates required public fields (`id`, `name`, `address.street`, `address.city`, non-empty `schedule`), checks all `tags[]` are known IDs, runs a final "no `_curatorMeta` in serialized output" safety check.
+- **Hook:** `scripts/install-hooks.js` writes `.git/hooks/pre-commit` (a shell script that calls `node scripts/precommit.js`). One-time install per checkout.
+- **Watch (optional):** `scripts/watch-master.js` re-runs the build on master save. Useful during curation sessions paired with a local dev server.
+- **Editor mode detection:** `editor.js` prefers `window.curatorMasterData` over `window.karaokeData` at boot. Mode badge in the header. Curator-fields fieldset hidden in Public mode.
+- **Dashboard:** `_curator/index.html` is single-file (inline HTML+CSS+JS), no external CSS or modules, deliberately plain styling.
+
+## Reaffirms / clarifies ADR-002
+
+ADR-002 said "no build step." This ADR clarifies that the scope of that rule is the **deploy pipeline** — what runs between `git push` and what visitors see. A developer-side transformation that runs before commit (and produces the same committed artifacts that have always been committed) is not what ADR-002 was guarding against. The properties ADR-002 was protecting — forever-readable code, zero supply-chain surface area for the deployed site, no framework churn, debuggable runtime — all still hold.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,3 +12,4 @@ Format and threshold rule: see [sdlc-baseline `docs/adrs.md`](https://github.com
 | [002](002-vanilla-js-no-build.md) | Vanilla JS, no framework, no build step | Accepted |
 | [003](003-github-pages-deploy.md) | GitHub Pages as deploy target | Accepted |
 | [004](004-parallel-data-source-flag.md) | Parallel data source via URL flag — production stays on JSON | Accepted |
+| [005](005-curator-master-build-step.md) | Curator-side data transformation; deploy stays build-free | Accepted |

--- a/editor.html
+++ b/editor.html
@@ -15,6 +15,7 @@
 <body>
     <header class="editor-header">
         <h1><i class="fa-solid fa-pen-to-square"></i> Venue Editor</h1>
+        <span id="editor-mode-badge" class="editor-mode-badge" data-mode="public">Public mode</span>
         <div class="editor-header__actions">
             <button id="btn-toggle-preview" class="btn btn--secondary" title="Toggle preview panel">
                 <i class="fa-solid fa-eye"></i> <span class="btn-label">Preview</span>
@@ -227,6 +228,66 @@
                     </div>
                 </fieldset>
 
+                <!-- Curator Notes (Master mode only) -->
+                <fieldset class="form-section form-section--curator" id="curator-fieldset" hidden>
+                    <legend><i class="fa-solid fa-clipboard"></i> Curator Notes <span class="curator-badge">local only</span></legend>
+                    <p class="form-hint">Private notes for this venue. Stripped before publish; never reaches the public site.</p>
+
+                    <div class="form-row">
+                        <div class="form-group form-group--wide">
+                            <label for="curator-source">Source URL</label>
+                            <input type="url" id="curator-source" name="_curatorMeta.source"
+                                   placeholder="https://facebook.com/venue/posts/...">
+                            <small>Where you found out about this venue</small>
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group form-group--wide">
+                            <label for="curator-source-notes">Source notes</label>
+                            <input type="text" id="curator-source-notes" name="_curatorMeta.sourceNotes"
+                                   placeholder="Saw their March 2025 post; manager DM, etc.">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="curator-contact-name">Contact name</label>
+                            <input type="text" id="curator-contact-name" name="_curatorMeta.contact.name"
+                                   placeholder="Sarah Manager">
+                        </div>
+                        <div class="form-group">
+                            <label for="curator-contact-role">Role</label>
+                            <input type="text" id="curator-contact-role" name="_curatorMeta.contact.role"
+                                   placeholder="Owner / Manager / KJ / etc.">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="curator-contact-phone">Phone</label>
+                            <input type="tel" id="curator-contact-phone" name="_curatorMeta.contact.phone"
+                                   placeholder="512-555-1234">
+                        </div>
+                        <div class="form-group">
+                            <label for="curator-contact-email">Email</label>
+                            <input type="email" id="curator-contact-email" name="_curatorMeta.contact.email"
+                                   placeholder="contact@example.com">
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group form-group--wide">
+                            <label for="curator-notes">Notes</label>
+                            <textarea id="curator-notes" name="_curatorMeta.notes" rows="3"
+                                      placeholder="Quiet on holidays. Best to call to confirm. Manager's birthday in October."></textarea>
+                        </div>
+                    </div>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="curator-last-verified">Last verified</label>
+                            <input type="date" id="curator-last-verified" name="_curatorMeta.lastVerified">
+                            <small>When did you last confirm this info?</small>
+                        </div>
+                    </div>
+                </fieldset>
+
                 <!-- Venue Socials -->
                 <fieldset class="form-section">
                     <legend><i class="fa-solid fa-share-nodes"></i> Venue Social Links</legend>
@@ -320,6 +381,8 @@
         <span class="editor-footer__copyright">&copy; 2025 Austin Karaoke Directory</span>
     </footer>
 
+    <!-- Curator master (gitignored). 404s silently on the public deploy; editor falls back to Public mode. -->
+    <script src="_curator/data.js" onerror="void 0"></script>
     <script src="js/data.js"></script>
     <script type="module" src="editor/editor.js"></script>
     <script src="js/analytics.js" defer></script>

--- a/editor/editor.js
+++ b/editor/editor.js
@@ -13,6 +13,9 @@ let venues = [];
 let tagDefinitions = {};
 let selectedVenueId = null;
 let hasUnsavedChanges = false;
+// Mode: 'master' if _curator/data.js loaded (curatorMasterData defined), else 'public'.
+// Master mode shows curator fields and emits _curatorMeta in JSON output.
+let mode = 'public';
 const STORAGE_KEY = 'karaoke-editor-draft';
 const PREVIEW_STATE_KEY = 'karaoke-editor-preview';
 
@@ -90,20 +93,44 @@ function init() {
 }
 
 /**
- * Load venue data
+ * Load venue data. Prefers curatorMasterData (master mode, when _curator/data.js
+ * is present) over karaokeData (public mode, fallback).
  */
 function loadData() {
-    if (typeof karaokeData !== 'undefined') {
-        venues = karaokeData.listings || [];
-        tagDefinitions = karaokeData.tagDefinitions || {};
-        initTagConfig(tagDefinitions);
-        renderVenueList();
-        updateVenueCount();
-        renderTagSelector();
-        renderTagDefinitionsEditor();
-    } else {
+    const masterData = (typeof curatorMasterData !== 'undefined') ? curatorMasterData : null;
+    const publicData = (typeof karaokeData !== 'undefined') ? karaokeData : null;
+    const source = masterData || publicData;
+
+    if (!source) {
         showToast('Failed to load venue data', 'error');
+        return;
     }
+
+    mode = masterData ? 'master' : 'public';
+    venues = source.listings || [];
+    tagDefinitions = source.tagDefinitions || {};
+    initTagConfig(tagDefinitions);
+    applyMode();
+    renderVenueList();
+    updateVenueCount();
+    renderTagSelector();
+    renderTagDefinitionsEditor();
+}
+
+/**
+ * Reflect the current mode in the UI: badge text/color, curator fieldset visibility.
+ */
+function applyMode() {
+    const badge = document.getElementById('editor-mode-badge');
+    if (badge) {
+        badge.dataset.mode = mode;
+        badge.textContent = mode === 'master' ? 'Master mode (local)' : 'Public mode';
+        badge.title = mode === 'master'
+            ? 'Editing the gitignored curator master. _curatorMeta is included in Copy JSON output.'
+            : 'Editing public data. Curator fields are hidden; _curatorMeta is never emitted.';
+    }
+    const fieldset = document.getElementById('curator-fieldset');
+    if (fieldset) fieldset.hidden = (mode !== 'master');
 }
 
 /**
@@ -278,6 +305,57 @@ function fillForm(venue) {
     // Active Period
     document.getElementById('active-period-start').value = venue.activePeriod?.start || '';
     document.getElementById('active-period-end').value = venue.activePeriod?.end || '';
+
+    // Curator Notes (master mode only — fields are hidden in public mode)
+    fillCuratorFields(venue._curatorMeta);
+}
+
+/**
+ * Populate the curator-notes fieldset from a venue's _curatorMeta.
+ * Always called; in public mode the fieldset is hidden anyway, so writes are harmless.
+ */
+function fillCuratorFields(meta) {
+    const m = meta || {};
+    const c = m.contact || {};
+    document.getElementById('curator-source').value = m.source || '';
+    document.getElementById('curator-source-notes').value = m.sourceNotes || '';
+    document.getElementById('curator-contact-name').value = c.name || '';
+    document.getElementById('curator-contact-role').value = c.role || '';
+    document.getElementById('curator-contact-phone').value = c.phone || '';
+    document.getElementById('curator-contact-email').value = c.email || '';
+    document.getElementById('curator-notes').value = m.notes || '';
+    document.getElementById('curator-last-verified').value = m.lastVerified || '';
+}
+
+/**
+ * Read curator fields back into a _curatorMeta object.
+ * Returns null if all fields are empty (so the venue stays clean of an empty meta).
+ * Caller is responsible for only attaching this in master mode.
+ */
+function readCuratorFields() {
+    const source = document.getElementById('curator-source').value.trim();
+    const sourceNotes = document.getElementById('curator-source-notes').value.trim();
+    const contactName = document.getElementById('curator-contact-name').value.trim();
+    const contactRole = document.getElementById('curator-contact-role').value.trim();
+    const contactPhone = document.getElementById('curator-contact-phone').value.trim();
+    const contactEmail = document.getElementById('curator-contact-email').value.trim();
+    const notes = document.getElementById('curator-notes').value.trim();
+    const lastVerified = document.getElementById('curator-last-verified').value;
+
+    const contact = {};
+    if (contactName) contact.name = contactName;
+    if (contactRole) contact.role = contactRole;
+    if (contactPhone) contact.phone = contactPhone;
+    if (contactEmail) contact.email = contactEmail;
+
+    const meta = {};
+    if (source) meta.source = source;
+    if (sourceNotes) meta.sourceNotes = sourceNotes;
+    if (Object.keys(contact).length) meta.contact = contact;
+    if (notes) meta.notes = notes;
+    if (lastVerified) meta.lastVerified = lastVerified;
+
+    return Object.keys(meta).length ? meta : null;
 }
 
 /**
@@ -445,6 +523,15 @@ function getFormData() {
     // Include active period if set
     if (activePeriod) {
         result.activePeriod = activePeriod;
+    }
+
+    // Curator notes — only in master mode, only if any field is non-empty.
+    // Public mode NEVER emits _curatorMeta, which is the structural leak guard:
+    // even if a curator opens the deployed editor.html and hits Copy JSON, the
+    // output is incapable of containing private fields.
+    if (mode === 'master') {
+        const curatorMeta = readCuratorFields();
+        if (curatorMeta) result._curatorMeta = curatorMeta;
     }
 
     return result;
@@ -631,10 +718,16 @@ function markVenueUnsaved() {
 }
 
 /**
- * Copy JSON to clipboard
+ * Copy JSON to clipboard. Output format depends on mode:
+ * - master: const curatorMasterData = {...}; + dual export footer → paste into _curator/data.js
+ * - public: const karaokeData = {...};                           → paste into js/data.js
+ *
+ * In master mode, sorted venues may carry _curatorMeta. In public mode they cannot
+ * (getFormData() does not emit it), so a master accidentally copy-pasted into the
+ * wrong file is not a leak — but it would null out _curatorMeta entries that did
+ * exist. Mode badge keeps that confusion visible.
  */
 function copyJson() {
-    // Sort venues alphabetically (ignoring articles) before export
     const sortedVenues = [...venues].sort((a, b) => {
         const nameA = getSortableName(a.name).toLowerCase();
         const nameB = getSortableName(b.name).toLowerCase();
@@ -647,8 +740,20 @@ function copyJson() {
     };
     const json = JSON.stringify(output, null, 2);
 
-    navigator.clipboard.writeText(`const karaokeData = ${json};`).then(() => {
-        showToast('JSON copied to clipboard!', 'success');
+    let payload;
+    if (mode === 'master') {
+        payload =
+            'const curatorMasterData = ' + json + ';\n' +
+            '\n' +
+            'if (typeof window !== \'undefined\') window.curatorMasterData = curatorMasterData;\n' +
+            'if (typeof module !== \'undefined\') module.exports = curatorMasterData;\n';
+    } else {
+        payload = 'const karaokeData = ' + json + ';';
+    }
+
+    navigator.clipboard.writeText(payload).then(() => {
+        const target = mode === 'master' ? '_curator/data.js' : 'js/data.js';
+        showToast('JSON copied — paste into ' + target, 'success');
     }).catch(() => {
         showToast('Failed to copy to clipboard', 'error');
     });

--- a/js/data.js
+++ b/js/data.js
@@ -2182,7 +2182,10 @@ const karaokeData = {
           "startTime": "21:00",
           "endTime": "00:00",
           "exclusions": [
-            { "date": "2026-06-12", "reason": "Private event" }
+            {
+              "date": "2026-06-12",
+              "reason": "Private event"
+            }
           ]
         }
       ],

--- a/scripts/bootstrap-curator.js
+++ b/scripts/bootstrap-curator.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/**
+ * One-time bootstrap: convert current js/data.js → _curator/data.js (master format).
+ * Run once at the start of the curator's setup.
+ * Safe to re-run only if _curator/data.js doesn't yet have hand-added _curatorMeta —
+ * otherwise it will be overwritten. (Use with caution after initial setup.)
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const SRC = path.join(REPO_ROOT, 'js', 'data.js');
+const DEST_DIR = path.join(REPO_ROOT, '_curator');
+const DEST = path.join(DEST_DIR, 'data.js');
+
+if (!fs.existsSync(SRC)) {
+    process.stderr.write('js/data.js not found — cannot bootstrap.\n');
+    process.exit(1);
+}
+
+let src = fs.readFileSync(SRC, 'utf8');
+src = src.replace(/^const karaokeData = /, 'const curatorMasterData = ');
+if (!src.endsWith('\n')) src += '\n';
+src +=
+    '\nif (typeof window !== \'undefined\') window.curatorMasterData = curatorMasterData;\n' +
+    'if (typeof module !== \'undefined\') module.exports = curatorMasterData;\n';
+
+fs.mkdirSync(DEST_DIR, { recursive: true });
+fs.writeFileSync(DEST, src);
+
+process.stdout.write('[bootstrap] wrote ' + path.relative(REPO_ROOT, DEST) + ' (' + src.length + ' bytes)\n');

--- a/scripts/build-public-data.js
+++ b/scripts/build-public-data.js
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * Build public js/data.js from the gitignored curator master.
+ *
+ * Strict mode: if anything in the master is malformed, or any _curatorMeta
+ * would survive into the output, the build refuses to write and exits non-zero.
+ *
+ * Usage:
+ *   node scripts/build-public-data.js
+ *
+ * Exit codes:
+ *   0  — clean build (or no-op if js/data.js would be byte-identical)
+ *   1  — master missing or unreadable
+ *   2  — validation errors (master has bad shape or output would be malformed)
+ *   3  — write failure
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MASTER_PATH = path.join(REPO_ROOT, '_curator', 'data.js');
+const PUBLIC_PATH = path.join(REPO_ROOT, 'js', 'data.js');
+
+function die(code, message) {
+    process.stderr.write('[build-public-data] ERROR: ' + message + '\n');
+    process.exit(code);
+}
+
+function reportErrors(errors) {
+    process.stderr.write('[build-public-data] VALIDATION FAILED (' + errors.length + ' issue' + (errors.length === 1 ? '' : 's') + '):\n');
+    for (const e of errors) process.stderr.write('  - ' + e + '\n');
+    process.stderr.write('\nNo changes written to ' + path.relative(REPO_ROOT, PUBLIC_PATH) + '.\n');
+    process.exit(2);
+}
+
+// 1. Load master ------------------------------------------------------------
+if (!fs.existsSync(MASTER_PATH)) {
+    die(1,
+        'Master not found at ' + path.relative(REPO_ROOT, MASTER_PATH) + '.\n' +
+        'Bootstrap: cp -r _curator.example _curator, then paste your venue data into _curator/data.js.'
+    );
+}
+
+let master;
+try {
+    // Clear cache so re-runs (e.g. from watch-master.js) pick up edits
+    delete require.cache[require.resolve(MASTER_PATH)];
+    master = require(MASTER_PATH);
+} catch (err) {
+    die(1, 'Could not load master file: ' + err.message);
+}
+
+// 2. Validate master shape --------------------------------------------------
+const shapeErrors = [];
+if (!master || typeof master !== 'object') shapeErrors.push('master export is not an object');
+else {
+    if (!master.tagDefinitions || typeof master.tagDefinitions !== 'object') {
+        shapeErrors.push('master.tagDefinitions is missing or not an object');
+    }
+    if (!Array.isArray(master.listings)) {
+        shapeErrors.push('master.listings is missing or not an array');
+    }
+}
+if (shapeErrors.length) reportErrors(shapeErrors);
+
+// 3. Deep-clone listings, strip _curatorMeta --------------------------------
+const tagIds = new Set(Object.keys(master.tagDefinitions));
+const requiredFields = ['id', 'name', 'address', 'schedule'];
+const errors = [];
+let stripped = 0;
+
+// Recursive strip: catches _curatorMeta anywhere in the tree, including on
+// schedule entries or nested objects. The top-level count tracks per-venue
+// strips; nested strips also feed the safety check below.
+function stripCuratorMetaDeep(node) {
+    if (Array.isArray(node)) {
+        for (const item of node) stripCuratorMetaDeep(item);
+    } else if (node && typeof node === 'object') {
+        if (Object.prototype.hasOwnProperty.call(node, '_curatorMeta')) {
+            delete node._curatorMeta;
+        }
+        for (const value of Object.values(node)) stripCuratorMetaDeep(value);
+    }
+}
+
+const publicListings = master.listings.map((venue, idx) => {
+    const clone = JSON.parse(JSON.stringify(venue));
+    const hadTopLevelMeta = Object.prototype.hasOwnProperty.call(clone, '_curatorMeta');
+    stripCuratorMetaDeep(clone);
+    if (hadTopLevelMeta) stripped++;
+
+    const label = clone.id ? `listing[${idx}] "${clone.id}"` : `listing[${idx}]`;
+
+    for (const field of requiredFields) {
+        if (!clone[field]) errors.push(`${label}: missing required field "${field}"`);
+    }
+    if (clone.address && (!clone.address.street || !clone.address.city)) {
+        errors.push(`${label}: address.street and address.city are required`);
+    }
+    if (!Array.isArray(clone.schedule) || clone.schedule.length === 0) {
+        errors.push(`${label}: schedule must be a non-empty array`);
+    }
+    if (Array.isArray(clone.tags)) {
+        for (const tag of clone.tags) {
+            if (!tagIds.has(tag)) errors.push(`${label}: unknown tag id "${tag}"`);
+        }
+    }
+    return clone;
+});
+
+// 4. Final safety check — no _curatorMeta survived --------------------------
+const serialized = JSON.stringify(publicListings);
+if (serialized.indexOf('_curatorMeta') !== -1) {
+    errors.push('SAFETY CHECK FAILED: "_curatorMeta" appeared in serialized output. Refusing to write.');
+}
+
+if (errors.length) reportErrors(errors);
+
+// 5. Build the public file -------------------------------------------------
+const publicData = {
+    tagDefinitions: master.tagDefinitions,
+    listings: publicListings
+};
+const output = 'const karaokeData = ' + JSON.stringify(publicData, null, 2) + ';\n';
+
+// Skip write if byte-identical (avoids touching mtime / git status)
+let prevContent = null;
+if (fs.existsSync(PUBLIC_PATH)) {
+    prevContent = fs.readFileSync(PUBLIC_PATH, 'utf8');
+}
+
+if (prevContent === output) {
+    process.stdout.write('[build-public-data] up to date — ' + publicListings.length + ' venues, ' + stripped + ' had _curatorMeta stripped\n');
+    process.exit(0);
+}
+
+try {
+    fs.writeFileSync(PUBLIC_PATH, output, 'utf8');
+} catch (err) {
+    die(3, 'Could not write public data: ' + err.message);
+}
+
+process.stdout.write(
+    '[build-public-data] wrote ' + publicListings.length + ' venues to ' + path.relative(REPO_ROOT, PUBLIC_PATH) +
+    ' (' + stripped + ' had _curatorMeta stripped, ' + output.length + ' bytes)\n'
+);

--- a/scripts/install-hooks.js
+++ b/scripts/install-hooks.js
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+/**
+ * One-time setup: install git hooks for the karaokedirectory project.
+ *
+ * Currently installs:
+ *   .git/hooks/pre-commit — runs scripts/precommit.js (curator build + stage)
+ *
+ * Run from the repo root:
+ *   node scripts/install-hooks.js
+ *
+ * Safe to re-run. Overwrites any existing hook of the same name with a backup.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const HOOKS_DIR = path.join(REPO_ROOT, '.git', 'hooks');
+
+if (!fs.existsSync(HOOKS_DIR)) {
+    process.stderr.write('[install-hooks] .git/hooks not found at ' + HOOKS_DIR + '.\n');
+    process.stderr.write('Are you running this from the repo root in a fresh clone? Try `git init` or `git clone` first.\n');
+    process.exit(1);
+}
+
+const hookPath = path.join(HOOKS_DIR, 'pre-commit');
+const hookBody =
+    '#!/bin/sh\n' +
+    '# karaokedirectory pre-commit hook (installed by scripts/install-hooks.js)\n' +
+    '# Runs the curator build if _curator/data.js exists; stages js/data.js if it changed.\n' +
+    'exec node scripts/precommit.js\n';
+
+if (fs.existsSync(hookPath)) {
+    const existing = fs.readFileSync(hookPath, 'utf8');
+    if (existing === hookBody) {
+        process.stdout.write('[install-hooks] pre-commit already installed and current. No changes.\n');
+        process.exit(0);
+    }
+    const backupPath = hookPath + '.backup-' + Date.now();
+    fs.copyFileSync(hookPath, backupPath);
+    process.stdout.write('[install-hooks] existing pre-commit backed up to ' + path.relative(REPO_ROOT, backupPath) + '\n');
+}
+
+fs.writeFileSync(hookPath, hookBody, 'utf8');
+
+// chmod +x — best effort; on Windows this is a no-op but harmless
+try {
+    fs.chmodSync(hookPath, 0o755);
+} catch (err) {
+    // Windows fs.chmodSync may throw on some filesystems; ignore
+}
+
+process.stdout.write('[install-hooks] installed ' + path.relative(REPO_ROOT, hookPath) + '\n');
+process.stdout.write('[install-hooks] git commits will now auto-run the curator build when _curator/data.js exists.\n');

--- a/scripts/precommit.js
+++ b/scripts/precommit.js
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Git pre-commit hook callback.
+ *
+ * Runs the curator build script if the master file exists. If the build
+ * succeeds and js/data.js changed, stages it so it goes into the commit.
+ * If the build fails (validation error, bad master), blocks the commit.
+ *
+ * If the master file doesn't exist (fresh clone, no curator data), this is
+ * a no-op — exits 0 so commits proceed normally.
+ *
+ * Installed by scripts/install-hooks.js into .git/hooks/pre-commit.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { execSync, spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MASTER_PATH = path.join(REPO_ROOT, '_curator', 'data.js');
+const PUBLIC_PATH = path.join(REPO_ROOT, 'js', 'data.js');
+const BUILD_SCRIPT = path.join(__dirname, 'build-public-data.js');
+
+if (!fs.existsSync(MASTER_PATH)) {
+    // No master = no curator workflow here. Common on CI or fresh clones.
+    process.exit(0);
+}
+
+process.stdout.write('[pre-commit] _curator/data.js found — running build...\n');
+
+const prevContent = fs.existsSync(PUBLIC_PATH) ? fs.readFileSync(PUBLIC_PATH, 'utf8') : null;
+
+const result = spawnSync(process.execPath, [BUILD_SCRIPT], {
+    cwd: REPO_ROOT,
+    stdio: 'inherit'
+});
+
+if (result.status !== 0) {
+    process.stderr.write('[pre-commit] build failed — commit blocked.\n');
+    process.exit(result.status || 1);
+}
+
+// Stage js/data.js if it changed
+const newContent = fs.existsSync(PUBLIC_PATH) ? fs.readFileSync(PUBLIC_PATH, 'utf8') : null;
+if (newContent !== prevContent) {
+    try {
+        execSync('git add ' + JSON.stringify(path.relative(REPO_ROOT, PUBLIC_PATH).replace(/\\/g, '/')), {
+            cwd: REPO_ROOT,
+            stdio: 'inherit'
+        });
+        process.stdout.write('[pre-commit] js/data.js updated and staged.\n');
+    } catch (err) {
+        process.stderr.write('[pre-commit] WARNING: build succeeded but could not stage js/data.js: ' + err.message + '\n');
+        process.exit(1);
+    }
+}
+
+process.exit(0);

--- a/scripts/watch-master.js
+++ b/scripts/watch-master.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Optional: watch _curator/data.js and rebuild js/data.js on save.
+ *
+ * Leave this running in a terminal during a curation session. Edits to the
+ * master trigger an automatic rebuild; reload localhost to see public-app
+ * rendering update without manual `node scripts/build-public-data.js` calls.
+ *
+ * Usage:
+ *   node scripts/watch-master.js
+ *
+ * Ctrl-C to stop.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const MASTER_PATH = path.join(REPO_ROOT, '_curator', 'data.js');
+const BUILD_SCRIPT = path.join(__dirname, 'build-public-data.js');
+
+if (!fs.existsSync(MASTER_PATH)) {
+    process.stderr.write('[watch-master] _curator/data.js not found. Bootstrap before watching.\n');
+    process.exit(1);
+}
+
+function build() {
+    const result = spawnSync(process.execPath, [BUILD_SCRIPT], {
+        cwd: REPO_ROOT,
+        stdio: 'inherit'
+    });
+    if (result.status !== 0) {
+        process.stderr.write('[watch-master] build returned exit ' + result.status + '\n');
+    }
+}
+
+// Initial build so the watcher boots from a known-good state
+build();
+
+// fs.watch fires multiple events per save on some platforms — debounce
+let pending = null;
+fs.watch(MASTER_PATH, { persistent: true }, (eventType) => {
+    if (pending) clearTimeout(pending);
+    pending = setTimeout(() => {
+        pending = null;
+        process.stdout.write('[watch-master] master changed (' + eventType + '), rebuilding...\n');
+        build();
+    }, 150);
+});
+
+process.stdout.write('[watch-master] watching ' + path.relative(REPO_ROOT, MASTER_PATH) + ' — Ctrl-C to stop\n');


### PR DESCRIPTION
## Summary
- Introduces `_curator/data.js` (gitignored) as the curator's authoritative editing surface. Each listing may carry an optional `_curatorMeta` field with source, contact, notes, and `lastVerified`.
- `scripts/build-public-data.js` (Node) reads the master, strips every `_curatorMeta` recursively, validates strictly, and writes `js/data.js`. Refuses to write on any validation error.
- Git pre-commit hook (`scripts/install-hooks.js` → `.git/hooks/pre-commit` → `scripts/precommit.js`) runs the build automatically and stages `js/data.js` if it changed.
- `editor.html` auto-detects which file loaded: Master mode (curator fields visible, `_curatorMeta` emitted) vs. Public mode (curator fields hidden, structurally cannot emit private fields — verified by manually forcing values into the hidden DOM and confirming Copy JSON output stayed clean).
- `_curator/index.html` is a plain table dashboard (NOT styled like the public app) with tabs By Venue / By KJ Show / Needs Sources / Overdue, search, sort, and coverage stats. Read-only.
- [ADR-005](docs/adr/005-curator-master-build-step.md) records the deviation from ADR-002: deploy stays build-free; the transformation runs on the curator's machine.
- `CLAUDE.md` updated with the new flow, file structure, and venue/curator schema.

## Verification (local)
- Build strips `_curatorMeta` and produces no leak: confirmed via `grep _curatorMeta js/data.js` after annotating Sociedad with full curator notes — zero matches.
- Build refuses on invalid master: removed a required `name` field → exit 2, `js/data.js` untouched.
- Pre-commit hook end-to-end: `git commit` ran the build, reported "up to date", commit proceeded normally.
- Editor Master mode: badge "Master mode (local)", fieldset visible, Copy JSON output includes `_curatorMeta` with curator data.
- Editor Public mode (after renaming `_curator/data.js` aside): badge "Public mode", fieldset hidden. Forced values into the hidden inputs via DevTools and confirmed Copy JSON output excluded those values — structural leak guard works.
- Dashboard: 77 venues, 141 shows, coverage stats, tabs, search, sort all functional. After annotating Sociedad: "1/77 venues sourced, 2/141 shows sourced", overdue=1 (lastVerified 186 days ago), needs=76.
- Public app at `localhost:8000/index.html` still renders all 77 venues correctly; no `_curatorMeta` anywhere in DOM.

## Bootstrap for the curator (one-time)
```
node scripts/bootstrap-curator.js   # _curator/data.js created from current js/data.js
node scripts/install-hooks.js       # pre-commit hook installed
```
After that, edit master via `editor.html` (Master mode), reload `localhost:8000` to preview, `git commit` to ship.

## Test plan
- [ ] Run the two bootstrap commands
- [ ] Open `editor.html` locally, confirm "Master mode (local)" badge appears (distinct color)
- [ ] Select a venue, fill in curator-notes fields, click "Copy JSON", paste into `_curator/data.js`
- [ ] Run `node scripts/build-public-data.js` — should report N had `_curatorMeta` stripped
- [ ] `grep _curatorMeta js/data.js` returns nothing
- [ ] Reload `localhost:8000` — public app shows the venue normally
- [ ] Open `_curator/index.html` — dashboard renders, your annotation shows in the row
- [ ] `git commit` — pre-commit hook runs, build is up to date

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)