### PR TITLE
Unify how surfaces read the venue model (S1-S5)

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -411,36 +411,6 @@
     color: var(--color-primary-light);
 }
 
-.venue-card__schedule h4,
-.venue-card__host h4 {
-    font-size: var(--font-size-sm);
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    margin-bottom: var(--spacing-sm);
-}
-
-.venue-card__schedule-list {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-xs);
-}
-
-.venue-card__schedule-item {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm);
-    font-size: var(--font-size-sm);
-}
-
-.venue-card__schedule-day {
-    font-weight: 500;
-}
-
-.venue-card__schedule-time {
-    color: var(--text-secondary);
-}
-
 .venue-card__host {
     margin-top: var(--spacing-md);
 }
@@ -776,6 +746,130 @@
     }
 
     .venue-modal__schedule-table td:first-child::before {
+        content: none;
+    }
+}
+
+/* Alphabetical full card reuses the shared detail-section renderer
+   (renderVenueDetailSections, classPrefix 'venue-card', actions omitted).
+   These mirror the .venue-modal__/.detail-pane__ section styles for the classes
+   not already defined above (__address, __host, __host-name, __host-affiliation,
+   __socials, __exclusion-banner are shared with the compact/weekly card). */
+.venue-card__section {
+    margin-bottom: var(--spacing-lg);
+}
+
+.venue-card__section h3 {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    font-size: var(--font-size-base);
+    color: var(--text-muted);
+    margin-bottom: var(--spacing-sm);
+}
+
+.venue-card__section h3 i {
+    color: var(--color-primary-light);
+}
+
+.venue-card__schedule-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.venue-card__schedule-table th,
+.venue-card__schedule-table td {
+    text-align: left;
+    border-bottom: 1px solid var(--border-color);
+    padding: var(--spacing-sm);
+}
+
+.venue-card__schedule-table th {
+    color: var(--text-muted);
+    font-weight: 500;
+    font-size: var(--font-size-sm);
+}
+
+.venue-card__active-period {
+    color: var(--color-warning);
+    font-size: var(--font-size-sm);
+    margin-top: var(--spacing-sm);
+}
+
+.venue-card__host-website {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+}
+
+.venue-card__socials-label {
+    font-size: var(--font-size-sm);
+    color: var(--text-muted);
+    margin-top: var(--spacing-md);
+    margin-bottom: var(--spacing-xs);
+}
+
+.venue-card__host-socials {
+    display: flex;
+    gap: var(--spacing-sm);
+}
+
+.venue-card__upcoming-closures {
+    display: flex;
+    align-items: baseline;
+    gap: var(--spacing-xs);
+    margin: var(--spacing-sm) 0 0;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+}
+
+.venue-card__upcoming-closures i {
+    color: var(--color-warning);
+}
+
+/* Stack the inline schedule table into label/value rows on small phones,
+   mirroring the modal (data-label comes from renderScheduleTable). */
+@media (max-width: 480px) {
+    .venue-card__schedule-table,
+    .venue-card__schedule-table tbody {
+        display: block;
+    }
+
+    .venue-card__schedule-table thead {
+        display: none;
+    }
+
+    .venue-card__schedule-table tr {
+        display: block;
+        padding: var(--spacing-sm) 0;
+        border-bottom: 1px solid var(--border-color);
+    }
+
+    .venue-card__schedule-table td {
+        display: flex;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-2xs) 0;
+        border: none;
+    }
+
+    .venue-card__schedule-table td:empty {
+        display: none;
+    }
+
+    .venue-card__schedule-table td::before {
+        content: attr(data-label);
+        flex: 0 0 4.5em;
+        color: var(--text-muted);
+        font-size: var(--font-size-sm);
+        font-weight: 500;
+    }
+
+    .venue-card__schedule-table td:first-child {
+        font-weight: 600;
+        font-size: var(--font-size-base);
+    }
+
+    .venue-card__schedule-table td:first-child::before {
         content: none;
     }
 }

--- a/css/components.css
+++ b/css/components.css
@@ -334,12 +334,6 @@
     color: var(--text-secondary);
 }
 
