### PR TITLE
#110: Responsive polish round 2 — tap targets, mobile density, layout fixes

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1039,6 +1039,10 @@
 }
 
 .consent-banner__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--size-icon-lg); /* 44px touch target — first thing a new visitor taps */
     padding: var(--spacing-xs) var(--spacing-md);
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);

--- a/css/components.css
+++ b/css/components.css
@@ -706,6 +706,55 @@
     .venue-modal__map-links {
         flex-direction: column;
     }
+
+    /* Stack the schedule table into label/value cards on small phones — a
+       4-column table (Day/Time/Host/Note) is too cramped here. data-label
+       attributes come from renderScheduleTable() in js/utils/render.js. */
+    .venue-modal__schedule-table,
+    .venue-modal__schedule-table tbody {
+        display: block;
+    }
+
+    .venue-modal__schedule-table thead {
+        display: none;
+    }
+
+    .venue-modal__schedule-table tr {
+        display: block;
+        padding: var(--spacing-sm) 0;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .venue-modal__schedule-table td {
+        display: flex;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-2xs) 0;
+        border: none;
+    }
+
+    /* Empty cells (e.g. a show with no note) collapse instead of showing a bare label */
+    .venue-modal__schedule-table td:empty {
+        display: none;
+    }
+
+    /* Label column from data-label */
+    .venue-modal__schedule-table td::before {
+        content: attr(data-label);
+        flex: 0 0 4.5em;
+        color: var(--text-muted);
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+    }
+
+    /* The day cell is the card's title — bold, no label */
+    .venue-modal__schedule-table td:first-child {
+        font-weight: 600;
+        font-size: var(--font-size-base);
+    }
+
+    .venue-modal__schedule-table td:first-child::before {
+        content: none;
+    }
 }
 
 /* Special Event card accent */

--- a/css/submit.css
+++ b/css/submit.css
@@ -89,6 +89,26 @@
     margin-bottom: 0;
 }
 
