### PR TITLE
#108: Responsive polish — venue grids, mobile nav, A-Z strip, readable about

### DIFF
--- a/about.html
+++ b/about.html
@@ -23,8 +23,9 @@
     <link rel="stylesheet" href="css/components.css">
     <link rel="stylesheet" href="css/views.css">
 </head>
-<body>
+<body class="page--readable">
     <!-- Note: Not using page--edge-to-edge as this is a content page, not the main app -->
+    <!-- page--readable constrains the content column to a comfortable reading measure (see layout.css) -->
     <header class="site-header">
         <div class="site-header__content">
             <h1 class="site-header__title">Greater Austin Karaoke Directory</h1>

--- a/css/components.css
+++ b/css/components.css
@@ -147,6 +147,17 @@
     max-width: 400px;
 }
 
+/* Mobile-only search toggle button — hidden on desktop where the
+   search input is always visible */
+.navigation__search-toggle {
+    display: none;
+}
+
+/* Compact "Dedicated" label swaps in for the full toggle label on mobile */
+.navigation__toggle-text--short {
+    display: none;
+}
+
 /* Active-filter chips row (shown when ?kj= or similar URL-driven filter is active) */
 .navigation__active-filters {
     display: flex;
@@ -871,11 +882,29 @@
         max-width: 100vw;
     }
 
-    /* Search input on mobile */
+    /* Search on mobile: hidden behind the toggle button until opened
+       (or while a query is active — see Navigation.js) */
     .navigation__search {
+        display: none;
+    }
+
+    .navigation--search-open .navigation__search {
+        display: block;
         order: 10;
         flex-basis: 100%;
         max-width: none;
+    }
+
+    .navigation__search-toggle {
+        display: inline-flex;
+    }
+
+    .navigation__toggle-text--long {
+        display: none;
+    }
+
+    .navigation__toggle-text--short {
+        display: inline;
     }
 }
 

--- a/css/components.css
+++ b/css/components.css
@@ -881,9 +881,14 @@
     .main-content {
         max-width: 100vw;
     }
+}
 