-.venue-card__note {
-    font-style: italic;
-    opacity: 0.8;
-    margin-left: var(--spacing-sm);
-}
-
 .venue-card__more-nights {
     display: flex;
     align-items: center;
@@ -445,12 +439,6 @@
 
 .venue-card__schedule-time {
     color: var(--text-secondary);
-}
-
-.venue-card__schedule-note {
-    color: var(--text-muted);
-    font-style: italic;
-    width: 100%;
 }
 
 .venue-card__host {
@@ -634,13 +622,6 @@
     font-size: var(--font-size-sm);
 }
 
-.venue-modal__schedule-table .schedule-note,
-.detail-pane__schedule-table .schedule-note {
-    color: var(--text-muted);
-    font-style: italic;
-    font-size: var(--font-size-sm);
-}
-
 .venue-modal__active-period,
 .detail-pane__active-period {
     color: var(--color-warning);
@@ -750,7 +731,7 @@
     }
 
     /* Stack the schedule table into label/value cards on small phones — a
-       4-column table (Day/Time/Host/Note) is too cramped here. data-label
+       3-column table (Day/Time/Host) is too cramped here. data-label
        attributes come from renderScheduleTable() in js/utils/render.js. */
     .venue-modal__schedule-table,
     .venue-modal__schedule-table tbody {
@@ -774,7 +755,7 @@
         border: none;
     }
 
-    /* Empty cells (e.g. a show with no note) collapse instead of showing a bare label */
+    /* Empty cells (e.g. a show with no host) collapse instead of showing a bare label */
     .venue-modal__schedule-table td:empty {
         display: none;
     }

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -580,6 +580,7 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
       endTime           string|null   24-hour format "HH:MM" or null (open-ended)
       eventUrl          string        OPTIONAL  Link to event page
       exclusions        array         OPTIONAL  Dates this show is skipped (see "Schedule Exclusions")
+      socials           object|null   OPTIONAL  Event-level social links (same shape as venue `socials`)
 
     One-time entry:
       frequency         string        "once"
@@ -588,6 +589,7 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
       endTime           string|null   24-hour format "HH:MM" or null
       eventName         string        OPTIONAL  Display name for the event
       eventUrl          string        OPTIONAL  Link to event page
+      socials           object|null   OPTIONAL  Event-level social links (same shape as venue `socials`)
 
   activePeriod          object        OPTIONAL  Limits when venue appears
     activePeriod.start  string        "YYYY-MM-DD"
@@ -597,6 +599,7 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
     host.name           string        OPTIONAL  Individual KJ name
     host.affiliation    string        OPTIONAL  Parent company/org (e.g. "Starling Karaoke")
     host.website        string        OPTIONAL  Host/KJ personal website
+    host.socials        object|null   OPTIONAL  KJ/host social links (same shape as venue `socials`)
 
   socials               object|null   OPTIONAL
     socials.website     string        OPTIONAL
@@ -607,7 +610,7 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
     socials.youtube     string        OPTIONAL
     socials.bluesky     string        OPTIONAL
 
-  phone                 string        OPTIONAL  Venue phone number (displayed in detail views)
+  phone                 string        OPTIONAL  Venue's public phone — tel: link in detail views (venue line only, not KJ/host or curator-internal)
 }
 ```
 

--- a/docs/spikes/surface-data-unification.md
+++ b/docs/spikes/surface-data-unification.md
@@ -143,13 +143,13 @@ estimate to be replaced with "Actual" as each issue lands. S2 and S3 overlap on
 | Seam | Issue | Implementations today | Baseline dup LOC | Projected net LOC | Actual | Status |
 |---|---|---|---|---|---|---|
 | S1 host walk | #114 | 4 walks | ~100 | −40 … −60 | net **+10** (+40/−30); `getVenueHosts` ~24 LOC offsets per-consumer savings; **4 walks → 1** | ✅ `114-get-venue-hosts`, pending Verify |
-| S2 schedule render | #115 | 6 formatters | ~93 | −15 … −30 (converge) | — | Not started |
+| S2 schedule render | #115 | 6 formatters | ~93 | −15 … −30 (converge) | net **−1**; most skins already used `formatScheduleEntry` — converged the last holdout (`renderOneTime` via a `weekday` opt) + `getScheduleForDate`; **1 core, all skins** | ✅ `unify-surfaces`, pending Verify |
 | S3 alpha detail parity | #116 | 2 detail renderers | 72 (`fullTemplate` 46 + `renderScheduleList` 26) | −55 … −60 | JS net **−57**; CSS **+95** (venue-card section styles) → net **+43**; **facts parity achieved** | ✅ `116-alphabetical-detail-parity`, pending Verify |
-| S4 service predicate/sort | #117 | 6 copies | ~50 | −30 … −50 | — | Not started |
+| S4 service predicate/sort | #117 | 6 copies | ~50 | −30 … −50 | net **−7**; predicate **6→1** (`venuePasses`) + `byName`; `getVenuesForDate` derived from events; supersedes #72 | ✅ `unify-surfaces`, pending Verify |
 | S5 schema↔render | #118 | 3 phantom fields | ~18 | −18 (delete) / +schema (promote) | note −26 (render+CSS+debug); schema +18 (phone, host+event socials); **phantom 3→0** | ✅ Implemented on `118-schema-rendered-fields`, pending human Verify |
-| **Total** | (parent #113) | | **~330** | **−160 … −220** | | |
+| **Total** | (parent #113) | | **~330** | **−160 … −220** | **≈ +37 net** (JS/logic ≈ −61, CSS +80, schema +18) | 5/5 implemented |
 
-**Actuals to date (S5, S1, S3 implemented).** Raw LOC is running **net-positive (~+45)**, not the projected −160…−220 — the projections under-counted the cost of the new *shared* code (the `getVenueHosts` primitive in S1; the `venue-card__*` section CSS in S3, which partly mirrors the modal/pane values). The realized value is **structural dedup + cross-surface consistency** (Alphabetical now shows per-show hosts / closures / active period it previously omitted), not raw line deletion. The largest *raw* reductions remain in S2 (converge 6 schedule renderers) and S4 (collapse 6 service predicates).
+**Final actuals — all five implemented, integrated on `unify-surfaces`.** Per-seam net: S5 −8, S1 +10, S3 +43, S4 −7, S2 −1 = **≈ +37 LOC overall**, *not* the projected −160…−220. Split by layer: **JS/application logic ≈ −61** (the real dedup), **CSS +80** (S3's `venue-card` detail-section styling for A–Z parity), **schema +18** (S5 phone + multi-scope socials). The projections badly over-counted raw deletion — every seam added shared code (`getVenueHosts`, `venuePasses`/`byName`, the `weekday` option, the section CSS), and the codebase had *already* converged on `formatScheduleEntry`, so S2/S4 had little raw fat to cut. **The realized value is structural dedup + cross-surface consistency + correctness**, not line count (see below) — plus A–Z now shows per-show hosts / closures / active period it previously omitted, and the KJ surfaces now sort article-insensitively.
 
 Structural wins (independent of LOC):
 - host-walk implementations **4 → 1**

--- a/docs/spikes/surface-data-unification.md
+++ b/docs/spikes/surface-data-unification.md
@@ -142,12 +142,14 @@ estimate to be replaced with "Actual" as each issue lands. S2 and S3 overlap on
 
 | Seam | Issue | Implementations today | Baseline dup LOC | Projected net LOC | Actual | Status |
 |---|---|---|---|---|---|---|
-| S1 host walk | #114 | 4 walks | ~100 | −40 … −60 | — | Not started |
+| S1 host walk | #114 | 4 walks | ~100 | −40 … −60 | net **+10** (+40/−30); `getVenueHosts` ~24 LOC offsets per-consumer savings; **4 walks → 1** | ✅ `114-get-venue-hosts`, pending Verify |
 | S2 schedule render | #115 | 6 formatters | ~93 | −15 … −30 (converge) | — | Not started |
-| S3 alpha detail parity | #116 | 2 detail renderers | 72 (`fullTemplate` 46 + `renderScheduleList` 26) | −55 … −60 | — | Not started |
+| S3 alpha detail parity | #116 | 2 detail renderers | 72 (`fullTemplate` 46 + `renderScheduleList` 26) | −55 … −60 | JS net **−57**; CSS **+95** (venue-card section styles) → net **+43**; **facts parity achieved** | ✅ `116-alphabetical-detail-parity`, pending Verify |
 | S4 service predicate/sort | #117 | 6 copies | ~50 | −30 … −50 | — | Not started |
 | S5 schema↔render | #118 | 3 phantom fields | ~18 | −18 (delete) / +schema (promote) | note −26 (render+CSS+debug); schema +18 (phone, host+event socials); **phantom 3→0** | ✅ Implemented on `118-schema-rendered-fields`, pending human Verify |
 | **Total** | (parent #113) | | **~330** | **−160 … −220** | | |
+
+**Actuals to date (S5, S1, S3 implemented).** Raw LOC is running **net-positive (~+45)**, not the projected −160…−220 — the projections under-counted the cost of the new *shared* code (the `getVenueHosts` primitive in S1; the `venue-card__*` section CSS in S3, which partly mirrors the modal/pane values). The realized value is **structural dedup + cross-surface consistency** (Alphabetical now shows per-show hosts / closures / active period it previously omitted), not raw line deletion. The largest *raw* reductions remain in S2 (converge 6 schedule renderers) and S4 (collapse 6 service predicates).
 
 Structural wins (independent of LOC):
 - host-walk implementations **4 → 1**

--- a/docs/spikes/surface-data-unification.md
+++ b/docs/spikes/surface-data-unification.md
@@ -1,0 +1,169 @@
+# Spike: Unify how surfaces read the venue model
+
+> **Status:** Draft / analysis complete — follow-up issues filed (S1–S5)
+> **Date:** 2026-06-14
+> **Type:** Spike (research/investigation)
+> **Related milestone:** Technical Foundation
+
+## Why
+
+The directory has grown to **five public surfaces** plus a shared venue-detail view:
+
+| Surface | Entry point | View class |
+|---|---|---|
+| Weekly | `?view=weekly` (default) | `WeeklyView` |
+| Alphabetical | `?view=alphabetical` | `AlphabeticalView` |
+| Map | `?view=map` | `MapView` |
+| KJ Index | `?kj=all` | `KJIndexView` |
+| KJ Dossier | `?kj=<name>` / `?kj=none` | `KJDossierView` |
+| Venue detail | `VENUE_SELECTED` event | `VenueModal` (mobile) + `VenueDetailPane` (desktop) + Map floating card |
+
+Each surface independently re-derives the same three things from one small data model:
+**(a)** which schedule entry applies, **(b)** who hosts, and **(c)** which venues to show. Those
+derivations have drifted, producing duplicated code *and* surfaces that present different facts
+for the same venue. This spike maps the data shape, the per-surface data flow, and the seams
+where code and data should be united, with a measured duplication ledger to track payoff.
+
+## The data, as it actually exists (77 venues)
+
+Counts from `js/data.json`; shape from [`schema/venue.schema.json`](../../schema/venue.schema.json) (ADR-005).
+
+| Field | Present | Note |
+|---|---|---|
+| `coordinates` | 77 / 77 | every venue geocoded — Map's "has coords?" guard never excludes anyone |
+| `host` (venue and/or per-show) | ~all | `affiliation` on ~31 |
+| `socials` | 75 | venue-level |
+| `tags` | 68 | |
+| `address.neighborhood` | 26 | optional |
+| `activePeriod` | 3 | seasonal |
+| `frequency:"once"` | 6 | specials genuinely rare |
+| `exclusions` | 1 | closure dates |
+| **`phone`** | **0** | rendered in detail view but **not in schema** |
+| **`schedule.note`** | **0** | rendered in 3 places but **not in schema** |
+| **`host.socials`** | **0** | rendered in 2 places but **schema-forbidden** |
+
+The host model is the richest part of the shape: a host may live on the venue **or** on an
+individual schedule entry, and a per-show host is a **full-object override** (not a field merge).
+This is exactly the part the surfaces each re-walk.
+
+## How each surface consumes the model
+
+| Surface | Data source fn | active / activePeriod / dedicated / search | schedule → HTML | venue detail |
+|---|---|---|---|---|
+| Weekly | `getVenuesForDate` + `getVenueEventsForDate` | ✓ / ✓ / ✓ / ✓ | VenueCard compact + `getScheduleContext` | modal / pane (shared) |
+| Alphabetical | `getVenuesSorted` | ✓ / ✓ / ✓ / ✓ | `VenueCard.renderScheduleList` | modal / pane (shared) |
+| Map | `getVenuesWithCoordinates` | ✓ / ✓ / ✓ / ✓ | `renderScheduleCompact` + `renderScheduleTable` | `renderVenueDetailSections` (shared) |
+| KJ Index | `getAllVenues` | ✓ / **✗** / **✗** / — | — | — |
+| KJ Dossier | `getAllVenues` + `venueMatchesHost` | ✓ / **✗** / **✗** / — | `renderRecurring` / `renderOneTime` | inline (its own) |
+
+Two columns carry the duplication: **six distinct schedule→HTML functions**, and the **KJ surfaces
+bypassing the service layer** (so they silently ignore `activePeriod` and the dedicated toggle).
+
+## The seams
+
+### S1 — The host model has no primitive
+The rule *"a venue's hosts = `venue.host` plus every `schedule[].host` (full-object override)"* is
+independently re-encoded in **four/five** places:
+
+- `js/utils/render.js:17` `resolveHostFor`, `:25` `hasPerShowHosts`
+- `js/services/venues.js:100` `venueMatchesHost`
+- `js/views/KJIndexView.js:135` `processHost` (walk both → build index)
+- `js/views/KJDossierView.js:99` `hasAnyHost` + `:148` `getMatches` (walk both → filter)
+
+No `getVenueHosts(venue)` exists. **Fix:** one accessor returning the canonical host list
+(`{ host, scope: 'venue'|'show', scheduleEntry? }`); the others become thin consumers.
+Enabler for **#81** (kjDefinitions identity registry).
+
+### S2 — `schedule → HTML` happens six times
+1. `js/utils/render.js:38` `renderScheduleTable` — table w/ per-show **Host column**, event links, notes → modal/pane/map-detail
+2. `js/utils/render.js:97` `renderScheduleCompact` — `<div>` list → map popup
+3. `js/utils/render.js:259` `getScheduleContext` + `:193` `buildAlsoText` + `:367` `renderScheduleContext` — "Every Fri · Also Tue" summary → Weekly cards *(already owned by #30/#32)*
+4. `js/components/VenueCard.js:165` `renderScheduleList` — `<ul>` → Alphabetical full card
+5. `js/components/VenueCard.js:40` compact time row → Weekly day cards
+6. `js/views/KJDossierView.js:203` `renderRecurring` / `:216` `renderOneTime` → KJ dossier
+
+They disagree on host overrides, exclusions, notes, and event links. They won't all collapse to one
+(a marker popup ≠ an audit dossier), but the **entry-formatting core** should be a single function the
+skins call. The "Also/+N more" family (#3) is already tracked by **#30/#32** and is out of scope here.
+
+### S3 — Alphabetical shows *less truth* than every other surface (consistency bug)
+Alphabetical renders through `VenueCard.fullTemplate` (`js/components/VenueCard.js:118`) →
+`renderScheduleList`, while modal/pane/map go through `renderVenueDetailSections`
+(`js/utils/render.js:299`). So the A–Z surface **silently omits**: per-show host overrides (no Host
+column), the "Closed today" banner, "Upcoming closures," and the active-period notice. The same venue
+presents different facts depending on where you click it. `fullTemplate` is a parallel
+re-implementation of the shared section helpers. **Decision (locked): Option A** — keep Alphabetical
+inline-expanded and reduce `fullTemplate` to a wrapper over the shared section helpers, adding a
+trimmed "list/inline" variant (e.g. `renderVenueDetailSections(venue, { actions: false })`) so the
+77-venue page stays light. No interaction change. See #116.
+
+### S4 — The service layer copy-pastes its filter predicate and comparators
+The predicate *active + activePeriod + dedicated + search* is duplicated across **six** functions:
+`getVenuesForDate` (`:166`), `getVenueEventsForDate` (`:206`), `getVenuesSorted` (`:247`),
+`getVenuesWithCoordinates` (`:432`), `searchVenues` (`:309`), `filterVenues` (`:339`) — all in
+`js/services/venues.js`. The alpha-sort comparator appears 5×; the "specials-first" comparator 2×.
+`getVenuesForDate` and `getVenueEventsForDate` are near-twins (unique-venue vs venue+event).
+**Fix:** one `venuePasses(venue, ctx)` predicate + exported `byName` / `specialsFirst` comparators;
+derive the unique list from the events list. Supersedes **#72** (which is now largely already fixed).
+
+### S5 — The render layer believes in a shape the schema forbids
+Three fields are rendered but are **schema-illegal** (`additionalProperties:false`) and absent from data:
+
+- `venue.phone` → Contact section `js/utils/render.js:345`. *(And `js/utils/validation.js:198` sanitizes a `phone` from the submit form — a field the schema drops and the renderer can never show: an end-to-end orphan.)*
+- `schedule.note` → `js/utils/render.js:69`, `js/components/VenueCard.js:98`, `:184`
+- `host.socials` → `js/utils/render.js:152`, `js/components/VenueCard.js:122`
+
+**Decision (locked), per field — see #118:**
+- `venue.phone`: **promote**, scoped as the **venue's** public phone (explicitly not KJ, not curator-internal).
+- socials: **promote multi-scope** — one shared `socials` shape attachable to **venue** (exists), **event** (`scheduleEntry.socials`, new), and **host** (`host.socials`, new). Event-level *render* is a fast-follow; the shape lands now.
+- `schedule.note`: **delete**.
+
+### Minor seams (fold into the above)
+- KJ surfaces sort by **raw name**, not `getSortableName` — `KJIndexView.js:158`, `KJDossierView.js:130` — so "The Highball" sorts under **T** there but under **H** everywhere else. (Fix in S1/S4.)
+- `VenueCard.getScheduleForDate` (`js/components/VenueCard.js:192`) re-implements day matching with `toLocaleDateString` instead of `scheduleMatchesDate`/`getDayName`. (Fix in S2.)
+
+## Target architecture
+
+A thin **derived-accessor layer** every surface reads through, so the model has one interpreter:
+
+- `getVenueHosts(venue)` → canonical host list (S1)
+- a single schedule-entry formatter the 3 skins call (S2; `formatScheduleEntry` already exists as the seed)
+- `renderVenueDetailSections` as the **only** full-detail renderer (S3)
+- `venuePasses(venue, ctx)` + exported comparators, with KJ views routed through the service (S4)
+- schema and renderer agreeing on the field set (S5)
+
+Net **less** code, and the surface-consistency gaps close as a side effect.
+
+## Duplication ledger (tracker)
+
+Baseline LOC measured from the function line-ranges cited above (current `main`). "Projected net" is an
+estimate to be replaced with "Actual" as each issue lands. S2 and S3 overlap on
+`VenueCard.renderScheduleList` (26 LOC) — it is attributed to **S3** (deleted there) to avoid double-counting.
+
+| Seam | Issue | Implementations today | Baseline dup LOC | Projected net LOC | Actual | Status |
+|---|---|---|---|---|---|---|
+| S1 host walk | #114 | 4 walks | ~100 | −40 … −60 | — | Not started |
+| S2 schedule render | #115 | 6 formatters | ~93 | −15 … −30 (converge) | — | Not started |
+| S3 alpha detail parity | #116 | 2 detail renderers | 72 (`fullTemplate` 46 + `renderScheduleList` 26) | −55 … −60 | — | Not started |
+| S4 service predicate/sort | #117 | 6 copies | ~50 | −30 … −50 | — | Not started |
+| S5 schema↔render | #118 | 3 phantom fields | ~18 | −18 (delete) / +schema (promote) | note −26 (render+CSS+debug); schema +18 (phone, host+event socials); **phantom 3→0** | ✅ Implemented on `118-schema-rendered-fields`, pending human Verify |
+| **Total** | (parent #113) | | **~330** | **−160 … −220** | | |
+
+Structural wins (independent of LOC):
+- host-walk implementations **4 → 1**
+- schedule formatters **6 → 1 core + 3 skins**
+- full-detail renderers **2 → 1**
+- service filter predicate **6 → 1**
+- phantom rendered fields **3 → 0** (or promoted to schema)
+
+## Decisions (resolved 2026-06-14)
+1. **S5 fields** — ✅ `venue.phone` **promote** (venue's public phone only); **socials** **promote multi-scope** (venue / event / host, one shared shape; event render is a fast-follow); `schedule.note` **delete**. See #118.
+2. **S3 approach** — ✅ **Option A**: keep Alphabetical inline-expanded, reduce `fullTemplate` to a wrapper over the shared helpers with a trimmed "list/inline" (no-actions) variant. See #116.
+3. **Sequencing** — S1 and S3 give the most user-visible payoff; S4 is the lowest-risk internal win. Suggested order: **S5 → S1 → S3 → S2 → S4**.
+
+## Related existing issues
+- **#72** searchVenues duplication / activePeriod — subset of S4; verify & close as superseded.
+- **#30 / #32** Unify frequency label + "Also/+N more" renderer — the one schedule formatter S2 leaves alone.
+- **#81** Normalize KJ identity via kjDefinitions — S1's `getVenueHosts` is its enabler.
+- **#78 / #88** Map multi-show rendering — consumers of the S2 schedule core.
+- **#36** Type-safety strategy (JSDoc vs TS) — the new primitives are the place to start typing.

--- a/js/components/VenueCard.js
+++ b/js/components/VenueCard.js
@@ -5,12 +5,12 @@
 
 import { Component } from './Component.js';
 import { escapeHtml } from '../utils/string.js';
-import { formatTimeRange, formatScheduleEntry, scheduleMatchesDate, getScheduleExclusion } from '../utils/date.js';
-import { buildMapUrl, createSocialLinks, formatAddress, sanitizeUrl } from '../utils/url.js';
+import { formatTimeRange, scheduleMatchesDate, getScheduleExclusion } from '../utils/date.js';
+import { buildMapUrl, formatAddress, sanitizeUrl } from '../utils/url.js';
 import { emit, Events } from '../core/events.js';
 import { isDebugMode, getDebugHtml } from '../utils/debug.js';
 import { renderTags } from '../utils/tags.js';
-import { formatHostDisplay, renderScheduleContext } from '../utils/render.js';
+import { formatHostDisplay, renderScheduleContext, renderVenueDetailSections } from '../utils/render.js';
 
 export class VenueCard extends Component {
     /**
@@ -115,11 +115,12 @@ export class VenueCard extends Component {
     }
 
     fullTemplate(venue) {
-        const addressHtml = formatAddress(venue.address);
-        const mapUrl = buildMapUrl(venue.address, venue.name);
-        const socialLinksHtml = createSocialLinks(venue.socials);
-        const hostSocialsHtml = venue.host?.socials ? createSocialLinks(venue.host.socials) : '';
-
+        // Inline-expanded card for the Alphabetical view. Delegates to the same
+        // shared section renderer the modal/pane/map detail use, so the A–Z card
+        // shows the same facts (per-show hosts, exclusions, upcoming closures,
+        // active period). `actions: false` drops the View Map / Directions / Share
+        // button row to keep the long A–Z list light — full actions live in the
+        // detail pane/modal opened on click.
         return `
             <div class="venue-card venue-card--full" data-venue-id="${escapeHtml(venue.id)}">
                 <div class="venue-card__header">
