### PR TITLE
#124: Accept host registry refs in schema, validator, and runtime (Phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,7 @@ karaokedirectory/
 │   └── utils/
 │       ├── date.js        # Date formatting, schedule matching
 │       ├── debug.js       # Debug mode utilities
+│       ├── hosts.js       # Host ref hydration (kjs/companies registries, ADR-007)
 │       ├── render.js      # Shared rendering (schedule table, host section, active period)
 │       ├── string.js      # Text manipulation, escaping
 │       ├── tags.js        # Venue tag rendering and configuration
@@ -251,6 +252,25 @@ Where this is consumed:
 - `js/utils/render.js` → `resolveHostFor(venue, scheduleEntry)` returns the effective host. `renderScheduleTable()` adds a "Host" column whenever any entry has its own host.
 - `js/views/KJIndexView.js` → walks both `venue.host` and `schedule[].host` when enumerating KJs.
 - `js/services/venues.js` → `venueMatchesHost()` matches at either level.
+
+### Host registries (ADR-007)
+
+Hosts are being normalized out of inline objects into two top-level registries, referenced by id — the same indirection `tags[]` uses:
+
+```javascript
+kjs: { "kj-stephanie": { name: "KJ Stephanie" } },          // people and named acts
+companies: { "starling-karaoke": { name: "Starling Karaoke", website: "https://..." } },
+listings: [
+  { id: "some-bar", host: { kjId: "kj-stephanie", companyId: "starling-karaoke" } }
+]
+```
+
+- A **host ref** is `{ kjId?, companyId? }` with at least one id: company-only (a company runs it, KJ rotates/unknown), KJ-only (independent), or both. Valid at venue level and per schedule entry, with the same full-swap override rule.
+- **The KJ↔company link lives on the show, not on the entities** — no company on a KJ, no roster on a company. Rosters and the KJ index are derived by scanning shows, so they can't go stale, and a KJ can work under different companies at different venues.
+- `hydrateVenues()` in `js/utils/hosts.js` resolves refs inside `initVenues()` into the legacy display shape (KJ fields win, company fills gaps), so nothing downstream needs to know which form was stored.
+- **Both forms are accepted during the migration window.** `data.json` is not yet migrated (that's #124 Phase 2); `submit.html` still emits the legacy inline shape for curator reconciliation. `validate-data.js` fails on unresolvable ids and warns on unreferenced or same-named registry entries.
+
+Full detail: [functional spec §11 "Host Registries"](docs/functional-spec.md).
 
 ### Venue Tags
 
@@ -488,6 +508,10 @@ Current ADRs:
 - [ADR-002](docs/adr/002-vanilla-js-no-build.md) — Vanilla JS, no framework, no build step
 - [ADR-003](docs/adr/003-github-pages-deploy.md) — GitHub Pages as deploy target
 - [ADR-004](docs/adr/004-parallel-data-source-flag.md) — Parallel data source via URL flag
+- [ADR-005](docs/adr/005-venue-json-schema.md) — Venue JSON Schema as single source of truth
+- [ADR-006](docs/adr/006-data-json-canonical.md) — `js/data.json` canonical, `js/data.js` auto-generated
+- [ADR-007](docs/adr/007-host-registry-normalization.md) — Host normalization: KJ and company registries referenced by shows
+- [ADR-008](docs/adr/008-fetch-data-json-directly.md) — Browser fetches `js/data.json`, removing the generated `data.js` wrapper
 
 ## Security Considerations
 - Always use `escapeHtml()` when rendering user-provided content

--- a/docs/adr/007-host-registry-normalization.md
+++ b/docs/adr/007-host-registry-normalization.md
@@ -1,0 +1,70 @@
+# ADR-007: Host normalization — KJ and company registries referenced by shows
+
+**Status:** Accepted
+**Date:** 2026-07-29
+**Issue:** [#124](https://github.com/Johnesco/karaokedirectory/issues/124)
+**Related:** [ADR-001](001-supabase-schema-jsonb.md) (Supabase JSONB) · [ADR-005](005-venue-json-schema.md) (schema as contract) · [ADR-006](006-data-json-canonical.md) (data.json canonical)
+
+## Context
+
+Hosts are stored as inline `host` objects (`{ name?, affiliation?, website?, socials? }`) duplicated wherever they appear — on venues and on individual schedule entries. A 2026-07-29 audit of `data.json` (77 venues, 52 host objects) found:
+
+- **Xpider Cantu appears at 6 venues; only 2 copies carry his website.** One fact, six edit sites.
+- **Companies duplicate hardest:** Diamond Karaoke Austin ×5 venues, Starling Karaoke ×4, Party Pipes ×2. "Karaoke Underground" vs "The Karaoke Underground" have already drifted apart, with the website on 1 of 3 copies.
+- **Hosts have no identity, only spellings.** The KJ index and `?kj=` dossier group and match by lowercased/substring name — `?kj=Armando` also matches "KJ Armando and Paola", and "Average Joe" / "KJ Average Joe" (both Starling) are probably one person the data cannot connect.
+- **The name/affiliation split is used inconsistently:** "Marshall Joshua Entertainment" is a host *name* at 2 venues and an *affiliation* at a third. 17 host objects are affiliation-only (a company runs the night, no named KJ).
+- **One person under two companies is unrepresentable** (possibly Jen / KJ J3N) because the affiliation string is welded to each host copy.
+
+The domain model is: a venue (the anchor, always present) has shows; a show *may* have a host; "who runs it" is a KJ, a company, or both; a company fields several KJs; a KJ may freelance across companies. Venue↔KJ is many-to-many through shows.
+
+The codebase already solves this exact problem for tags: `tags: ["lgbtq"]` points into `tagDefinitions`, cross-checked by `validate-data.js` in CI.
+
+## Decision
+
+Two top-level registries in `data.json`, with shows referencing them by id:
+
+```json
+"companies": { "starling-karaoke": { "name": "Starling Karaoke", "website": "https://..." } },
+"kjs":       { "kj-stephanie": { "name": "KJ Stephanie" } },
+"listings":  [ { "id": "bar-a", "host": { "companyId": "starling-karaoke", "kjId": "kj-stephanie" } } ]
+```
+
+1. **Registries.** `kjs` (people/acts) and `companies`, object maps keyed by slug (the `tagDefinitions` pattern). Entries carry `name` plus optional `website`/`socials`. Duos ("DJ Cysum & Mo") are single KJ entries — the act is the entity.
+2. **Host reference = `{ kjId?, companyId? }`, at least one required.** Company-only ("Starling runs it, roster rotates"), KJ-only (independent), or both. Mirrors the current schema's `anyOf: name | affiliation`.
+3. **Specificity overrides, full-object swap.** The pair is valid at venue level (default) and per schedule entry (override). A show-level pair fully replaces the venue-level pair — the existing `entry.host ?? venue.host` rule, unchanged.
+4. **No stored relationships between entities.** No `companyId` on a KJ, no roster array on a company. The KJ↔company association is a fact about each *gig*, recorded per show. Rosters, the KJ index, and dossiers are **derived** from per-show effective hosts — a KJ appears under a company exactly as long as real shows pair them, so rollups can never go stale and freelancers need no special case.
+5. **Hydration at load.** The service layer resolves refs into the legacy display shape `{ name, affiliation, website, socials }` (KJ fields win, company fills gaps), keeping `resolveHostFor()`, components, search, and `?kj=` views unchanged.
+6. **Transition window.** Schema and hydration accept both the legacy inline object and the ref pair, so the site, the external curator, and `submit.html` migrate independently; mixed data stays valid until a cleanup ticket drops the legacy shape.
+7. **Migration merges are human-ruled.** The migration script auto-merges only exact (case-insensitive) duplicates; near-misses (Average Joe / KJ Average Joe, the two Karaoke Undergrounds, …) go into a review report for the curator. Name variants in this data have been intentional before; tooling flags, never decides.
+8. **Public submissions stay free-text.** Submitters can't know registry ids; the form's KJ/Company fields emit free text that the curator reconciles (match-or-create) into the registries.
+
+## Consequences
+
+### Positive
+
+- Each KJ and company is one record — fixing Xpider's website is one edit, not six.
+- CI-enforced referential integrity: `kjId`/`companyId` cross-checks join the existing tag cross-reference in `validate-data.js`; a typo'd ref fails the build instead of silently dropping a host.
+- Exact identity for KJ listings: the index and dossiers group by id, ending substring conflation and enabling stable `?kj=<slug>` URLs later.
+- One person under multiple companies is now just one `kjId` with different `companyId`s per show.
+- Registries map 1:1 to future Supabase `kjs`/`companies` tables (ADR-001); the JSON becomes a dry run for the relational model.
+- The curator gains pickers instead of retyped strings — drift like "The Karaoke Underground" can't recur.
+
+### Negative
+
+- Indirection: adding a brand-new host is a two-place edit (registry entry + ref). Acceptable — the curator tool absorbs it.
+- The external curator and `submit.html` must be updated (tracked in #124 Phases 3–4); until then the transition window carries dual-shape complexity in schema and hydration.
+- Migration requires human merge rulings before the data flip ships.
+- Derived rosters mean a company's KJ list is only as complete as its current shows — consistent with the "week is the heartbeat" display philosophy, but it is *not* an employment directory.
+
+## Alternatives considered
+
+- **Single flat `hosts` registry** (dedupe today's host object as-is). Halfway: collapses repeated hosts but company strings still duplicate across every KJ entry of the same company, and company-vs-person stays conflated.
+- **`companyId` on the KJ entity.** Assumes one company per KJ, permanently. Breaks freelancers, forces a wrong answer for "company-booked, several possible KJs" (the Starling case), and stores an employment claim that rots.
+- **Stored roster on the company.** Same staleness problem from the other side; derivation from shows self-heals.
+- **Skip JSON normalization, go straight to Supabase.** The runtime flag is deliberately off (ADR-004); normalizing in JSON now yields the benefits immediately and de-risks the eventual schema.
+
+## Related work
+
+- **#124** — implementation ticket (phased: contract/runtime → migration → submit form → curator → cleanup)
+- **ADR-005** — the schema this extends; **ADR-006** — migration edits `data.json`, `data.js` regenerated
+- Tag system (`tagDefinitions` + `validate-data.js` cross-reference) — the in-repo precedent this generalizes

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,4 +14,5 @@ Format and threshold rule: see [sdlc-baseline `docs/adrs.md`](https://github.com
 | [004](004-parallel-data-source-flag.md) | Parallel data source via URL flag — production stays on JSON | Accepted |
 | [005](005-venue-json-schema.md) | Venue JSON Schema as single source of truth | Accepted |
 | [006](006-data-json-canonical.md) | `js/data.json` canonical, `js/data.js` auto-generated | Accepted |
+| [007](007-host-registry-normalization.md) | Host normalization — KJ and company registries referenced by shows | Accepted |
 | [008](008-fetch-data-json-directly.md) | Browser fetches `js/data.json` — remove the generated `js/data.js` wrapper | Accepted |

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -595,11 +595,15 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
     activePeriod.start  string        "YYYY-MM-DD"
     activePeriod.end    string        "YYYY-MM-DD"
 
-  host                  object|null   OPTIONAL
-    host.name           string        OPTIONAL  Individual KJ name
-    host.affiliation    string        OPTIONAL  Parent company/org (e.g. "Starling Karaoke")
-    host.website        string        OPTIONAL  Host/KJ personal website
-    host.socials        object|null   OPTIONAL  KJ/host social links (same shape as venue `socials`)
+  host                  object|null   OPTIONAL  Two accepted forms — see "Host Registries" below
+    Registry ref (preferred, ADR-007) — at least one id required:
+      host.kjId         string        OPTIONAL  Key into the top-level `kjs` map
+      host.companyId    string        OPTIONAL  Key into the top-level `companies` map
+    Legacy inline (accepted during the migration window):
+      host.name         string        OPTIONAL  Individual KJ name
+      host.affiliation  string        OPTIONAL  Parent company/org (e.g. "Starling Karaoke")
+      host.website      string        OPTIONAL  Host/KJ personal website
+      host.socials      object|null   OPTIONAL  KJ/host social links (same shape as venue `socials`)
 
   socials               object|null   OPTIONAL
     socials.website     string        OPTIONAL
@@ -613,6 +617,31 @@ The shape `{ tagDefinitions, listings }` is the contract — both the local file
   phone                 string        OPTIONAL  Venue's public phone — tel: link in detail views (venue line only, not KJ/host or curator-internal)
 }
 ```
+
+### Host Registries
+
+Who runs a show is stored once, in two top-level maps alongside `tagDefinitions`, and referenced by id — the same indirection `tags[]` already uses. See [ADR-007](adr/007-host-registry-normalization.md).
+
+```
+kjs                     object        OPTIONAL  id → { name, website?, socials? }   People and named acts
+companies               object        OPTIONAL  id → { name, website?, socials? }   Karaoke companies
+```
+
+A **host ref** is the pair `{ kjId?, companyId? }`, with at least one id present:
+
+| Recorded as | Means |
+|---|---|
+| `companyId` only | A company runs the night; the KJ is unrecorded or rotates |
+| `kjId` only | An independent KJ |
+| both | That KJ, working under that company, at that show |
+
+**The KJ↔company association lives on the show, never on the registry entries.** A KJ has no stored company and a company has no stored roster, so one person can work under different companies at different venues, and "which KJs does this company field?" is derived by scanning shows. Derived rollups can go stale only when the shows do, which matches the directory's "the week is the heartbeat" stance.
+
+**Specificity overrides:** a ref on a schedule entry fully replaces the venue-level ref for that show (no field-level merge), the same rule the legacy inline host already followed. Effective host = `entry.host ?? venue.host`.
+
+**Hydration:** `hydrateVenues()` in `js/utils/hosts.js` resolves refs at load time inside `initVenues()`, producing the legacy display shape `{ name, affiliation, website, socials }` — KJ fields win, the company fills gaps (a KJ with no website of their own shows the company's). Views, components, search, and the KJ pages therefore only ever see one host shape. The resolved object also carries `kjId`/`companyId` for id-aware consumers.
+
+**Transition window:** the schema accepts either form, and venues carrying no refs pass through hydration untouched, so `data.json`, the external curator, and `submit.html` can migrate independently. `submit.html` emits the legacy inline shape for curator reconciliation. Unresolvable ids fail `validate-data.js` (and warn in the console at runtime, rendering what resolved rather than dropping the host block). Unreferenced or same-named registry entries are reported as non-fatal validator warnings.
 
 ### Schedule Exclusions
 

--- a/js/data.json
+++ b/js/data.json
@@ -428,7 +428,7 @@
         }
       ],
       "host": {
-        "name": "KJ Average Joe",
+        "name": "Average Joe",
         "affiliation": "Starling Karaoke"
       },
       "socials": {
@@ -1160,7 +1160,7 @@
         }
       ],
       "host": {
-        "name": "Marshall Joshua Entertainment"
+        "affiliation": "Marshall Joshua Entertainment"
       },
       "coordinates": {
         "lat": 30.2453635,
@@ -1547,7 +1547,7 @@
         }
       ],
       "host": {
-        "affiliation": "The Karaoke Underground"
+        "affiliation": "Karaoke Underground"
       },
       "socials": {
         "facebook": "https://www.facebook.com/NomadBarATX",
@@ -2434,7 +2434,7 @@
         }
       ],
       "host": {
-        "name": "Marshall Joshua Entertainment"
+        "affiliation": "Marshall Joshua Entertainment"
       },
       "socials": {
         "facebook": "https://www.facebook.com/RoundRockTavern/",

--- a/js/services/venues.js
+++ b/js/services/venues.js
@@ -3,7 +3,7 @@
  * Handles loading, filtering, sorting, and querying venue data.
  *
  * Key exports:
- * - initVenues(data): Initialize venue data from js/data.json
+ * - initVenues(data): Initialize venue data from js/data.json (resolves host refs)
  * - getAllVenues(): Get all active venues
  * - getVenueById(id): Get single venue by ID
  * - getVenuesForDate(date, options): Get venues with karaoke on a specific date
@@ -18,6 +18,7 @@ import { scheduleMatchesDate, isDateInRange } from '../utils/date.js';
 import { getSortableName, containsIgnoreCase } from '../utils/string.js';
 import { getTagConfig } from '../utils/tags.js';
 import { getVenueHosts } from '../utils/render.js';
+import { hydrateVenues } from '../utils/hosts.js';
 
 let venues = [];
 
@@ -92,7 +93,9 @@ export function initVenues(data) {
         return;
     }
 
-    venues = data.listings;
+    // Resolve any { kjId, companyId } host refs against the kjs/companies
+    // registries so everything downstream sees one host shape (ADR-007).
+    venues = hydrateVenues(data);
     const activeCount = getActiveVenues().length;
     const inactiveCount = venues.length - activeCount;
     console.log(`Loaded ${venues.length} venues (${activeCount} active, ${inactiveCount} inactive)`);

--- a/js/utils/hosts.js
+++ b/js/utils/hosts.js
@@ -1,0 +1,115 @@
+/**
+ * Host reference hydration (ADR-007)
+ *
+ * During the transition window data.json stores a host two ways:
+ *   - Legacy inline object: { name?, affiliation?, website?, socials? }
+ *   - Registry ref pair:    { kjId?, companyId? } pointing into the top-level
+ *                           `kjs` / `companies` maps
+ *
+ * Views, components, search, and the KJ pages only ever see the inline display
+ * shape — refs are resolved once in initVenues(), so nothing downstream needs to
+ * know which storage form a venue used.
+ *
+ * Key exports:
+ * - isHostRef(host): true when a host value is a registry ref pair
+ * - resolveHostRef(ref, registries): one ref pair → display host object
+ * - hydrateVenues(data): full listings array with every ref resolved
+ */
+
+/**
+ * A host value is a registry ref when it carries either id key. Legacy inline
+ * hosts never do, so the two shapes are unambiguous (the schema enforces this
+ * with mutually exclusive additionalProperties).
+ * @param {Object|null} host
+ * @returns {boolean}
+ */
+export function isHostRef(host) {
+    return !!host && ('kjId' in host || 'companyId' in host);
+}
+
+/**
+ * Resolve a { kjId?, companyId? } pair into the display host shape.
+ *
+ * KJ fields win and the company fills gaps: a KJ with no website of their own
+ * shows the company's, which matches how the single legacy `website` field
+ * ("Host / Affiliation Website") has always been used.
+ *
+ * The ids ride along on the result for id-aware consumers (KJ index, dossier
+ * links); rendering ignores them.
+ *
+ * @param {Object} ref - { kjId?, companyId? }
+ * @param {Object} registries - { kjs, companies } id → { name, website?, socials? }
+ * @param {string} [context] - Venue id, used only in the unresolved-ref warning
+ * @returns {Object|null} { name?, affiliation?, website?, socials?, kjId?, companyId? }, or null if neither id resolves
+ */
+export function resolveHostRef(ref, { kjs = {}, companies = {} } = {}, context = '') {
+    const kj = ref.kjId ? kjs[ref.kjId] : null;
+    const company = ref.companyId ? companies[ref.companyId] : null;
+
+    // Unresolved ids mean data.json and its registries disagree. validate-data.js
+    // fails CI on this, so at runtime we warn and render what we can rather than
+    // dropping the venue's whole host block.
+    if (ref.kjId && !kj) warnMissing('kjs', ref.kjId, context);
+    if (ref.companyId && !company) warnMissing('companies', ref.companyId, context);
+    if (!kj && !company) return null;
+
+    const host = {};
+    if (kj?.name) host.name = kj.name;
+    if (company?.name) host.affiliation = company.name;
+
+    const website = kj?.website || company?.website;
+    if (website) host.website = website;
+
+    const socials = kj?.socials || company?.socials;
+    if (socials) host.socials = socials;
+
+    if (ref.kjId) host.kjId = ref.kjId;
+    if (ref.companyId) host.companyId = ref.companyId;
+
+    return host;
+}
+
+function warnMissing(registry, id, context) {
+    console.warn(`Unknown ${registry} id "${id}"${context ? ` (referenced by ${context})` : ''} — host info will be incomplete.`);
+}
+
+/**
+ * Resolve every host ref in the listings array.
+ *
+ * Venues that carry no refs are returned untouched (same object identity), so
+ * data that predates the migration behaves exactly as before.
+ *
+ * @param {Object} data - { listings, kjs?, companies? }
+ * @returns {Object[]} Listings with hosts in display shape
+ */
+export function hydrateVenues(data) {
+    const registries = { kjs: data?.kjs || {}, companies: data?.companies || {} };
+    return (data?.listings || []).map(venue => hydrateVenue(venue, registries));
+}
+
+/**
+ * @param {Object} venue
+ * @param {Object} registries - { kjs, companies }
+ * @returns {Object} Hydrated copy, or the original when there was nothing to resolve
+ */
+function hydrateVenue(venue, registries) {
+    const venueHostIsRef = isHostRef(venue.host);
+    const scheduleHasRef = (venue.schedule || []).some(entry => isHostRef(entry.host));
+    if (!venueHostIsRef && !scheduleHasRef) return venue;
+
+    const hydrated = { ...venue };
+
+    if (venueHostIsRef) {
+        hydrated.host = resolveHostRef(venue.host, registries, venue.id);
+    }
+
+    if (scheduleHasRef) {
+        hydrated.schedule = venue.schedule.map(entry => (
+            isHostRef(entry.host)
+                ? { ...entry, host: resolveHostRef(entry.host, registries, venue.id) }
+                : entry
+        ));
+    }
+
+    return hydrated;
+}

--- a/schema/venue.schema.json
+++ b/schema/venue.schema.json
@@ -16,6 +16,22 @@
       },
       "additionalProperties": false
     },
+    "kjs": {
+      "description": "Map of KJ id → { name, website?, socials? }. Referenced by host.kjId (ADR-007). A duo or named act is a single entry. Optional while the data migrates off inline hosts.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9][a-z0-9-]*$": { "$ref": "#/$defs/registryEntry" }
+      },
+      "additionalProperties": false
+    },
+    "companies": {
+      "description": "Map of company id → { name, website?, socials? }. Referenced by host.companyId (ADR-007). Optional while the data migrates off inline hosts.",
+      "type": "object",
+      "patternProperties": {
+        "^[a-z0-9][a-z0-9-]*$": { "$ref": "#/$defs/registryEntry" }
+      },
+      "additionalProperties": false
+    },
     "listings": {
       "type": "array",
       "items": { "$ref": "#/$defs/venue" }
@@ -66,10 +82,8 @@
         },
         "activePeriod": { "$ref": "#/$defs/activePeriod" },
         "host": {
-          "oneOf": [
-            { "type": "null" },
-            { "$ref": "#/$defs/host" }
-          ]
+          "$ref": "#/$defs/hostAssignment",
+          "description": "Default host for shows that don't override it."
         },
         "socials": {
           "oneOf": [
@@ -144,10 +158,8 @@
         "eventName": { "type": "string", "minLength": 1 },
         "eventUrl": { "type": "string", "format": "uri" },
         "host": {
-          "oneOf": [
-            { "type": "null" },
-            { "$ref": "#/$defs/host" }
-          ]
+          "$ref": "#/$defs/hostAssignment",
+          "description": "Host for this show only. Fully replaces the venue-level host — fields are not merged."
         },
         "exclusions": {
           "type": "array",
@@ -182,9 +194,47 @@
       "pattern": "^([01]\\d|2[0-3]):[0-5]\\d$",
       "description": "HH:MM in 24-hour format."
     },
+    "hostAssignment": {
+      "description": "Who runs a show. Either a registry ref pair (preferred, ADR-007) or the legacy inline object still accepted during the migration window. The two shapes are mutually exclusive — each forbids the other's properties — so oneOf is unambiguous.",
+      "oneOf": [
+        { "type": "null" },
+        { "$ref": "#/$defs/hostRef" },
+        { "$ref": "#/$defs/host" }
+      ]
+    },
+    "hostRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Reference into the kjs/companies registries. At least one id required: companyId alone (a company runs the night, KJ unrecorded or rotating), kjId alone (independent), or both. The KJ↔company association lives here, on the show — never on the registry entries — so rosters stay derived and cannot go stale (ADR-007).",
+      "properties": {
+        "kjId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" },
+        "companyId": { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$" }
+      },
+      "anyOf": [
+        { "required": ["kjId"] },
+        { "required": ["companyId"] }
+      ]
+    },
+    "registryEntry": {
+      "type": "object",
+      "required": ["name"],
+      "additionalProperties": false,
+      "description": "One KJ or one company. Shared shape for both registries.",
+      "properties": {
+        "name": { "type": "string", "minLength": 1 },
+        "website": { "type": "string", "format": "uri" },
+        "socials": {
+          "oneOf": [
+            { "type": "null" },
+            { "$ref": "#/$defs/socials" }
+          ]
+        }
+      }
+    },
     "host": {
       "type": "object",
       "additionalProperties": false,
+      "description": "Legacy inline host, accepted during the migration window and emitted by submit.html for curator reconciliation. Superseded by hostRef.",
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "affiliation": { "type": "string", "minLength": 1 },

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -2,8 +2,11 @@
 /**
  * Validate js/data.json against schema/venue.schema.json (via Ajv) plus the
  * supplementary checks JSON Schema cannot express: cross-row constraints
- * (unique venue ids, tag-id cross-reference) and data-quality heuristics
- * (minute-typo detection, noon end-time after evening start).
+ * (unique venue ids, tag-id and host-ref cross-reference) and data-quality
+ * heuristics (minute-typo detection, noon end-time after evening start).
+ *
+ * Registry hygiene (unreferenced or same-named kjs/companies entries) is
+ * reported as warnings — worth a look, but not a build failure.
  *
  * Exits non-zero on failure — suitable as a pre-commit / CI gate. Enforced
  * by .github/workflows/ci.yml.
@@ -16,7 +19,11 @@ const addFormats = require('ajv-formats');
 
 const ROOT = path.resolve(__dirname, '..');
 const SCHEMA_PATH = path.join(ROOT, 'schema', 'venue.schema.json');
-const DATA_PATH = path.join(ROOT, 'js', 'data.json');
+// Defaults to the canonical data file; an explicit path lets the migration
+// script validate a candidate file before it overwrites anything.
+const DATA_PATH = process.argv[2]
+    ? path.resolve(process.argv[2])
+    : path.join(ROOT, 'js', 'data.json');
 
 console.log('Reading:', DATA_PATH);
 
@@ -46,6 +53,7 @@ const validate = ajv.compile(schema);
 const schemaOk = validate(data);
 
 const issues = [];
+const warnings = [];
 
 function venueLabel(idx) {
     const v = data.listings[idx];
@@ -67,9 +75,33 @@ if (!schemaOk) {
 
 // ---- Supplementary checks ----
 const VALID_TAGS = Object.keys(data.tagDefinitions || {});
+const KJS = data.kjs || {};
+const COMPANIES = data.companies || {};
+
+// Registry ids actually pointed at by a host, so unused entries can be reported.
+const referenced = { kjs: new Set(), companies: new Set() };
 
 function fail(venue, msg) {
     issues.push(`${venue.name || 'index ?'} (${venue.id || '?'}): ${msg}`);
+}
+
+/**
+ * Host ref cross-reference: kjId/companyId must resolve in the registries —
+ * the same class of check as tag ids against tagDefinitions (ADR-007). Legacy
+ * inline hosts carry neither id and are skipped.
+ */
+function checkHostRef(venue, host, where) {
+    for (const [key, registry, label] of [
+        ['kjId', KJS, 'kjs'],
+        ['companyId', COMPANIES, 'companies'],
+    ]) {
+        const id = host?.[key];
+        if (!id) continue;
+        referenced[label].add(id);
+        if (!(id in registry)) {
+            fail(venue, `${where} ${key} "${id}" is not defined in ${label}`);
+        }
+    }
 }
 
 const idCounts = {};
@@ -85,9 +117,12 @@ for (const venue of data.listings) {
         }
     }
 
+    checkHostRef(venue, venue.host, 'host');
+
     if (Array.isArray(venue.schedule)) {
         venue.schedule.forEach((entry, i) => {
             const prefix = `schedule[${i}]`;
+            checkHostRef(venue, entry.host, `${prefix}.host`);
 
             // Minute-typo heuristic — start times should land on :00/:15/:30/:45.
             // Catches things like 17:03 that should have been 17:00.
@@ -114,17 +149,53 @@ for (const [id, count] of Object.entries(idCounts)) {
     if (count > 1) issues.push(`Duplicate ID: ${id} (${count} times)`);
 }
 
+// ---- Registry hygiene (warnings — bad smells, not broken data) ----
+// An unreferenced entry is dead weight; two entries with the same name are the
+// duplication ADR-007 exists to remove, creeping back in.
+for (const [label, registry] of [['kjs', KJS], ['companies', COMPANIES]]) {
+    const namesSeen = new Map();
+
+    for (const [id, entry] of Object.entries(registry)) {
+        if (!referenced[label].has(id)) {
+            warnings.push(`${label}["${id}"] (${entry.name}) is never referenced by a host`);
+        }
+
+        const key = (entry.name || '').trim().toLowerCase();
+        if (!key) continue;
+        if (!namesSeen.has(key)) namesSeen.set(key, []);
+        namesSeen.get(key).push(id);
+    }
+
+    for (const [, ids] of namesSeen) {
+        if (ids.length > 1) {
+            warnings.push(`${label} entries share the name "${registry[ids[0]].name}": ${ids.join(', ')} — merge?`);
+        }
+    }
+}
+
 // ---- Output ----
 console.log('=== Summary ===');
 console.log('Total venues:', data.listings.length);
 const withCoords = data.listings.filter(v => v.coordinates?.lat && v.coordinates?.lng).length;
 console.log('With coordinates:', withCoords);
 
+const kjCount = Object.keys(KJS).length;
+const companyCount = Object.keys(COMPANIES).length;
+if (kjCount || companyCount) {
+    console.log('Registered KJs:', kjCount);
+    console.log('Registered companies:', companyCount);
+}
+
 if (issues.length > 0) {
     console.log(`\n=== ${issues.length} Issue(s) Found ===`);
     issues.forEach(issue => console.log('- ' + issue));
 } else {
     console.log('\nNo issues found!');
+}
+
+if (warnings.length > 0) {
+    console.log(`\n=== ${warnings.length} Warning(s) — not fatal ===`);
+    warnings.forEach(warning => console.log('- ' + warning));
 }
 
 console.log('\n=== Data Quality (informational) ===');


### PR DESCRIPTION
## Summary

Phase 1 of host normalization (ADR-007): the schema, validator, and runtime learn the `{ kjId?, companyId? }` host ref. **No data is migrated and nothing on the site changes** — that is the point of this phase. It lands the contract so Phase 2 can migrate the data behind it.

Hosts today have no identity, only spellings, and the duplication is measurable across `data.json`: Xpider Cantu appears at 6 venues with his website on only 2 copies, Diamond Karaoke Austin is copied at 5, and "Karaoke Underground" vs "The Karaoke Underground" have already drifted into two things.

## Related Issue

Part of #124 (Phase 1 of 5 — Phases 2–5 remain open on the ticket)

## Changes

- `schema/venue.schema.json` — optional `kjs` and `companies` registries, and a `hostAssignment` union accepting either a ref pair or the legacy inline host. The two shapes forbid each other's properties, so the union is unambiguous
- `scripts/validate-data.js` — host refs cross-checked against the registries exactly as tag ids are checked against `tagDefinitions`; unreferenced and same-named registry entries reported as **non-fatal warnings** (the duplication ADR-007 removes, creeping back). Also accepts an optional data path so the Phase 2 migration can validate a candidate file before overwriting anything
- `js/utils/hosts.js` (new) — `hydrateVenues()` resolves refs inside `initVenues()` into the display shape every view already consumes: KJ fields win, the company fills gaps
- Docs — ADR-007, a new "Host Registries" section in spec §11, CLAUDE.md (including ADR list entries 005–008, which had gone missing)

## The design question this settles

The KJ↔company association lives **on the show**, never on the registry entries — no company stored on a KJ, no roster stored on a company. That is what makes all three real cases representable: a company running the night with a rotating KJ (`companyId` alone), an independent (`kjId` alone), and a specific KJ under a specific company (both). Rosters and the KJ index are derived by scanning shows, so they cannot go stale, and one person can work under different companies at different venues.

## Documentation Checklist

- [x] Project spec updated — §11 gains a "Host Registries" section
- [x] CLAUDE.md updated — host registries section, `hosts.js` in the file structure, ADR list
- [x] README.md — no public-facing change in this phase

## Testing Checklist

- [x] Manually tested the happy path — app boots clean; hosts render across all three cases: "Presented by Diamond Karaoke Austin" (company-only), "Presented by Armando" (KJ-only), "KJ Stephanie (Starling Karaoke)" (both)
- [x] Tested edge cases — 13 schema accept/reject cases pass, including rejection of mixed ref+legacy shapes, empty host objects, bad id slugs, and registry entries missing a name. 16 hydration assertions pass, covering company-only, KJ-only, both-ids, per-show override, legacy passthrough, and unresolvable refs (which degrade to no host and warn rather than dropping the venue)
- [x] Checked for regressions in related features — **hydration is a verified no-op on unmigrated data**: every venue comes back by object reference, so views receive byte-identical input to before. Validator and CSS-order gate pass; 150 host lines render in the live app

## Notes for the reviewer

Stacked on **#126** (and therefore **#125**). The rebase conflict between this work and the `data.js` removal is already resolved here — both branches touched the same `venues.js` docblock line and the ADR index.

Phase 2 (the data migration) is deliberately not in this PR. It will auto-merge only exact duplicate hosts and produce a review report for the near-misses — Average Joe / KJ Average Joe, the two Karaoke Undergrounds, Marshall Joshua as name-vs-affiliation, Jen / KJ J3N — for you to rule on. Name variants in this data have been intentional before, so tooling flags rather than decides.