+/* Address: City / State / ZIP read as one unit. The generic auto-fit floor
+   (200px) only fits 2 columns in the ~600px form (orphaning ZIP), and its
+   min-content can overflow the section near 760px. Override with explicit
+   tracks: stacked on phones, City-wide 3-up once there's room. min-width: 0
+   lets State/ZIP shrink below the input's intrinsic width so the 2:1:1 ratio
+   holds instead of clamping all three to min-content (equal) width. */
+.form-row--address {
+    grid-template-columns: 1fr;
+}
+
+@media (min-width: 561px) {
+    .form-row--address {
+        grid-template-columns: 2fr 1fr 1fr;
+    }
+
+    .form-row--address .form-group {
+        min-width: 0;
+    }
+}
+
 .form-group {
     display: flex;
     flex-direction: column;

--- a/css/views.css
+++ b/css/views.css
@@ -783,6 +783,7 @@ body.view--map .app-layout__detail {
 .map-controls__btn--text {
     width: auto;
     height: auto;
+    min-height: var(--size-icon-lg); /* keep 44px touch target despite height: auto */
     padding: var(--spacing-sm) var(--spacing-md);
     border-radius: var(--border-radius-lg);
     font-size: var(--font-size-sm);
@@ -1074,6 +1075,7 @@ body.view--map .app-layout__detail {
         bottom: auto;
         top: 50%;
         transform: translateX(calc(100% + var(--spacing-lg))) translateY(-50%);
+        width: 350px; /* explicit — otherwise shrink-to-fit leaves it ~247px and skinny */
         max-width: 350px;
     }
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -243,6 +243,7 @@ A card that appears over the map when a marker is selected. Has two states:
 - "Details" button expands the card and shows a back arrow
 - "Back to Summary" returns to compact view
 - Clicking the map background (not a marker or card) dismisses the card
+- **Sizing:** full-width bottom sheet on mobile; on desktop (≥1024px) a fixed 350px-wide card anchored right (explicit width so it doesn't shrink to its content). The floating "Hide Dedicated" map control and the analytics consent-banner buttons are ≥44px tall (touch targets).
 
 ### Floating Controls
 
@@ -823,6 +824,8 @@ Automatically restored on page load.
 **File:** `submit.html`
 
 Single-purpose mobile-first form for community submissions of new karaoke venues. Optimized for KJs/fans on a phone with limited time. Single column on mobile (<768px), multi-column on tablet+. Touch targets ≥44×44 px, native input types for keyboard intent (`type="time"`, `type="url"`, `type="email"`, `type="tel"`, `inputmode="numeric"` on ZIP), 16px input font-size to prevent iOS auto-zoom, sticky submit button always reachable.
+
+The City / State / ZIP row uses an explicit `2fr 1fr 1fr` template at ≥561px (City wider; State/ZIP narrow, with `min-width: 0` so they shrink below the inputs' intrinsic width rather than clamping equal), stacking to one column below that. This keeps the three fields on one row without orphaning ZIP — the generic `auto-fit` floor otherwise fit only two columns and its min-content overflowed the form near 760px.
 
 ### Required vs optional split
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -399,6 +399,8 @@ The modal opens only when ALL of these conditions are met:
 
 Schedule tables, host sections, and active period notices are rendered using shared utilities from `js/utils/render.js`.
 
+On small phones (≤480px) the modal's schedule table collapses from a 4-column grid (Day/Time/Host/Note) into stacked label/value cards: the thead is hidden, each row becomes a block, the day cell is the bold title, and Time/Host/Note are labeled via `data-label` (`::before`). Empty cells (e.g. a show with no note) are hidden rather than showing a bare label. Above 480px it renders as a normal table. `data-label` attributes are emitted by `renderScheduleTable()` for all surfaces but only consumed by this modal breakpoint.
+
 ### Close Triggers
 
 1. Click the close button (X)

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -984,6 +984,7 @@ The `<body>` carries the `page--readable` class, which constrains `.main-content
 - Venue detail pane as sticky right sidebar
 - Modal suppressed (pane used instead)
 - Wider cards and multi-column layouts
+- The two-pane `.app-layout` is a fixed-height grid (`calc(100vh - 140px)`) whose list and detail columns each scroll internally. The footer lives **inside the scrolling list column** (not as a body-level sibling) so there is a single scroll context — a body-level footer would overflow the fixed-height layout and produce a second outer scrollbar. Below 1400px the list is plain block flow, so the footer sits at the page bottom as normal.
 
 ### Map View
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -125,6 +125,7 @@ Below the current 7-day week, three additional collapsible sections display venu
 - Each section has a header showing title and venue count badge
 - Sections are collapsible — click header to toggle
 - Collapse state persists in `localStorage` (key: `extendedSection_{title-slug}_collapsed`)
+- **Default collapse state is viewport-dependent:** on small screens (≤768px) sections start **collapsed** (they otherwise add ~20,000px to an already-tall single-column page); on desktop they start **expanded**. A stored choice always wins over the default, so toggling a section once makes that choice stick on every screen. The toggle stores the section's *actual* resulting state (DOM is the source of truth), since the displayed state may originate from the viewport default rather than storage.
 - Empty sections (no venues in date range) are not rendered
 - Day cards within sections use the same format as the current week
 - Maximum lookahead is 60 days from today

--- a/index.html
+++ b/index.html
@@ -94,6 +94,38 @@
                     Loading venues...
                 </div>
             </main>
+
+            <!-- Footer lives inside the scrolling list column so the two-pane
+                 layout (>=1400px) has a single scroll context: at those widths
+                 .app-layout is a fixed-height grid, so a body-level footer would
+                 overflow the body and create a second outer scrollbar. Below
+                 1400px the list is plain block flow, so the footer still sits at
+                 the bottom of the page exactly as before. -->
+            <footer class="site-footer">
+                <div class="site-footer__social">
+                    <h2>Follow Us</h2>
+                    <div class="social-links">
+                        <a href="https://www.facebook.com/groups/2494105004273043"
+                           target="_blank" rel="noopener noreferrer" title="Facebook">
+                            <i class="fa-brands fa-facebook fa-lg"></i>
+                        </a>
+                        <a href="https://www.instagram.com/karaokedirectory/"
+                           target="_blank" rel="noopener noreferrer" title="Instagram">
+                            <i class="fa-brands fa-instagram fa-lg"></i>
+                        </a>
+                    </div>
+                </div>
+
+                <div class="site-footer__links">
+                    <a href="about.html">About Us</a>
+                    <a href="submit.html">Submit Venue</a>
+                    <a href="docs/index.html">Documentation</a>
+                </div>
+
+                <p class="site-footer__copyright">
+                    &copy; 2025 Austin Karaoke Directory
+                </p>
+            </footer>
         </div>
 
         <!-- Desktop venue detail pane (>=1400px). Hidden on mobile; replaced by venue-modal. -->
@@ -102,32 +134,6 @@
 
     <!-- Mobile venue detail modal mount point. Populated by VenueModal.js. -->
     <div id="venue-modal"></div>
-
-    <footer class="site-footer">
-        <div class="site-footer__social">
-            <h2>Follow Us</h2>
-            <div class="social-links">
-                <a href="https://www.facebook.com/groups/2494105004273043"
-                   target="_blank" rel="noopener noreferrer" title="Facebook">
-                    <i class="fa-brands fa-facebook fa-lg"></i>
-                </a>
-                <a href="https://www.instagram.com/karaokedirectory/"
-                   target="_blank" rel="noopener noreferrer" title="Instagram">
-                    <i class="fa-brands fa-instagram fa-lg"></i>
-                </a>
-            </div>
-        </div>
-
-        <div class="site-footer__links">
-            <a href="about.html">About Us</a>
-            <a href="submit.html">Submit Venue</a>
-            <a href="docs/index.html">Documentation</a>
-        </div>
-
-        <p class="site-footer__copyright">
-            &copy; 2025 Austin Karaoke Directory
-        </p>
-    </footer>
 
     <div class="fab-group">
         <button id="jump-to-today"

--- a/js/components/ExtendedSection.js
+++ b/js/components/ExtendedSection.js
@@ -49,22 +49,42 @@ function migrateStorageKeys() {
 migrateStorageKeys();
 
 /**
- * Check if section should be collapsed
+ * Whether sections default to collapsed when the user has made no explicit
+ * choice. On small screens (≤768px, single-column) the extended sections add
+ * ~20,000px to an already-tall calendar page, so they start collapsed there;
+ * desktop (multi-column, roomier) starts expanded.
+ * @returns {boolean}
+ */
+function defaultCollapsedForViewport() {
+    return typeof window !== 'undefined'
+        && typeof window.matchMedia === 'function'
+        && window.matchMedia('(max-width: 768px)').matches;
+}
+
+/**
+ * Check if section should be collapsed. An explicit stored choice always wins;
+ * otherwise fall back to the viewport-dependent default (collapsed on mobile).
  * @param {string} title - Section title
  * @returns {boolean} True if collapsed
  */
 function isCollapsed(title) {
-    return localStorage.getItem(getStorageKey(title)) === 'true';
+    const stored = localStorage.getItem(getStorageKey(title));
+    if (stored !== null) {
+        return stored === 'true';
+    }
+    return defaultCollapsedForViewport();
 }
 
 /**
- * Toggle collapse state
+ * Persist an explicit collapse choice.
+ * Stores the actual resulting state rather than deriving it from the previous
+ * stored value — the displayed state may come from the viewport default (no
+ * stored value yet), so the DOM, not localStorage, is the source of truth.
  * @param {string} title - Section title
+ * @param {boolean} collapsed - The new collapsed state
  */
-function toggleCollapsed(title) {
-    const key = getStorageKey(title);
-    const current = localStorage.getItem(key) === 'true';
-    localStorage.setItem(key, (!current).toString());
+function setCollapsed(title, collapsed) {
+    localStorage.setItem(getStorageKey(title), collapsed.toString());
 }
 
 /**
@@ -178,9 +198,10 @@ export function attachExtendedSectionListeners(container) {
             const section = e.target.closest('.extended-section');
             if (section) {
                 const title = section.dataset.sectionTitle;
-                toggleCollapsed(title);
-                section.classList.toggle('extended-section--collapsed');
-                button.classList.toggle('extended-section__toggle--expanded');
+                // Toggle the DOM first; its result is the authoritative new state
+                const nowCollapsed = section.classList.toggle('extended-section--collapsed');
+                button.classList.toggle('extended-section__toggle--expanded', !nowCollapsed);
+                setCollapsed(title, nowCollapsed);
             }
         });
     });

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -56,15 +56,17 @@ export function renderScheduleTable(venue, classPrefix) {
             : '';
 
         const hostCell = showHostColumn
-            ? `<td>${escapeHtml(formatHostDisplay(resolveHostFor(venue, entry)))}</td>`
+            ? `<td data-label="Host">${escapeHtml(formatHostDisplay(resolveHostFor(venue, entry)))}</td>`
             : '';
 
+        // data-label drives the stacked card layout on small phones (<480px),
+        // where the table collapses to label/value rows — see components.css.
         return `
             <tr>
-                <td>${dayLabel}${eventLink}</td>
-                <td>${formatted.time}</td>
+                <td data-label="Day">${dayLabel}${eventLink}</td>
+                <td data-label="Time">${formatted.time}</td>
                 ${hostCell}
-                ${entry.note ? `<td class="schedule-note">${escapeHtml(entry.note)}</td>` : '<td></td>'}
+                ${entry.note ? `<td class="schedule-note" data-label="Note">${escapeHtml(entry.note)}</td>` : '<td data-label="Note"></td>'}
             </tr>
         `;
     }).join('');

--- a/submit.html
+++ b/submit.html
@@ -76,7 +76,7 @@
                                 <input type="text" id="street" name="street" required autocomplete="street-address" placeholder="e.g., 123 Main Street">
                             </div>
                         </div>
-                        <div class="form-row">
+                        <div class="form-row form-row--address">
                             <div class="form-group">
                                 <label for="city">City <span class="required">*</span></label>
                                 <input type="text" id="city" name="city" required autocomplete="address-level2" value="Austin">


### PR DESCRIPTION
## Summary

Responsive polish round 2 — the audit findings from #108 that didn't make round 1's top 5. Working through 4 items one at a time on this branch; **opened as a draft because only item 1 of 4 is done so far** (don't merge until the rest land, or it'll auto-close #110 early).

## Related Issue

Fixes #110

## Changes

### ✅ Item 1 — Tap targets & micro-polish (`f9ca720`)
- Consent-banner Accept/Decline buttons: 28px → **44px** (min-height + inline-flex centering)
- Map "Hide Dedicated" pill: 36px → **44px** (min-height despite `height: auto`)
- Map floating venue card at ≥1024px: explicit **350px** width (was ~247px shrink-to-fit)
- Submit City/State/ZIP row: explicit `2fr 1fr 1fr` at ≥561px with `min-width: 0` children, stacked below. Fixes ZIP orphaning onto its own row **and** a min-content overflow of the form section near 760px (real horizontal-scroll bug at that width).

### ⬜ Remaining (pending on this branch)
- **Item 2** — default-collapse extended sections on mobile (~45,000px phone page → much shorter; first-visit only, must not override stored user choice)
- **Item 3** — fix double scrollbar at 1400px+ (footer outside the fixed-height two-pane layout)
- **Item 4** — stack the venue-modal schedule table on small phones (<480px)

## Documentation Checklist
- [x] Project spec updated (functional-spec §4, §15 so far)
- [ ] CLAUDE.md updated
- [ ] README.md updated
- [x] No other doc updates needed

## Testing Checklist
- [x] Item 1 geometry verified at 375 / 561 / 760 / 1024 (address row: no orphan, no overflow; tap targets 44px; map card 350px)
- [x] No console errors; CSS load-order gate passes locally
- [ ] **Human Verify on real touch device** (owner)
- [ ] Items 2–4 implemented + verified before marking ready / merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