@@ -128,63 +129,11 @@ export class VenueCard extends Component {
                             ${escapeHtml(venue.name)}
                         </button>
                     </h3>
+                    ${renderTags(venue.tags, { dedicated: venue.dedicated })}
                 </div>
-
-                <div class="venue-card__address">
-                    <a href="${mapUrl}" target="_blank" rel="noopener noreferrer" class="venue-card__map-link">
-                        <i class="fa-solid fa-location-dot"></i>
-                        ${addressHtml}
-                    </a>
-                </div>
-
-                <div class="venue-card__schedule">
-                    <h4>Schedule</h4>
-                    ${this.renderScheduleList(venue.schedule)}
-                </div>
-
-                ${venue.host ? `
-                    <div class="venue-card__host">
-                        <h4>Host</h4>
-                        ${venue.host.name ? `<div class="venue-card__host-name">${escapeHtml(venue.host.name)}</div>` : ''}
-                        ${venue.host.affiliation ? `<div class="venue-card__host-affiliation">${escapeHtml(venue.host.affiliation)}</div>` : ''}
-                        ${hostSocialsHtml ? `<div class="venue-card__host-socials">${hostSocialsHtml}</div>` : ''}
-                    </div>
-                ` : ''}
-
-                ${socialLinksHtml ? `
-                    <div class="venue-card__socials">
-                        ${socialLinksHtml}
-                    </div>
-                ` : ''}
-                ${renderTags(venue.tags, { dedicated: venue.dedicated })}
+                ${renderVenueDetailSections(venue, { classPrefix: 'venue-card', actions: false })}
             </div>
         `;
-    }
-
-    renderScheduleList(schedule) {
-        if (!schedule || schedule.length === 0) {
-            return '<p class="venue-card__no-schedule">No schedule available</p>';
-        }
-
-        const items = schedule.map(entry => {
-            const formatted = formatScheduleEntry(entry, { showEvery: false });
-
-            // For one-time events, show the frequencyPrefix (event name) and day (date)
-            const dayLabel = entry.frequency === 'once'
-                ? `${formatted.frequencyPrefix} — ${formatted.day}`
-                : `${formatted.frequencyPrefix}${formatted.day}`;
-
-            const eventLink = entry.eventUrl ? `<a href="${escapeHtml(sanitizeUrl(entry.eventUrl) || '')}" target="_blank" rel="noopener noreferrer" class="venue-card__event-link" title="Event page"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>` : '';
-
-            return `
-                <li class="venue-card__schedule-item">
-                    <span class="venue-card__schedule-day">${dayLabel}${eventLink}</span>
-                    <span class="venue-card__schedule-time">${formatted.time}</span>
-                </li>
-            `;
-        }).join('');
-
-        return `<ul class="venue-card__schedule-list">${items}</ul>`;
     }
 
     getScheduleForDate(venue, date) {

--- a/js/components/VenueCard.js
+++ b/js/components/VenueCard.js
@@ -95,7 +95,6 @@ export class VenueCard extends Component {
                     <div class="venue-card__time">
                         <i class="fa-regular fa-clock"></i> ${frequencyHtml}${timeDisplay}
                         ${!eventName && schedule?.eventUrl ? `<a href="${escapeHtml(sanitizeUrl(schedule.eventUrl) || '')}" target="_blank" rel="noopener noreferrer" class="venue-card__event-link" title="Event page"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>` : ''}
-                        ${schedule?.note ? `<span class="venue-card__note">${escapeHtml(schedule.note)}</span>` : ''}
                     </div>
                 ` : ''}
                 ${showSchedule ? moreNightsHtml : ''}
