### PR TITLE
#99: Add CI workflow running data and CSS validators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  validate:
+    name: Validate data and CSS load order
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate venue data (js/data.js)
+        run: node scripts/validate-data.js
+
+      - name: Check CSS load order across HTML pages
+        run: node scripts/check-css-load-order.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,7 +335,7 @@ All pages should load CSS in this order for consistency:
 | bingo.html | base, layout, components, bingo |
 | bday.html | base, layout, components (inline `<style>` for the rest) |
 
-Enforced by `scripts/check-css-load-order.js` — run it before merging any change that touches `<link>` tags. Exits non-zero on violation.
+Enforced by `scripts/check-css-load-order.js` — also run automatically in CI on every PR (`.github/workflows/ci.yml`). Exits non-zero on violation.
 
 ### BEM Naming
 - Block: `.venue-card`
@@ -369,7 +369,7 @@ Use these semantic elements consistently:
 If you're a contributor (or a Claude session that needs to add a venue inside this repo):
 
 1. Edit `js/data.js` directly. Add the venue object to the `listings` array, following the schema in the "Venue Data Format" section below.
-2. Run `scripts/validate-data.js` to check format.
+2. Run `node scripts/validate-data.js` to check format. CI also runs this on every PR — see `.github/workflows/ci.yml`.
 3. Add coordinates via `scripts/geocode-venues.js` (Node.js batch).
 4. Open a PR. The owner will reconcile your change with their curator master before merging or after.
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` running `scripts/validate-data.js` and `scripts/check-css-load-order.js` on every PR and push to `main`.
- Updates CLAUDE.md to note CI enforcement (two small edits).
- Both validators are Node stdlib-only, so the workflow skips `npm install` — fast and dependency-free.

Closes #99.

## Note on npm scripts (DoD deviation)

The original ticket listed adding `npm run validate` and `npm run validate:css` scripts to `package.json`. Discovered while implementing: `package.json` is gitignored (commit 063a1719, alongside the Playwright test infra). The npm script convenience exists in my local `package.json` and is harmless, but isn't checked in. CI invokes `node scripts/...` directly, which is what matters.

Suggest a follow-up ticket to revisit whether `package.json` (and `playwright.config.js`) should be tracked — that's a repo-wide policy decision beyond this ticket's scope.

## Note on emergency-edit access

This workflow only **reports** pass/fail. It does not block merges or direct pushes — that requires branch protection rules in repo Settings (separate, not configured here). As repo admin, branch protection can be configured to allow admin override so emergency hotfixes remain one-click.

## Test plan

- [x] `node scripts/validate-data.js` passes locally (77 venues, 0 issues)
- [x] `node scripts/check-css-load-order.js` passes locally (5 pages OK)
- [ ] CI run on this PR passes
- [ ] CI run fails when validators fail (verified by transient failure in another branch — not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
