### PR TITLE
Complete Exclusion Dates feature (map + detail views + docs) — #5 #6 #8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@
 
 ### 2. Mobile-First Responsive Design
 - Base styles target mobile devices
-- Media queries enhance for larger screens (768px, 1024px, 1400px breakpoints)
+- Media queries enhance for larger screens (560px, 768px, 1024px, 1400px breakpoints); 560px splits phone vs phablet nav, 769px+ enables multi-column venue grids (see spec §19)
 - Modal for venue details on mobile, side pane on desktop (1400px+)
 
 ### 3. Separation of Concerns
@@ -198,6 +198,9 @@ When adding or modifying venues in `js/data.js`, follow this structure:
       startTime: "21:00",     // 24-hour format
       endTime: "01:00",       // Can cross midnight
       eventUrl: "https://...", // Optional: link to event page
+      exclusions: [           // Optional: dates this recurring show is skipped (holiday/closure)
+        { date: "2026-12-25", reason: "Holiday" }  // reason optional; "2026-12-25" shorthand also accepted
+      ],
       host: {                 // Optional: overrides venue-level host for this show only
         name: "Guest KJ",     // See "Per-show host override" below
         affiliation: "Some Karaoke Co",
@@ -463,7 +466,7 @@ GitHub Projects field IDs and option IDs for this project. Used by Claude when s
 | Milestone | Spec Sections | Description |
 |-----------|---------------|-------------|
 | Documentation Portal | — | Documentation site navigation and landing pages |
-| Exclusion Dates | — (future) | Venue closure/exclusion dates feature |
+| Exclusion Dates | 4, 11 | Venue closure/exclusion dates (`schedule[].exclusions`). Shipped: matching logic, Weekly + Map display. Pending: detail-view notice, full docs |
 | Form Parity | 15 | Submit form UX (intentionally a slim subset of editor; curator handles the rest) |
 | Weekly Calendar View | 2, 13 | Weekly schedule grid, day cards, schedule matching |
 | Alphabetical View | 3 | A-Z venue listing |
@@ -502,5 +505,5 @@ Current ADRs:
 
 ---
 
-*Last updated: February 2026*
+*Last updated: June 2026*
 *Maintained by: Project contributors and Claude Code sessions*

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A mobile-friendly web application for discovering karaoke venues in and around A
 - **Venue Details** — View addresses, schedules, host/KJ info, and social media links (mobile modal / desktop side pane)
 - **Venue Tags** — 19 color-coded badges showing venue characteristics (LGBTQ+, 21+, Dive Bar, Live Band, etc.)
 - **Special Events** — One-time karaoke events with specific dates, event names, and event page links
+- **Closure Dates** — Recurring shows can be marked closed on specific dates (holidays, private events), shown with a "Closed" indicator in the Calendar and on the Map
 - **Active Periods** — Define when a venue appears in the directory
 - **Quick Directions** — One-tap access to Google Maps navigation
 - **Dedicated Venue Filter** — Toggle to show only dedicated karaoke bars

--- a/css/components.css
+++ b/css/components.css
@@ -693,6 +693,48 @@
     font-size: var(--font-size-lg);
 }
 