@@ -181,7 +180,6 @@ export class VenueCard extends Component {
                 <li class="venue-card__schedule-item">
                     <span class="venue-card__schedule-day">${dayLabel}${eventLink}</span>
                     <span class="venue-card__schedule-time">${formatted.time}</span>
-                    ${entry.note ? `<span class="venue-card__schedule-note">${escapeHtml(entry.note)}</span>` : ''}
                 </li>
             `;
         }).join('');

--- a/js/components/VenueCard.js
+++ b/js/components/VenueCard.js
@@ -5,7 +5,7 @@
 
 import { Component } from './Component.js';
 import { escapeHtml } from '../utils/string.js';
-import { formatTimeRange, scheduleMatchesDate, getScheduleExclusion } from '../utils/date.js';
+import { formatTimeRange, scheduleMatchesDate, getScheduleExclusion, getDayName } from '../utils/date.js';
 import { buildMapUrl, formatAddress, sanitizeUrl } from '../utils/url.js';
 import { emit, Events } from '../core/events.js';
 import { isDebugMode, getDebugHtml } from '../utils/debug.js';
@@ -145,8 +145,8 @@ export class VenueCard extends Component {
         );
         if (onceEntry) return onceEntry;
 
-        // Fall back to recurring match
-        const dayName = date.toLocaleDateString('en-US', { weekday: 'long' }).toLowerCase();
+        // Fall back to the recurring entry for this weekday
+        const dayName = getDayName(date);
         return venue.schedule.find(s => s.day?.toLowerCase() === dayName) || venue.schedule[0];
     }
 

--- a/js/services/venues.js
+++ b/js/services/venues.js
@@ -52,6 +52,36 @@ function getActiveVenues() {
 }
 
 /**
+ * Shared filter predicate for the public venue lists: a venue "passes" when it
+ * isn't hidden by the dedicated toggle, matches the search query (if any), and
+ * is within its activePeriod on the relevant date. Callers start from
+ * getActiveVenues() (the `active` flag) and layer on their own date/coords
+ * checks. Single source of truth for the dedicated + search + activePeriod gate.
+ * @param {Object} venue - Venue object
+ * @param {Object} [ctx]
+ * @param {Date} [ctx.date] - Date for the activePeriod check (defaults to today)
+ * @param {boolean} [ctx.includeDedicated=true]
+ * @param {string} [ctx.searchQuery='']
+ * @returns {boolean}
+ */
+export function venuePasses(venue, { date = null, includeDedicated = true, searchQuery = '' } = {}) {
+    if (!includeDedicated && venue.dedicated) return false;
+    if (searchQuery && !venueMatchesSearch(venue, searchQuery)) return false;
+    if (!isVenueActiveOn(venue, date || new Date())) return false;
+    return true;
+}
+
+/**
+ * Alphabetical comparator on sortable venue name (leading articles ignored).
+ * @param {Object} a - Venue object
+ * @param {Object} b - Venue object
+ * @returns {number}
+ */
+export function byName(a, b) {
+    return getSortableName(a.name).toLowerCase().localeCompare(getSortableName(b.name).toLowerCase());
+}
+
+/**
  * Initialize venues from data
  * @param {Object} data - Karaoke data object
  */
@@ -157,25 +187,19 @@ export function venueMatchesSearch(venue, query) {
  * @returns {Object[]} Matching venues
  */
 export function getVenuesForDate(date, options = {}) {
-    const { includeDedicated = true, searchQuery = '' } = options;
-
-    return getActiveVenues().filter(venue => {
-        if (!includeDedicated && venue.dedicated) return false;
-        if (searchQuery && !venueMatchesSearch(venue, searchQuery)) return false;
-        if (!isVenueActiveOn(venue, date)) return false;
-        return venue.schedule.some(sched => scheduleMatchesDate(sched, date));
-    }).sort((a, b) => {
-        // Special events sort to top
-        const aSpecial = a.schedule?.some(s => s.frequency === 'once' && scheduleMatchesDate(s, date));
-        const bSpecial = b.schedule?.some(s => s.frequency === 'once' && scheduleMatchesDate(s, date));
-        if (aSpecial && !bSpecial) return -1;
-        if (!aSpecial && bSpecial) return 1;
-
-        // Then alphabetical
-        const nameA = getSortableName(a.name).toLowerCase();
-        const nameB = getSortableName(b.name).toLowerCase();
-        return nameA.localeCompare(nameB);
-    });
+    // Derive unique venues from the per-event list: getVenueEventsForDate already
+    // applies the shared filter and sorts specials-first then alphabetically, so
+    // taking each venue's first appearance preserves that order without
+    // duplicating the filter/sort logic here.
+    const seen = new Set();
+    const result = [];
+    for (const { venue } of getVenueEventsForDate(date, options)) {
+        if (!seen.has(venue.id)) {
+            seen.add(venue.id);
+            result.push(venue);
+        }
+    }
+    return result;
 }
 
 /**
@@ -201,9 +225,7 @@ export function getVenueEventsForDate(date, options = {}) {
 
     const events = [];
     for (const venue of getActiveVenues()) {
-        if (!includeDedicated && venue.dedicated) continue;
-        if (searchQuery && !venueMatchesSearch(venue, searchQuery)) continue;
-        if (!isVenueActiveOn(venue, date)) continue;
+        if (!venuePasses(venue, { date, includeDedicated, searchQuery })) continue;
 
         for (const schedule of venue.schedule) {
             if (scheduleMatchesDate(schedule, date)) {
@@ -213,19 +235,15 @@ export function getVenueEventsForDate(date, options = {}) {
     }
 
     return events.sort((a, b) => {
-        // Special events sort to top
+        // Special one-time events sort to the top
         const aSpecial = a.schedule.frequency === 'once';
         const bSpecial = b.schedule.frequency === 'once';
-        if (aSpecial && !bSpecial) return -1;
-        if (!aSpecial && bSpecial) return 1;
+        if (aSpecial !== bSpecial) return aSpecial ? -1 : 1;
 
-        // Then alphabetical by venue name
-        const nameA = getSortableName(a.venue.name).toLowerCase();
-        const nameB = getSortableName(b.venue.name).toLowerCase();
-        const nameCmp = nameA.localeCompare(nameB);
+        // Then alphabetical by venue name, ties broken by start time so multiple
+        // events at one venue read chronologically
+        const nameCmp = byName(a.venue, b.venue);
         if (nameCmp !== 0) return nameCmp;
-
-        // Ties broken by startTime so multiple events at one venue read chronologically
         return (a.schedule.startTime || '').localeCompare(b.schedule.startTime || '');
     });
 }
@@ -239,23 +257,9 @@ export function getVenueEventsForDate(date, options = {}) {
  */
 export function getVenuesSorted(options = {}) {
     const { includeDedicated = true, searchQuery = '' } = options;
-    const today = new Date();
-
-    let result = getActiveVenues().filter(v => isVenueActiveOn(v, today));
-
-    if (!includeDedicated) {
-        result = result.filter(v => !v.dedicated);
-    }
-
-    if (searchQuery) {
-        result = result.filter(v => venueMatchesSearch(v, searchQuery));
-    }
-
-    return [...result].sort((a, b) => {
-        const nameA = getSortableName(a.name).toLowerCase();
-        const nameB = getSortableName(b.name).toLowerCase();
-        return nameA.localeCompare(nameB);
-    });
+    return getActiveVenues()
+        .filter(v => venuePasses(v, { includeDedicated, searchQuery }))
+        .sort(byName);
 }
 
 /**
@@ -306,22 +310,16 @@ export function searchVenues(query, options = {}) {
 
     const q = query.toLowerCase().trim();
     const { includeDedicated = true } = options;
-    const today = new Date();
 
-    return getActiveVenues().filter(venue => {
-        if (!includeDedicated && venue.dedicated) return false;
-        if (!isVenueActiveOn(venue, today)) return false;
-        return venueMatchesSearch(venue, q);
-    }).sort((a, b) => {
-        // Prioritize name matches
-        const aNameMatch = containsIgnoreCase(a.name, q);
-        const bNameMatch = containsIgnoreCase(b.name, q);
-        if (aNameMatch && !bNameMatch) return -1;
-        if (!aNameMatch && bNameMatch) return 1;
-
-        // Then sort alphabetically
-        return getSortableName(a.name).localeCompare(getSortableName(b.name));
-    });
+    return getActiveVenues()
+        .filter(venue => venuePasses(venue, { includeDedicated, searchQuery: q }))
+        .sort((a, b) => {
+            // Prioritize name matches, then alphabetical
+            const aNameMatch = containsIgnoreCase(a.name, q);
+            const bNameMatch = containsIgnoreCase(b.name, q);
+            if (aNameMatch !== bNameMatch) return aNameMatch ? -1 : 1;
+            return byName(a, b);
+        });
 }
 
 /**
@@ -424,15 +422,10 @@ export function getNeighborhoods() {
  */
 export function getVenuesWithCoordinates(options = {}) {
     const { includeDedicated = true, searchQuery = '' } = options;
-    const today = new Date();
-
-    return getActiveVenues().filter(v => {
-        if (!v.coordinates?.lat || !v.coordinates?.lng) return false;
-        if (!includeDedicated && v.dedicated) return false;
-        if (!isVenueActiveOn(v, today)) return false;
-        if (searchQuery && !venueMatchesSearch(v, searchQuery)) return false;
-        return true;
-    });
+    return getActiveVenues().filter(v =>
+        v.coordinates?.lat && v.coordinates?.lng &&
+        venuePasses(v, { includeDedicated, searchQuery })
+    );
 }
 
 export { venues };

--- a/js/services/venues.js
+++ b/js/services/venues.js
@@ -17,6 +17,7 @@
 import { scheduleMatchesDate, isDateInRange } from '../utils/date.js';
 import { getSortableName, containsIgnoreCase } from '../utils/string.js';
 import { getTagConfig } from '../utils/tags.js';
+import { getVenueHosts } from '../utils/render.js';
 
 let venues = [];
 
@@ -101,17 +102,9 @@ export function venueMatchesHost(venue, query) {
     if (!query?.trim()) return true;
     const q = query.toLowerCase().trim();
 
-    if (containsIgnoreCase(venue.host?.name, q)) return true;
-    if (containsIgnoreCase(venue.host?.affiliation, q)) return true;
-
-    if (Array.isArray(venue.schedule)) {
-        for (const entry of venue.schedule) {
-            if (containsIgnoreCase(entry.host?.name, q)) return true;
-            if (containsIgnoreCase(entry.host?.affiliation, q)) return true;
-        }
-    }
-
-    return false;
+    return getVenueHosts(venue).some(({ host }) =>
+        containsIgnoreCase(host.name, q) || containsIgnoreCase(host.affiliation, q)
+    );
 }
 
 /**

--- a/js/utils/date.js
+++ b/js/utils/date.js
@@ -329,15 +329,19 @@ export function isDateInRange(date, startDate, endDate) {
  * @param {Object} entry - Schedule entry with day, frequency, startTime, endTime
  * @param {Object} options - Formatting options
  * @param {boolean} options.showEvery - Whether to show "Every" prefix (default: true)
+ * @param {boolean} [options.weekday] - Include the weekday in one-time date labels (default: false)
  * @returns {Object} Formatted schedule parts { day, frequencyPrefix, time, fullText }
  */
 export function formatScheduleEntry(entry, options = {}) {
-    const { showEvery = true } = options;
+    const { showEvery = true, weekday = false } = options;
 
     // One-time special event
     if (entry.frequency === 'once') {
-        const dateObj = new Date(entry.date + 'T12:00:00');
-        const dateStr = dateObj.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+        const dateObj = parseLocalDate(entry.date);
+        const dateStr = dateObj.toLocaleDateString('en-US', {
+            ...(weekday ? { weekday: 'short' } : {}),
+            month: 'short', day: 'numeric', year: 'numeric'
+        });
         const time = formatTimeRange(entry.startTime, entry.endTime);
         const label = entry.eventName ? `${entry.eventName} — ${dateStr}` : `Special Event — ${dateStr}`;
         return { day: dateStr, frequencyPrefix: entry.eventName || 'Special Event', time, fullText: `${label}: ${time}` };

--- a/js/utils/debug.js
+++ b/js/utils/debug.js
@@ -73,7 +73,6 @@ export function getVenueDebugInfo(venue, date) {
                     day: sched.date,
                     startTime: sched.startTime,
                     endTime: sched.endTime,
-                    note: sched.note,
                     eventName: sched.eventName
                 });
             }
@@ -89,8 +88,7 @@ export function getVenueDebugInfo(venue, date) {
                 frequency: sched.frequency,
                 day: sched.day,
                 startTime: sched.startTime,
-                endTime: sched.endTime,
-                note: sched.note
+                endTime: sched.endTime
             });
         }
     }

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -19,11 +19,33 @@ export function resolveHostFor(venue, scheduleEntry) {
 }
 
 /**
+ * Enumerate every host associated with a venue: the venue-level host (if any)
+ * plus each schedule entry that carries its own per-show host. Single source of
+ * truth for "who hosts here" — consumed by host search (venueMatchesHost), the
+ * KJ index, and the KJ dossier.
+ *
+ * Full-object override semantics mean a per-show host does not inherit the venue
+ * host; both still appear here because both are genuinely associated with the
+ * venue (the venue host covers the non-overridden shows).
+ *
+ * @param {Object} venue
+ * @returns {Array<{ host: Object, scope: 'venue'|'show', scheduleEntry: Object|null }>}
+ */
+export function getVenueHosts(venue) {
+    const hosts = [];
+    if (venue?.host) hosts.push({ host: venue.host, scope: 'venue', scheduleEntry: null });
+    for (const entry of venue?.schedule || []) {
+        if (entry.host) hosts.push({ host: entry.host, scope: 'show', scheduleEntry: entry });
+    }
+    return hosts;
+}
+
+/**
  * @param {Object} venue
  * @returns {boolean} True if any schedule entry carries its own host
  */
 function hasPerShowHosts(venue) {
-    return Array.isArray(venue?.schedule) && venue.schedule.some(e => e.host);
+    return getVenueHosts(venue).some(h => h.scope === 'show');
 }
 
 /**

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -66,7 +66,6 @@ export function renderScheduleTable(venue, classPrefix) {
                 <td data-label="Day">${dayLabel}${eventLink}</td>
                 <td data-label="Time">${formatted.time}</td>
                 ${hostCell}
-                ${entry.note ? `<td class="schedule-note" data-label="Note">${escapeHtml(entry.note)}</td>` : '<td data-label="Note"></td>'}
             </tr>
         `;
     }).join('');