-    /* Search on mobile: hidden behind the toggle button until opened
-       (or while a query is active — see Navigation.js) */
+/* Phones only (<=560px): collapse search behind the toggle button and use
+   the compact "Dedicated" label. Phablets (561-768px) keep search inline
+   and the full label — see the matching nav block in views.css. */
+@media (max-width: 560px) {
+    /* Hidden behind the toggle button until opened (or while a query is
+       active — see Navigation.js) */
     .navigation__search {
         display: none;
     }

--- a/css/layout.css
+++ b/css/layout.css
@@ -247,7 +247,6 @@
     padding: var(--spacing-xl) var(--spacing-md);
     text-align: center;
     border-top: 1px solid var(--border-color);
-    margin-top: var(--spacing-2xl);
 }
 
 .site-footer__social h2 {
@@ -433,7 +432,6 @@ body.view--map .fab-group {
 
     .site-footer {
         padding: var(--spacing-xl) var(--spacing-xs);
-        margin-top: var(--spacing-lg);
     }
 
     .site-footer__links {

--- a/css/layout.css
+++ b/css/layout.css
@@ -196,6 +196,15 @@
     min-height: calc(100vh - 300px);
 }
 
+/* Prose / content pages (about, etc.): the app's 1400px content width is
+   meant for venue grids — for running text it produces ~165-char lines.
+   Constrain to a comfortable reading measure (~74ch at the longest line);
+   ~matches submit.html's form width for cross-page consistency. Centered
+   via the inherited margin: 0 auto. */
+.page--readable .main-content {
+    max-width: 600px;
+}
+
 /* Two-Pane Layout for Wide Screens */
 .app-layout {
     display: block; /* Default: single column */

--- a/css/layout.css
+++ b/css/layout.css
@@ -423,7 +423,7 @@ body.view--map .fab-group {
     }
 
     .navigation-container {
-        padding: var(--spacing-md) var(--spacing-xs);
+        padding: var(--spacing-sm) var(--spacing-xs);
     }
 
     .main-content {

--- a/css/views.css
+++ b/css/views.css
@@ -665,8 +665,11 @@
     }
 }
 
-/* Responsive navigation */
-@media (max-width: 768px) {
+/* Responsive navigation — PHONES ONLY (<=560px).
+   Phablets/small tablets (561-768px) have room for the desktop-style
+   labeled nav with inline search, so the aggressive compaction stops at
+   560px (see the search-collapse rules in components.css, scoped to match). */
+@media (max-width: 560px) {
     /* Two compact rows instead of four stacked ones: view tabs on top;
        week nav + dedicated toggle + search toggle share the second row
        (wrapping gracefully when cramped, e.g. with the "Today" button) */

--- a/css/views.css
+++ b/css/views.css
@@ -403,6 +403,27 @@
     background: var(--color-gray-700);
 }
 
+/* Desktop: venues flow into a multi-column grid. A single column stretches
+   one card across the full content width (~1300px on large screens). */
+@media (min-width: 769px) {
+    .day-card__venues,
+    .letter-card__venues {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    }
+
+    /* Equal-height cards within a grid row */
+    .day-card__venue-item,
+    .letter-card__venue-item {
+        display: flex;
+    }
+
+    .day-card__venue-item .venue-card,
+    .letter-card__venue-item .venue-card {
+        flex: 1;
+    }
+}
+
 @media (max-width: 768px) {
     .day-card {
         scroll-margin-top: var(--nav-height);

--- a/css/views.css
+++ b/css/views.css
@@ -637,13 +637,21 @@
 
 /* Responsive navigation */
 @media (max-width: 768px) {
+    /* Two compact rows instead of four stacked ones: view tabs on top;
+       week nav + dedicated toggle + search toggle share the second row
+       (wrapping gracefully when cramped, e.g. with the "Today" button) */
     .navigation {
-        flex-direction: column;
-        align-items: stretch;
+        justify-content: center;
+        gap: var(--spacing-sm) var(--spacing-md);
     }
 
     .navigation__views {
+        flex-basis: 100%;
         justify-content: center;
+    }
+
+    .navigation__views .nav-btn {
+        min-height: 40px;
     }
 
     .navigation__week {

--- a/css/views.css
+++ b/css/views.css
@@ -338,6 +338,36 @@
     text-decoration: none;
 }
 
+/* Mobile: the A-Z index becomes a single horizontally-scrollable row
+   instead of wrapping to ~3 rows (cuts sticky chrome from ~131px to
+   ~56px). The --az-index-height ResizeObserver in AlphabeticalView.js
+   keeps the letter-card headers pinned directly below the strip.
+   overflow-x lives on the sticky element itself (not an ancestor), so
+   it doesn't break the sticky positioning. */
+@media (max-width: 768px) {
+    .alphabetical-view__index {
+        flex-wrap: nowrap;
+        justify-content: flex-start;
+        overflow-x: auto;
+        overflow-y: hidden;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-sm);
+        -webkit-overflow-scrolling: touch;
+        scrollbar-width: none; /* Firefox */
+    }
+
+    /* Hide the horizontal scrollbar (base.css sets a global 8px one) */
+    .alphabetical-view__index::-webkit-scrollbar {
+        display: none;
+    }
+
+    .alphabetical-view__index-link {
+        flex: 0 0 auto; /* keep tap size; never shrink to fit */
+        width: 40px;
+        height: 40px;
+    }
+}
+
 .alphabetical-view__list {
     display: flex;
     flex-direction: column;

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -78,6 +78,7 @@ Each day card header displays:
 When expanded, shows:
 - One venue card per **matching schedule entry** (a venue with two events on the same date renders two cards, each showing its own event name, time, and host)
 - Footer with **unique venue count** (e.g., "14 venues" even if 15 cards rendered because one venue had two events)
+- **Venue card layout:** single column on mobile (≤768px); at 769px+ cards flow into a responsive grid (`repeat(auto-fill, minmax(320px, 1fr))` — 2 columns at ~1024px, up to 4 on large screens). Cards in the same grid row stretch to equal height. The same grid applies to letter cards in the Alphabetical view.
 
 ### Sorting
 
@@ -942,8 +943,8 @@ Includes a "Documentation" link to `docs/index.html`.
 | Width | Behavior |
 |-------|----------|
 | Base (mobile) | Single column, modal for venue details, stacked navigation |
-| 768px+ | Enhanced spacing and layout |
-| 1024px+ | Wider cards, more horizontal space |
+| 769px+ | Venue cards flow into a multi-column grid (`auto-fill, minmax(320px, 1fr)`) inside day/letter cards; labeled nav buttons |
+| 1024px+ | More grid columns as space allows |
 | 1200px+ | Side-by-side layouts where applicable |
 | 1400px+ | Desktop venue detail pane visible alongside main content; mobile modal suppressed |
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -296,19 +296,23 @@ Only visible when `view === 'weekly'`:
 
 ### Search Input
 
-Always visible on desktop (769px+). On mobile (≤768px) the input collapses behind a magnifying-glass toggle button — see Section 9 (Search) for full behavior.
+Visible inline on desktop **and phablets** (561px+). On phones (≤560px) the input collapses behind a magnifying-glass toggle button — see Section 9 (Search) for full behavior.
 
 ### Dedicated Venue Filter
 
-Always visible. Label reads "Show dedicated venues" on desktop, compact "Dedicated" on mobile (≤768px). See Section 10 (Filtering) for full behavior.
+Always visible. Label reads "Show dedicated venues" on desktop/phablet, compact "Dedicated" on phones (≤560px). See Section 10 (Filtering) for full behavior.
 
-### Mobile Layout (≤768px)
+### Responsive Layout Tiers
 
-The navigation compresses to two rows (~102px total, sticky):
-1. **View tabs** (icon-only, 40px min-height)
-2. **Week navigation + Dedicated toggle + search toggle button** (wraps to a third row when the "Today" button is present)
+The navigation has three tiers, sharing the desktop markup:
 
-The search toggle button (40×40, `aria-expanded`) expands the search input as a full-width row and focuses it. The row stays open while a query is active (including across re-renders). Collapsing via the toggle also **clears any active query** so a filter can never remain applied while its input is hidden.
+| Tier | Width | Layout |
+|------|-------|--------|
+| **Desktop** | 769px+ | Single roomy bar; labeled tabs; inline search; full toggle label |
+| **Phablet** | 561–768px | Desktop-style labeled nav — tabs + week nav on row one, inline search + toggle on row two (~115–130px) |
+| **Phone** | ≤560px | Compact two rows (~102px, sticky): icon-only tabs (40px min-height) on row one; week nav + compact "Dedicated" toggle + search toggle button on row two (wraps to a third row when the "Today" button is present) |
+
+On phones, the search toggle button (40×40, `aria-expanded`) expands the search input as a full-width row and focuses it. The row stays open while a query is active (including across re-renders). Collapsing via the toggle also **clears any active query** so a filter can never remain applied while its input is hidden.
 
 ### Navigation Height Tracking
 
@@ -442,11 +446,11 @@ The app includes a global search bar that filters venues across all views.
 
 ### Search Input
 
-Located in the Navigation component. Always visible on desktop (769px+); on mobile (≤768px) hidden behind a magnifying-glass toggle button in the navigation bar.
+Located in the Navigation component. Visible inline on desktop and phablets (561px+); on phones (≤560px) hidden behind a magnifying-glass toggle button in the navigation bar.
 - **Placeholder:** "Search venues, tags, hosts..."
 - **Clear button** (X icon) appears when search has text; clicking clears input and refocuses it
 - Typing updates the `searchQuery` state and emits `FILTER_CHANGED`
-- **Mobile toggle:** opening expands the input as a full-width row and focuses it; closing the toggle while a query is active clears the query (prevents invisible active filters). The row stays expanded while a query is active.
+- **Phone toggle (≤560px):** opening expands the input as a full-width row and focuses it; closing the toggle while a query is active clears the query (prevents invisible active filters). The row stays expanded while a query is active.
 
 ### What Search Matches Against
 
@@ -957,7 +961,8 @@ The `<body>` carries the `page--readable` class, which constrains `.main-content
 
 | Width | Behavior |
 |-------|----------|
-| Base (mobile) | Single column, modal for venue details; compact two-row navigation (~102px sticky) with collapsible search |
+| Phone (≤560px) | Single column, modal for venue details; compact two-row navigation (~102px sticky) with collapsible search; single-row scrollable A–Z index |
+| Phablet (561–768px) | Desktop-style labeled navigation with inline search (~115–130px); single column content |
 | 769px+ | Venue cards flow into a multi-column grid (`auto-fill, minmax(320px, 1fr)`) inside day/letter cards; labeled nav buttons |
 | 1024px+ | More grid columns as space allows |
 | 1200px+ | Side-by-side layouts where applicable |

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -294,11 +294,19 @@ Only visible when `view === 'weekly'`:
 
 ### Search Input
 
-Always visible. See Section 9 (Search) for full behavior.
+Always visible on desktop (769px+). On mobile (≤768px) the input collapses behind a magnifying-glass toggle button — see Section 9 (Search) for full behavior.
 
 ### Dedicated Venue Filter
 
-Always visible. See Section 10 (Filtering) for full behavior.
+Always visible. Label reads "Show dedicated venues" on desktop, compact "Dedicated" on mobile (≤768px). See Section 10 (Filtering) for full behavior.
+
+### Mobile Layout (≤768px)
+
+The navigation compresses to two rows (~102px total, sticky):
+1. **View tabs** (icon-only, 40px min-height)
+2. **Week navigation + Dedicated toggle + search toggle button** (wraps to a third row when the "Today" button is present)
+
+The search toggle button (40×40, `aria-expanded`) expands the search input as a full-width row and focuses it. The row stays open while a query is active (including across re-renders). Collapsing via the toggle also **clears any active query** so a filter can never remain applied while its input is hidden.
 
 ### Navigation Height Tracking
 
@@ -432,10 +440,11 @@ The app includes a global search bar that filters venues across all views.
 
 ### Search Input
 
-Located in the Navigation component. Always visible.
+Located in the Navigation component. Always visible on desktop (769px+); on mobile (≤768px) hidden behind a magnifying-glass toggle button in the navigation bar.
 - **Placeholder:** "Search venues, tags, hosts..."
 - **Clear button** (X icon) appears when search has text; clicking clears input and refocuses it
 - Typing updates the `searchQuery` state and emits `FILTER_CHANGED`
+- **Mobile toggle:** opening expands the input as a full-width row and focuses it; closing the toggle while a query is active clears the query (prevents invisible active filters). The row stays expanded while a query is active.
 
 ### What Search Matches Against
 
@@ -942,7 +951,7 @@ Includes a "Documentation" link to `docs/index.html`.
 
 | Width | Behavior |
 |-------|----------|
-| Base (mobile) | Single column, modal for venue details, stacked navigation |
+| Base (mobile) | Single column, modal for venue details; compact two-row navigation (~102px sticky) with collapsible search |
 | 769px+ | Venue cards flow into a multi-column grid (`auto-fill, minmax(320px, 1fr)`) inside day/letter cards; labeled nav buttons |
 | 1024px+ | More grid columns as space allows |
 | 1200px+ | Side-by-side layouts where applicable |

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -928,6 +928,10 @@ Includes a "Documentation" link to `docs/index.html`.
 - Tagline: "NOTE HOLIDAY MAY CHANGE AVAILABILITY, CALL VENUE FIRST"
 - Navigation link back to `index.html`
 
+### Reading Measure
+
+The `<body>` carries the `page--readable` class, which constrains `.main-content` to a 600px max-width (centered) so running prose holds a comfortable ~74-character line length instead of the app's 1400px grid width (~165 chars). The class is reusable for any future content/prose page.
+
 ---
 
 ## 18 Debug Mode

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -171,6 +171,8 @@ Browse all venues alphabetically, grouped by first letter.
 
 - The letter index bar sticks to the top during scroll
 - Its height is tracked via `ResizeObserver` and stored as CSS variable `--az-index-height` so letter headings can stick below it
+- **Desktop (769px+):** letters wrap across rows, centered
+- **Mobile (≤768px):** letters stay on a single horizontally-scrollable row (~54px tall vs. ~131px wrapped), with 40px touch targets; the `--az-index-height` observer keeps letter headings pinned directly below the strip regardless of its height
 
 > **Implementation note:** Alphabetical sorting uses `getSortableName()` from `js/utils/string.js`, which strips leading articles ("The", "A", "An", etc.) for sort ordering while preserving the original name for display. The sticky index height is dynamically measured via `ResizeObserver` and written to `--az-index-height` so CSS can position letter group headings below it without hardcoding pixel values.
 

--- a/js/components/Component.js
+++ b/js/components/Component.js
@@ -22,6 +22,7 @@ export class Component {
         this.state = {};
         this._subscriptions = [];
         this._eventListeners = [];
+        this._delegates = new Map();
         this._isMounted = false;
 
         this.init();
@@ -118,6 +119,18 @@ export class Component {
      * @param {Function} handler - Event handler
      */
     delegate(event, selector, handler) {
+        // afterRender() runs on every render, so re-binding the same
+        // event+selector must replace the previous listener — stacking
+        // duplicates would fire the handler N times per interaction
+        // (breaks non-idempotent handlers like toggles).
+        const key = `${event}::${selector}`;
+        const prev = this._delegates.get(key);
+        if (prev) {
+            this.container?.removeEventListener(event, prev);
+            const index = this._eventListeners.findIndex(l => l.handler === prev);
+            if (index !== -1) this._eventListeners.splice(index, 1);
+        }
+
         const delegatedHandler = (e) => {
             const target = e.target.closest(selector);
             if (target && this.container?.contains(target)) {
@@ -125,6 +138,7 @@ export class Component {
             }
         };
 
+        this._delegates.set(key, delegatedHandler);
         this.container?.addEventListener(event, delegatedHandler);
         this._eventListeners.push({
             element: this.container,
@@ -203,6 +217,7 @@ export class Component {
             element?.removeEventListener(event, handler, options);
         });
         this._eventListeners = [];
+        this._delegates.clear();
 
         // Unsubscribe from state/events
         this._subscriptions.forEach(unsubscribe => {

--- a/js/components/Navigation.js
+++ b/js/components/Navigation.js
@@ -70,9 +70,13 @@ export class Navigation extends Component {
 
         const weekRange = formatWeekRange(getWeekStart(weekStart));
         const isCurrentWeek = this.isCurrentWeek(weekStart);
+        // Mobile: search collapses to an icon button. Keep the row expanded
+        // across re-renders while toggled open or while a query is active.
+        const searchQuery = getState('searchQuery') || '';
+        const searchOpen = this.searchOpen || !!searchQuery;
 
         return `
-            <nav class="navigation">
+            <nav class="navigation${searchOpen ? ' navigation--search-open' : ''}">
                 ${this.renderViewSwitcher({ view, kjIndexActive: false })}
 
                 ${view === 'weekly' ? `
@@ -92,7 +96,7 @@ export class Navigation extends Component {
                     </div>
                 ` : ''}
 
-                <div class="navigation__search">
+                <div class="navigation__search" id="navigation-search">
                     <div class="search-input">
                         <i class="fa-solid fa-magnifying-glass search-input__icon"></i>
                         <input
@@ -100,9 +104,9 @@ export class Navigation extends Component {
                             class="search-input__field"
                             placeholder="Search venues, tags, hosts..."
                             data-search="query"
-                            value="${getState('searchQuery') || ''}"
+                            value="${searchQuery}"
                         >
-                        ${getState('searchQuery') ? `
+                        ${searchQuery ? `
                             <button class="search-input__clear" data-search="clear" type="button" title="Clear search">
                                 <i class="fa-solid fa-xmark"></i>
                             </button>
@@ -117,9 +121,22 @@ export class Navigation extends Component {
                             ${showDedicated ? 'checked' : ''}
                             data-filter="dedicated"
                         >
-                        <span>Show dedicated venues</span>
+                        <span class="navigation__toggle-text--long">Show dedicated venues</span>
+                        <span class="navigation__toggle-text--short">Dedicated</span>
                     </label>
                 </div>
+
+                <button
+                    class="nav-btn nav-btn--icon navigation__search-toggle"
+                    data-search="toggle"
+                    type="button"
+                    title="Search"
+                    aria-label="Search"
+                    aria-controls="navigation-search"
+                    aria-expanded="${searchOpen}"
+                >
+                    <i class="fa-solid fa-magnifying-glass"></i>
+                </button>
 
             </nav>
         `;
@@ -221,6 +238,27 @@ export class Navigation extends Component {
                 }
             } else if (!query && clearBtn) {
                 clearBtn.remove();
+            }
+        });
+
+        // Mobile search toggle: expands the search row. Collapsing also
+        // clears any active query so a filter can't stay applied while hidden.
+        this.delegate('click', '[data-search="toggle"]', (e, target) => {
+            const nav = this.container.querySelector('.navigation');
+            const opening = !nav.classList.contains('navigation--search-open');
+            this.searchOpen = opening;
+            nav.classList.toggle('navigation--search-open', opening);
+            target.setAttribute('aria-expanded', String(opening));
+            if (opening) {
+                const input = this.container.querySelector('[data-search="query"]');
+                if (input) input.focus();
+            } else if (getState('searchQuery')) {
+                const input = this.container.querySelector('[data-search="query"]');
+                if (input) input.value = '';
+                const clearBtn = this.container.querySelector('[data-search="clear"]');
+                if (clearBtn) clearBtn.remove();
+                setState({ searchQuery: '' });
+                emit(Events.FILTER_CHANGED, { searchQuery: '' });
             }
         });
 


### PR DESCRIPTION
## Summary

Responsive polish across all pages, from a measured breakpoint audit (320 / 375 / 560 / 600 / 768 / 769 / 1024 / 1440 / 1920 px). Five audit items plus two fixes surfaced during the work. No horizontal overflow at any width tested.

Each item was implemented and verified one at a time (geometry measured before/after); the human Verify pass on real touch devices remains.

## Related Issue

Fixes #108

## Changes

- **Multi-column venue grid on desktop** (`84673eb`) — day/letter card venue lists become `repeat(auto-fill, minmax(320px, 1fr))` at 769px+, equal-height rows. Single 1309px-wide card at 1920 → 4 columns. Mobile unchanged.
- **Footer background gap** (`ab08ca1`) — removed `.site-footer` top margin that left a 64–79px band of background image above the footer on every page.
- **Component.delegate duplicate-listener fix** (`39dd6bb`) — `delegate()` stacked a new listener every re-render, so handlers fired once per prior render. Now de-dupes by `event::selector`. **Affects every component** (see QA note below).
- **Mobile nav compaction** (`38ead60`) — phone nav dropped from 200px → ~102px (two rows); search collapses behind a toggle that auto-focuses, persists while a query is active, and clears on close so no filter hides while applied.
- **Single-row scrollable A–Z index** (`417d421`) — mobile letter strip from ~131px (3 wrapped rows) → ~54px (one horizontally-scrollable row), 40px tap targets. Pinned chrome on A–Z dropped ~340px → ~218px.
- **About-page reading measure** (`d785124`) — reusable `page--readable` body class caps `.main-content` at 600px (~165 ch → ~74 ch line length).
- **Phablet nav tier** (`f791bb7`) — aggressive compaction now stops at 560px; 561–768px gets the desktop-style labeled nav with inline search. Smooth 768→769 transition.

## Documentation Checklist
- [x] Project spec updated (functional-spec §2, 3, 5, 9, 17, 19)
- [ ] CLAUDE.md updated
- [ ] README.md updated
- [x] No doc updates needed (beyond spec)

## Testing Checklist
- [x] Geometry measured before/after at every breakpoint (320–1920px)
- [x] No horizontal overflow at 320/375/560/561/600/768/769/1024/1440/1920
- [x] Nav breakpoint flips verified at exact boundaries (560 phone / 561 phablet, 768/769)
- [x] Search toggle open/focus/clear cycle; persists across view re-renders
- [x] A–Z letter-jump lands below pinned chrome (`scroll-margin-top` tracks strip height)
- [x] All three CI gates pass locally (data validate, data.js sync, CSS load order)
- [ ] **Human Verify on real touch device** (owner) — esp. mobile nav, search toggle, A–Z horizontal scroll

## QA note — regression sniff

The `Component.delegate` fix touches the base class, so it affects more than the nav. Worth a quick check during Verify:
- Map view "Hide Dedicated" + view-switch buttons (these re-render — likely multi-firing before)
- Past-day expand/collapse in Weekly view
- Venue card clicks after switching views several times

🤖 Generated with [Claude Code](https://claude.com/claude-code)