+/* Exclusion (closure) notices — shared across the three detail surfaces
+   (modal, desktop pane, map expanded card). The "Closed today" banner mirrors
+   the weekly-view .venue-card__exclusion-banner; the upcoming-closures line
+   lists exclusion dates within the next 60 days. */
+.venue-modal__exclusion-banner,
+.detail-pane__exclusion-banner,
+.map-venue-card__exclusion-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    background: var(--color-warning);
+    color: var(--color-gray-900);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    border-radius: var(--border-radius-sm);
+}
+
+.venue-modal__exclusion-banner i,
+.detail-pane__exclusion-banner i,
+.map-venue-card__exclusion-banner i {
+    font-size: var(--font-size-xs);
+}
+
+.venue-modal__upcoming-closures,
+.detail-pane__upcoming-closures,
+.map-venue-card__upcoming-closures {
+    display: flex;
+    align-items: baseline;
+    gap: var(--spacing-xs);
+    margin: var(--spacing-sm) 0 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+}
+
+.venue-modal__upcoming-closures i,
+.detail-pane__upcoming-closures i,
+.map-venue-card__upcoming-closures i {
+    color: var(--color-warning);
+}
+
 /* Responsive modal */
 @media (max-width: 480px) {
     .venue-modal__content {

--- a/css/views.css
+++ b/css/views.css
@@ -618,6 +618,12 @@
     box-shadow: 0 3px 10px rgba(229, 57, 53, 0.4);
 }
 
+/* Excluded (closed today) marker - dimmed so it reads as inactive while
+   staying visible/clickable. Selection still overrides the color above. */
+.map-marker--excluded .map-marker__pin {
+    opacity: 0.45;
+}
+
 /* Map Cluster Icons - override MarkerCluster defaults with app theme */
 .map-cluster {
     border-radius: 50%;
@@ -877,6 +883,25 @@ body.view--map .app-layout__detail {
 .map-venue-card__header {
     padding-right: var(--spacing-xl);
     margin-bottom: var(--spacing-sm);
+}
+
+/* "Closed today" notice — venue has an excluded occurrence on the current date.
+   Mirrors the weekly-view .venue-card__exclusion-banner treatment. */
+.map-venue-card__exclusion-banner {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    background: var(--color-warning);
+    color: var(--color-gray-900);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    border-radius: var(--border-radius-sm);
+}
+
+.map-venue-card__exclusion-banner i {
+    font-size: var(--font-size-xs);
 }
 
 .map-venue-card__title {

--- a/css/views.css
+++ b/css/views.css
@@ -885,24 +885,8 @@ body.view--map .app-layout__detail {
     margin-bottom: var(--spacing-sm);
 }
 
-/* "Closed today" notice — venue has an excluded occurrence on the current date.
-   Mirrors the weekly-view .venue-card__exclusion-banner treatment. */
-.map-venue-card__exclusion-banner {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-    margin-bottom: var(--spacing-sm);
-    padding: var(--spacing-xs) var(--spacing-sm);
-    background: var(--color-warning);
-    color: var(--color-gray-900);
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-    border-radius: var(--border-radius-sm);
-}
-
-.map-venue-card__exclusion-banner i {
-    font-size: var(--font-size-xs);
-}
+/* Closure notices (.map-venue-card__exclusion-banner / __upcoming-closures) are
+   styled with the modal + pane variants in components.css. */
 
 .map-venue-card__title {
     font-size: var(--font-size-lg);

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -79,6 +79,7 @@ When expanded, shows:
 - One venue card per **matching schedule entry** (a venue with two events on the same date renders two cards, each showing its own event name, time, and host)
 - Footer with **unique venue count** (e.g., "14 venues" even if 15 cards rendered because one venue had two events)
 - **Venue card layout:** single column on mobile (≤768px); at 769px+ cards flow into a responsive grid (`repeat(auto-fill, minmax(320px, 1fr))` — 2 columns at ~1024px, up to 4 on large screens). Cards in the same grid row stretch to equal height. The same grid applies to letter cards in the Alphabetical view.
+- **Closures:** a card whose date is excluded (§11 Schedule Exclusions) keeps its place but is dimmed with a strikethrough name and a bright "Closed" banner (`.venue-card--excluded`), so the venue is still findable rather than silently dropped.
 
 ### Sorting
 
@@ -399,9 +400,10 @@ The modal opens only when ALL of these conditions are met:
 
 | Section | Content |
 |---------|---------|
+| Closure banner | "Closed Today: [reason]" warning banner at the top, shown only when the venue is excluded on the current date (§11 Schedule Exclusions) |
 | Header | Venue name, event name (if special event), tags |
 | Location | Full address, "View Map" button, "Directions" button, "Share" button |
-| Schedule | Schedule table (all entries) + active period notice if applicable |
+| Schedule | Schedule table (all entries) + active period notice + "Upcoming closures" list (exclusion dates within the next 60 days) if applicable |
 | Host | Host name, company, website, social links |
 | Social Media | Venue social links (if any) |
 | Contact | Phone number link (if venue has phone field) |
@@ -439,7 +441,7 @@ Visible when window width is **1400px or wider**. Hidden on smaller screens via 
 
 ### Content
 
-Same sections as the mobile modal (Location, Schedule, Host, Social Media, Contact).
+Same sections as the mobile modal (closure banner, Location, Schedule, Host, Social Media, Contact) — both are built by the shared `renderVenueDetailSections()`, so the "Closed Today" banner and "Upcoming closures" list (§7, §11) appear identically here.
 
 ### Empty State
 
@@ -577,6 +579,7 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
       startTime         string        24-hour format "HH:MM"
       endTime           string|null   24-hour format "HH:MM" or null (open-ended)
       eventUrl          string        OPTIONAL  Link to event page
+      exclusions        array         OPTIONAL  Dates this show is skipped (see "Schedule Exclusions")
 
     One-time entry:
       frequency         string        "once"
@@ -607,6 +610,24 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
   phone                 string        OPTIONAL  Venue phone number (displayed in detail views)
 }
 ```
+
+### Schedule Exclusions
+
+A recurring schedule entry may carry an `exclusions` array listing dates on which that show does **not** happen (holiday closures, private events, one-off cancellations). Each item is either a shorthand date string or an object with an optional reason:
+
+```
+exclusions: [
+  "2026-12-25",                              // shorthand — no reason
+  { date: "2026-12-26", reason: "Repairs" }  // object form with a reason
+]
+```
+
+- An exclusion **suppresses** the recurring occurrence on that date, but the schedule still "matches" the date — so the venue renders with a **closure indicator** rather than disappearing (users hunting for it still find it in place).
+- Helpers in `js/utils/date.js`: `getScheduleExclusion(entry, date)` (per-entry), `getVenueExclusionForDate(venue, date)` (venue-level — is it closed on a given date?), and `getUpcomingExclusions(venue, days)` (future closures within a window, today excluded).
+- **Display by surface:**
+  - **Weekly calendar** (§2) — dimmed card with a "Closed" banner on the excluded date
+  - **Map** (§4) — dimmed marker; "Closed Today: [reason]" banner in the floating card
+  - **Detail modal / desktop pane / map expanded card** (§7, §8) — "Closed Today: [reason]" banner plus an "Upcoming closures" list (next 60 days, e.g. "Jun 20 (Holiday), Jun 27")
 
 ### Venue Count
 
@@ -1206,6 +1227,7 @@ Each public page includes a `<link rel="canonical">` tag pointing to its canonic
 | 2026-02 | 1.0.20 | #32: Replaced "+N more" with smart "Also [days]" / "Everyday" schedule indicator on compact venue cards. Added `buildAlsoText()` and `abbreviateDay()` helpers in `render.js`. Updated Section 6. | Claude Code |
 | 2026-02 | 1.0.21 | Shareable venue links: URL hash syncs with venue selection (`#venue={id}`), share button on all detail surfaces (modal, pane, map card) with Web Share API / clipboard fallback. Added `shareVenue()` to `url.js`. Updated Sections 4, 7, 21. | Claude Code |
 | 2026-02 | 1.0.22 | SEO quick wins: Added meta descriptions, Open Graph tags, Twitter Card tags, and canonical URLs to all 5 public pages. Created `robots.txt` and `sitemap.xml`. Added `noindex` to `editor.html`. New Section 22. Renumbered Sections 22–23 → 23–24. | Claude Code |
+| 2026-06 | 1.0.23 | Exclusion Dates feature (#3–#8): recurring shows can be marked closed on specific dates via `schedule[].exclusions` (`"YYYY-MM-DD"` shorthand or `{date, reason}`). Weekly cards dim with a "Closed" banner; Map dims the marker and shows a "Closed Today" card banner; detail modal/pane/map-expanded show a "Closed Today" banner plus an "Upcoming closures" list (next 60 days). Added `getVenueExclusionForDate()` and `getUpcomingExclusions()` to `date.js`. New §11 "Schedule Exclusions"; updated §2, §4, §7, §8. | Claude Code |
 
 ---
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -246,6 +246,15 @@ A card that appears over the map when a marker is selected. Has two states:
 - Clicking the map background (not a marker or card) dismisses the card
 - **Sizing:** full-width bottom sheet on mobile; on desktop (≥1024px) a fixed 350px-wide card anchored right (explicit width so it doesn't shrink to its content). The floating "Hide Dedicated" map control and the analytics consent-banner buttons are ≥44px tall (touch targets).
 
+### Exclusion Dates on the Map
+
+When a venue has a recurring show that is **excluded on the current date** (a holiday/private-event closure — see the `exclusions` field, [Section 11](#11-venue-data-model)):
+
+- Its **marker is dimmed** (`.map-marker--excluded`, reduced opacity) but stays visible and clickable. The dimming persists through select/deselect (selection still recolors it).
+- Its **floating card shows a "Closed Today: [reason]" banner** (warning-colored), mirroring the Weekly view's closure banner. The reason is shown when present.
+
+The map isn't date-scoped, so "today" (`new Date()`) is the reference date. `MapView.getTodaysExclusion(venue)` walks the schedule and returns the first entry that matches today *and* carries an exclusion for it (via `scheduleMatchesDate` + `getScheduleExclusion`).
+
 ### Floating Controls
 
 | Control | Position | Contents |

--- a/js/utils/date.js
+++ b/js/utils/date.js
@@ -190,6 +190,56 @@ export function getScheduleExclusion(schedule, date) {
 }
 
 /**
+ * Whether a venue is closed on a given date — a recurring show that matches the
+ * date but is suppressed by an exclusion. Walks every schedule entry; returns
+ * the first matching exclusion, or null.
+ * @param {Object} venue - Venue object (needs .schedule)
+ * @param {Date} date - Date to check
+ * @returns {{date: string, reason: string|null}|null}
+ */
+export function getVenueExclusionForDate(venue, date) {
+    for (const entry of venue?.schedule || []) {
+        if (scheduleMatchesDate(entry, date)) {
+            const exclusion = getScheduleExclusion(entry, date);
+            if (exclusion) return exclusion;
+        }
+    }
+    return null;
+}
+
+/**
+ * Collect a venue's exclusion dates strictly after today, within `days` from
+ * today, de-duplicated across schedule entries and sorted chronologically.
+ * Today is excluded — a closure today is surfaced separately as a "Closed today"
+ * notice (see getVenueExclusionForDate), so it shouldn't repeat in this list.
+ * @param {Object} venue - Venue object (needs .schedule)
+ * @param {number} [days=60] - Look-ahead window in days
+ * @returns {Array<{date: string, reason: string|null}>}
+ */
+export function getUpcomingExclusions(venue, days = 60) {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    const horizon = new Date(today);
+    horizon.setDate(horizon.getDate() + days);
+
+    const seen = new Set();
+    const upcoming = [];
+    for (const entry of venue?.schedule || []) {
+        for (const ex of entry.exclusions || []) {
+            const dateStr = typeof ex === 'string' ? ex : ex?.date;
+            if (!dateStr || seen.has(dateStr)) continue;
+            const d = parseLocalDate(dateStr);
+            if (d > today && d <= horizon) {
+                seen.add(dateStr);
+                upcoming.push({ date: dateStr, reason: typeof ex === 'string' ? null : (ex.reason || null) });
+            }
+        }
+    }
+    upcoming.sort((a, b) => a.date.localeCompare(b.date));
+    return upcoming;
+}
+
+/**
  * Convert 24-hour time to 12-hour format
  * @param {string} time24 - Time in 24-hour format (e.g., "21:00")
  * @returns {string} Time in 12-hour format (e.g., "9:00 PM")

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -4,7 +4,7 @@
  */
 
 import { escapeHtml } from './string.js';
-import { formatScheduleEntry, formatActivePeriodText, scheduleMatchesDate, WEEKDAYS } from './date.js';
+import { formatScheduleEntry, formatActivePeriodText, scheduleMatchesDate, WEEKDAYS, getVenueExclusionForDate, getUpcomingExclusions, parseLocalDate } from './date.js';
 import { buildMapUrl, buildDirectionsUrl, createSocialLinks, formatAddress, sanitizeUrl } from './url.js';
 
 /**
@@ -116,6 +116,26 @@ export function renderActivePeriod(activePeriod, classPrefix) {
     if (!text) return '';
 
     return `<p class="${classPrefix}__active-period"><i class="fa-solid fa-calendar-check"></i> ${text}</p>`;
+}
+
+/**
+ * Render an "Upcoming closures" line listing a venue's exclusion dates within
+ * the next 60 days (e.g. "Dec 25 (Christmas), Dec 26 (Repairs)"). Returns an
+ * empty string when there are none.
+ * @param {Object} venue - Venue object (needs .schedule)
+ * @param {string} classPrefix - CSS class prefix
+ * @returns {string} HTML string or empty
+ */
+export function renderUpcomingClosures(venue, classPrefix) {
+    const upcoming = getUpcomingExclusions(venue, 60);
+    if (!upcoming.length) return '';
+
+    const list = upcoming.map(ex => {
+        const label = parseLocalDate(ex.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+        return ex.reason ? `${escapeHtml(label)} (${escapeHtml(ex.reason)})` : escapeHtml(label);
+    }).join(', ');
+
+    return `<p class="${classPrefix}__upcoming-closures"><i class="fa-solid fa-ban"></i> Upcoming closures: ${list}</p>`;
 }
 
 /**
@@ -282,7 +302,14 @@ export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize =
     const directionsUrl = buildDirectionsUrl(venue.address, venue.name);
     const socialLinksHtml = createSocialLinks(venue.socials, { size: 'fa-lg' });
 
+    // "Closed today" banner when a recurring show is excluded on the current date
+    const todayExclusion = getVenueExclusionForDate(venue, new Date());
+    const exclusionBanner = todayExclusion
+        ? `<div class="${classPrefix}__exclusion-banner"><i class="fa-solid fa-ban"></i> Closed Today${todayExclusion.reason ? `: ${escapeHtml(todayExclusion.reason)}` : ''}</div>`
+        : '';
+
     return `
+        ${exclusionBanner}
         <section class="${classPrefix}__section">
             <h3><i class="fa-solid fa-location-dot"></i> Location</h3>
             <address class="${classPrefix}__address">${addressHtml}</address>
@@ -303,6 +330,7 @@ export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize =
             <h3><i class="fa-regular fa-calendar"></i> Schedule</h3>
             ${renderScheduleTable(venue, classPrefix)}
             ${renderActivePeriod(venue.activePeriod, classPrefix)}
+            ${renderUpcomingClosures(venue, classPrefix)}
         </section>
 
         ${renderHostSection(venue.host, classPrefix, { socialSize: hostSocialSize })}

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -13,6 +13,7 @@ import { escapeHtml } from '../utils/string.js';
 import { buildDirectionsUrl, shareVenue } from '../utils/url.js';
 import { renderTags } from '../utils/tags.js';
 import { renderScheduleCompact, renderVenueDetailSections } from '../utils/render.js';
+import { scheduleMatchesDate, getScheduleExclusion } from '../utils/date.js';
 
 export class MapView extends Component {
     init() {
@@ -32,14 +33,32 @@ export class MapView extends Component {
      * Create a custom marker icon
      * @param {boolean} isSelected - Whether the marker is selected
      */
-    createMarkerIcon(isSelected = false) {
+    createMarkerIcon(isSelected = false, isExcluded = false) {
         return L.divIcon({
-            className: `map-marker ${isSelected ? 'map-marker--selected' : ''}`,
+            className: `map-marker ${isSelected ? 'map-marker--selected' : ''}${isExcluded ? ' map-marker--excluded' : ''}`,
             html: `<div class="map-marker__pin"></div>`,
             iconSize: [30, 40],
             iconAnchor: [15, 40],
             popupAnchor: [0, -40]
         });
+    }
+
+    /**
+     * Return today's exclusion for a venue, if any — a recurring show that would
+     * normally run today but is suppressed (holiday, private event, cancellation).
+     * The map isn't date-scoped, so "today" is the relevant date for a closure cue.
+     * @param {Object} venue
+     * @returns {{date: string, reason: string|null}|null}
+     */
+    getTodaysExclusion(venue) {
+        const today = new Date();
+        for (const entry of venue.schedule || []) {
+            if (scheduleMatchesDate(entry, today)) {
+                const exclusion = getScheduleExclusion(entry, today);
+                if (exclusion) return exclusion;
+            }
+        }
+        return null;
     }
 
     template() {
@@ -300,13 +319,17 @@ export class MapView extends Component {
 
         // Add markers to cluster group
         venues.forEach(venue => {
+            // Dim the marker if the venue is closed today (excluded occurrence)
+            const isExcludedToday = !!this.getTodaysExclusion(venue);
             const marker = L.marker(
                 [venue.coordinates.lat, venue.coordinates.lng],
-                { icon: this.createMarkerIcon(false) }
+                { icon: this.createMarkerIcon(false, isExcludedToday) }
             );
 
             // Store venue data on marker for cluster tooltip access
             marker.venueData = venue;
+            // Remember exclusion state so it survives select/deselect re-icons
+            marker.isExcluded = isExcludedToday;
 
             // Hover tooltip showing venue name
             marker.bindTooltip(escapeHtml(venue.name), {
@@ -345,18 +368,18 @@ export class MapView extends Component {
     }
 
     showVenueCard(venue, marker) {
-        // Reset previously selected marker
+        // Reset previously selected marker (keeping its excluded dimming)
         if (this.selectedMarker) {
-            this.selectedMarker.setIcon(this.createMarkerIcon(false));
+            this.selectedMarker.setIcon(this.createMarkerIcon(false, this.selectedMarker.isExcluded));
         }
 
         // Set new selected marker
         this.selectedVenue = venue;
         this.selectedMarker = marker;
 
-        // Highlight the selected marker
+        // Highlight the selected marker (preserving excluded state)
         if (marker) {
-            marker.setIcon(this.createMarkerIcon(true));
+            marker.setIcon(this.createMarkerIcon(true, marker.isExcluded));
         }
 
         const cardEl = this.$('#map-venue-card');
@@ -370,6 +393,12 @@ export class MapView extends Component {
         // Build tags HTML (includes dedicated tag if applicable)
         const tagsHtml = renderTags(venue.tags, { dedicated: venue.dedicated });
 
+        // "Closed today" notice when a recurring show is excluded on the current date
+        const exclusion = this.getTodaysExclusion(venue);
+        const exclusionBanner = exclusion
+            ? `<div class="map-venue-card__exclusion-banner"><i class="fa-solid fa-ban"></i> Closed Today${exclusion.reason ? `: ${escapeHtml(exclusion.reason)}` : ''}</div>`
+            : '';
+
         cardEl.innerHTML = `
             <button class="map-venue-card__close" data-action="close-card" type="button" aria-label="Close">
                 <i class="fa-solid fa-xmark"></i>
@@ -378,6 +407,7 @@ export class MapView extends Component {
                 <h3 class="map-venue-card__title">${escapeHtml(venue.name)}</h3>
                 ${tagsHtml}
             </div>
+            ${exclusionBanner}
             <div class="map-venue-card__schedule">${scheduleHtml}</div>
             <div class="map-venue-card__actions">
                 <a href="${directionsUrl}" target="_blank" rel="noopener noreferrer" class="btn btn--secondary btn--small">
@@ -425,9 +455,9 @@ export class MapView extends Component {
     }
 
     hideVenueCard() {
-        // Reset the selected marker's icon
+        // Reset the selected marker's icon (keeping its excluded dimming)
         if (this.selectedMarker) {
-            this.selectedMarker.setIcon(this.createMarkerIcon(false));
+            this.selectedMarker.setIcon(this.createMarkerIcon(false, this.selectedMarker.isExcluded));
             this.selectedMarker = null;
         }
 

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -13,7 +13,7 @@ import { escapeHtml } from '../utils/string.js';
 import { buildDirectionsUrl, shareVenue } from '../utils/url.js';
 import { renderTags } from '../utils/tags.js';
 import { renderScheduleCompact, renderVenueDetailSections } from '../utils/render.js';
-import { scheduleMatchesDate, getScheduleExclusion } from '../utils/date.js';
+import { getVenueExclusionForDate } from '../utils/date.js';
 
 export class MapView extends Component {
     init() {
@@ -51,14 +51,7 @@ export class MapView extends Component {
      * @returns {{date: string, reason: string|null}|null}
      */
     getTodaysExclusion(venue) {
-        const today = new Date();
-        for (const entry of venue.schedule || []) {
-            if (scheduleMatchesDate(entry, today)) {
-                const exclusion = getScheduleExclusion(entry, today);
-                if (exclusion) return exclusion;
-            }
-        }
-        return null;
+        return getVenueExclusionForDate(venue, new Date());
     }
 
     template() {


### PR DESCRIPTION
## Summary

Completes the **Exclusion Dates** milestone — recurring shows can be marked closed on specific dates (`schedule[].exclusions`), and every surface now reflects it. The matching logic (#3) and Weekly display (#4) already shipped; this PR adds the **Map** (#6) and **detail-view** (#5) display plus the **docs** (#8).

## Related Issues

Closes #5, #6, #8

## Changes

### #6 — Map view
- Excluded-today venues get a **dimmed marker** (`.map-marker--excluded`), still visible/clickable; dimming survives select/deselect.
- Floating summary card shows a **"Closed Today: [reason]"** banner.

### #5 — Detail views (modal, desktop pane, map expanded card)
- Shared `renderVenueDetailSections()` now renders a **"Closed Today: [reason]"** banner when the venue is excluded today, plus an **"Upcoming closures"** list (exclusion dates in the next 60 days, e.g. "Jun 20 (Holiday), Jun 27").
- New shared helpers in `date.js`: `getVenueExclusionForDate()` and `getUpcomingExclusions()`. `MapView.getTodaysExclusion()` now delegates to the former (de-dups #6's logic). Banner/upcoming CSS consolidated across all three detail surfaces.

### #8 — Documentation
- New functional-spec §11 "Schedule Exclusions" (schema + helpers + per-surface behavior); references added to §2, §4, §7, §8; change-log 1.0.23.
- CLAUDE.md venue format + milestone, and README feature list, updated (earlier commit).

## Documentation Checklist
- [x] Project spec updated (§2, §4, §7, §8, §11, change log)
- [x] CLAUDE.md updated (venue format, milestone, breakpoints)
- [x] README updated (Closure Dates feature)

## Testing Checklist
- [x] **#6** verified: temporary today-exclusion on Cheerz → exactly 1 dimmed marker; card "Closed Today" banner; dimming preserved through select/deselect; normal venues unaffected.
- [x] **#5** verified: temporary today + upcoming exclusions on Cheerz → modal **and** desktop pane both show "Closed Today: …" banner + "Upcoming closures: Jun 20 (Holiday (TEST)), Jun 27" (today correctly excluded from the upcoming list); non-excluded venues show neither.
- [x] All test data reverted; syntax, data-sync, CSS-load-order gates pass locally; no console errors.
- [ ] **Human Verify** (owner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