@@ -78,7 +77,6 @@ export function renderScheduleTable(venue, classPrefix) {
                     <th>Day</th>
                     <th>Time</th>
                     ${showHostColumn ? '<th>Host</th>' : ''}
-                    <th>Note</th>
                 </tr>
             </thead>
             <tbody>

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -294,7 +294,7 @@ export function getScheduleContext(venue, schedule, currentDate = null) {
  * @param {string} [options.hostSocialSize='fa-lg'] - Font Awesome size class for host socials ('' for compact)
  * @returns {string} HTML string of <section> elements
  */
-export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize = 'fa-lg' }) {
+export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize = 'fa-lg', actions = true }) {
     const addressHtml = formatAddress(venue.address);
     const mapUrl = buildMapUrl(venue.address, venue.name);
     const directionsUrl = buildDirectionsUrl(venue.address, venue.name);
@@ -311,7 +311,7 @@ export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize =
         <section class="${classPrefix}__section">
             <h3><i class="fa-solid fa-location-dot"></i> Location</h3>
             <address class="${classPrefix}__address">${addressHtml}</address>
-            <div class="${classPrefix}__map-links">
+            ${actions ? `<div class="${classPrefix}__map-links">
                 <a href="${mapUrl}" target="_blank" rel="noopener noreferrer" class="btn btn--secondary">
                     <i class="fa-solid fa-map"></i> View Map
                 </a>
@@ -321,7 +321,7 @@ export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize =
                 <button class="btn btn--secondary ${classPrefix}__share" type="button">
                     <i class="fa-solid fa-share-from-square"></i> Share
                 </button>
-            </div>
+            </div>` : ''}
         </section>
 
         <section class="${classPrefix}__section">

--- a/js/views/KJDossierView.js
+++ b/js/views/KJDossierView.js
@@ -16,7 +16,6 @@ import { getAllVenues, venueMatchesHost } from '../services/venues.js';
 import { escapeHtml, containsIgnoreCase, getSortableName } from '../utils/string.js';
 import {
     formatScheduleEntry,
-    formatTimeRange,
     parseLocalDate,
     WEEKDAYS
 } from '../utils/date.js';
@@ -208,11 +207,7 @@ export class KJDossierView extends Component {
     }
 
     renderOneTime(entry) {
-        const dateObj = parseLocalDate(entry.date);
-        const dateStr = dateObj.toLocaleDateString('en-US', {
-            weekday: 'short', month: 'short', day: 'numeric', year: 'numeric'
-        });
-        const time = formatTimeRange(entry.startTime, entry.endTime);
+        const { day: dateStr, time } = formatScheduleEntry(entry, { weekday: true });
         return `
             <li class="kj-dossier__show kj-dossier__show--once">
                 <span class="kj-dossier__show-when">

--- a/js/views/KJDossierView.js
+++ b/js/views/KJDossierView.js
@@ -13,14 +13,14 @@ import { Component } from '../components/Component.js';
 import { getState } from '../core/state.js';
 import { on, Events } from '../core/events.js';
 import { getAllVenues, venueMatchesHost } from '../services/venues.js';
-import { escapeHtml, containsIgnoreCase } from '../utils/string.js';
+import { escapeHtml, containsIgnoreCase, getSortableName } from '../utils/string.js';
 import {
     formatScheduleEntry,
     formatTimeRange,
     parseLocalDate,
     WEEKDAYS
 } from '../utils/date.js';
-import { resolveHostFor } from '../utils/render.js';
+import { resolveHostFor, getVenueHosts } from '../utils/render.js';
 
 export class KJDossierView extends Component {
     init() {
@@ -96,18 +96,12 @@ export class KJDossierView extends Component {
         const today = new Date();
         today.setHours(0, 0, 0, 0);
 
-        const hasAnyHost = (host) => {
-            if (!host) return false;
-            const name = host.name?.trim();
-            const aff = host.affiliation?.trim();
-            return !!(name || aff);
-        };
+        const hasNamedHost = (v) => getVenueHosts(v).some(({ host }) =>
+            host.name?.trim() || host.affiliation?.trim()
+        );
 
         return getAllVenues()
-            .filter(v => {
-                if (hasAnyHost(v.host)) return false;
-                return !(v.schedule || []).some(e => hasAnyHost(e.host));
-            })
+            .filter(v => !hasNamedHost(v))
             .map(v => {
                 const recurring = (v.schedule || [])
                     .filter(e => e.frequency !== 'once')
@@ -127,7 +121,7 @@ export class KJDossierView extends Component {
             // Show every hostless venue — including ones with no upcoming events.
             // These are exactly the records a curator wants to audit, so don't hide
             // stale ones (unlike the KJ-dossier path, which filters out stale-only).
-            .sort((a, b) => a.venue.name.localeCompare(b.venue.name));
+            .sort((a, b) => getSortableName(a.venue.name).localeCompare(getSortableName(b.venue.name)));
     }
 
     /**
@@ -173,7 +167,7 @@ export class KJDossierView extends Component {
                 return { venue: v, recurring, oneTimes };
             })
             .filter(m => m.recurring.length > 0 || m.oneTimes.length > 0)
-            .sort((a, b) => a.venue.name.localeCompare(b.venue.name));
+            .sort((a, b) => getSortableName(a.venue.name).localeCompare(getSortableName(b.venue.name)));
 
         return matches;
     }

--- a/js/views/KJIndexView.js
+++ b/js/views/KJIndexView.js
@@ -19,6 +19,7 @@
 
 import { Component } from '../components/Component.js';
 import { getAllVenues } from '../services/venues.js';
+import { getVenueHosts } from '../utils/render.js';
 import { escapeHtml } from '../utils/string.js';
 
 export class KJIndexView extends Component {
@@ -147,10 +148,10 @@ export class KJIndexView extends Component {
 
         let noHostCount = 0;
         getAllVenues().forEach(v => {
-            let attributed = processHost(v.host, v.id);
-            (v.schedule || []).forEach(e => {
-                if (processHost(e.host, v.id)) attributed = true;
-            });
+            let attributed = false;
+            for (const { host } of getVenueHosts(v)) {
+                if (processHost(host, v.id)) attributed = true;
+            }
             if (!attributed) noHostCount++;
         });
 

--- a/schema/venue.schema.json
+++ b/schema/venue.schema.json
@@ -76,6 +76,11 @@
             { "type": "null" },
             { "$ref": "#/$defs/socials" }
           ]
+        },
+        "phone": {
+          "type": "string",
+          "pattern": "^[-0-9+(). ]{7,}$",
+          "description": "Public phone number for the venue, rendered as a tel: link in detail views. The venue's line only — not a KJ/host or curator-internal number."
         }
       }
     },
@@ -156,6 +161,12 @@
               "reason": { "type": "string", "minLength": 1 }
             }
           }
+        },
+        "socials": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/socials" }
+          ]
         }
       },
       "allOf": [
@@ -177,7 +188,13 @@
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "affiliation": { "type": "string", "minLength": 1 },
-        "website": { "type": "string", "format": "uri" }
+        "website": { "type": "string", "format": "uri" },
+        "socials": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/socials" }
+          ]
+        }
       },
       "anyOf": [
         { "required": ["name"] },


### PR DESCRIPTION
## Summary

Implements the five unification seams (S1–S5) from the surface/data spike (#113). The Weekly, Alphabetical, Map, and KJ surfaces had drifted into duplicated host-walking, schedule rendering, and service-filter logic — and, worse, into showing **different facts for the same venue**. This routes them through shared primitives and closes the consistency gaps.

Developed and verified locally on `unify-surfaces` (integration of the per-ticket branches). `js/data.json` / `js/data.js` are untouched.

## Related Issue

Implements #114, #115, #116, #117, #118 — tracking spike #113. Supersedes #72.

_(Listed without the `Fixes` keyword so they move through the human-owned **Verify** column rather than auto-closing on merge.)_

## Changes

- **S5 (#118) — schema ↔ render reconciliation.** Promote `venue.phone` (venue line only) and a shared `socials` shape on the `host` `$def` and `scheduleEntry` (venue / host / event scopes); delete the unused `schedule.note` rendering (table column, card spans, debug refs, orphaned CSS). functional-spec updated.
- **S1 (#114) — host primitive.** New `getVenueHosts(venue)` is the single source of the venue + per-show host walk; `venueMatchesHost`, `hasPerShowHosts`, `KJIndexView.collectIndex`, and `KJDossierView.getNoHostMatches` consume it (**4 walks → 1**). KJ dossier now sorts by `getSortableName` (article-insensitive, consistent with the other surfaces).
- **S3 (#116) — Alphabetical detail parity.** `VenueCard.fullTemplate` delegates to `renderVenueDetailSections({ classPrefix: 'venue-card', actions: false })`; A–Z now shows the per-show host column, closure banner, upcoming closures, and active-period notice it previously omitted. New trimmed `actions` option drops the View Map / Directions / Share row to keep the list light. `renderScheduleList` + orphaned CSS removed.
- **S4 (#117) — service predicate/comparators.** Extract `venuePasses()` (active-window + dedicated + search) and `byName()`; the list functions consume them, and `getVenuesForDate` derives unique venues from `getVenueEventsForDate` (**6 predicate copies → 1**).
- **S2 (#115) — schedule core.** `formatScheduleEntry` is the single entry formatter; the last manual holdout (`renderOneTime`) routes through it via a new `weekday` option; `getScheduleForDate` uses `getDayName`.

### Duplication ledger (measured)

| Seam | Net LOC | Dedup |
|---|---|---|
| S5 | −8 | phantom fields 3→0 |
| S1 | +10 | host-walks 4→1 |
| S3 | +43 (JS −57 / CSS +95) | detail renderers 2→1 |
| S4 | −7 | predicate 6→1 |
| S2 | −1 | one schedule core |
| **Total** | **≈ +37** (JS/logic ≈ −61, CSS +80, schema +18) | |

Raw LOC is net-positive because each seam adds shared code and the A–Z parity feature needs CSS — but **JS/application logic shrank ~61 lines**. The real win is structural dedup + cross-surface consistency + three correctness fixes (A–Z hidden facts; KJ surfaces sorting "The X" under T; schema/render drift). Full analysis + ledger: [`docs/spikes/surface-data-unification.md`](docs/spikes/surface-data-unification.md).

## Documentation Checklist

- [x] Project spec updated (functional-spec: host/event `socials`, `phone`, schedule fields)
- [ ] CLAUDE.md updated — **pending follow-up** (venue-format summary: `phone` + multi-scope `socials`)
- [ ] README.md updated — not needed (no new public feature; A–Z shows existing facts more completely)
- [ ] No documentation updates needed

## Testing Checklist

- [x] Manually tested the happy path (Weekly / Alphabetical / Map / KJ index + dossier — live, no console errors)
- [x] Tested edge cases (multi-host Highball, no-host venues, exclusions, active-period, mobile table stacking)
- [x] Checked for regressions (weekly 271 cards; `getVenuesForDate` derivation = 10 unique venues matching the event set; dossier one-time weekday preserved)
- [ ] No testing needed

_(Above is author/dev verification — the board's **Verify** column remains human-owned.)_

## Reviewer notes

- **Single integration branch** — supersedes the per-ticket branches `114-get-venue-hosts`, `116-alphabetical-detail-parity`, `118-schema-rendered-fields` (all contained here).
- **#72** verified already-fixed (`searchVenues` applies the activePeriod filter via `venuePasses`) → close as superseded.
- **CI:** local `sync-data-js --check` shows only the known Windows CRLF false-positive (#107); `data.json`/`data.js` are unchanged, so Linux CI should pass.
- **Deferred (noted on tickets):** CLAUDE.md / README venue-shape sync; event-level `socials` *render* (this lands the shape only); A–Z DOM weight (73 expanded cards) if mobile scroll perf becomes a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
