### PR TITLE
#132: Apply three host dedupe rulings

### DIFF
--- a/js/data.json
+++ b/js/data.json
@@ -428,7 +428,7 @@
         }
       ],
       "host": {
-        "name": "KJ Average Joe",
+        "name": "Average Joe",
         "affiliation": "Starling Karaoke"
       },
       "socials": {
@@ -1160,7 +1160,7 @@
         }
       ],
       "host": {
-        "name": "Marshall Joshua Entertainment"
+        "affiliation": "Marshall Joshua Entertainment"
       },
       "coordinates": {
         "lat": 30.2453635,
@@ -1547,7 +1547,7 @@
         }
       ],
       "host": {
-        "affiliation": "The Karaoke Underground"
+        "affiliation": "Karaoke Underground"
       },
       "socials": {
         "facebook": "https://www.facebook.com/NomadBarATX",
@@ -2434,7 +2434,7 @@
         }
       ],
       "host": {
-        "name": "Marshall Joshua Entertainment"
+        "affiliation": "Marshall Joshua Entertainment"
       },
       "socials": {
         "facebook": "https://www.facebook.com/RoundRockTavern/",


### PR DESCRIPTION
## Summary

Applies the three unambiguous dedupe rulings from the host audit on #124. Each was visible as a split identity on `?kj=all`.

## Related Issue

Fixes #132

## Changes

| Venue(s) | Before | After |
|---|---|---|
| Gratas Pizzeria, Round Rock Tavern | `host.name: "Marshall Joshua Entertainment"` | `host.affiliation:` same |
| Boomerz | `host.name: "KJ Average Joe"` | `host.name: "Average Joe"` |
| Knomad Bar | `host.affiliation: "The Karaoke Underground"` | `host.affiliation: "Karaoke Underground"` |

## Documentation Checklist

- [x] No documentation updates needed (data-only change)

## Testing Checklist

- [x] Manually tested the happy path — `validate-data.js` passes at 80 venues
- [x] Checked for regressions — re-ran the audit: the near-duplicate company list and the name-vs-company conflict list are both now empty
- [x] Verified against the live KJ index: affiliations 19 -> 18, independents 13 -> 12, Marshall Joshua Entertainment appears once as a company with 3 venues (previously two rows in two different sections), Karaoke Underground once with 3 venues, and Starling's roster reads Average Joe (2), KJ J3N, KJ Stephanie

## Notes for the reviewer

Deliberately left alone, per your rulings: Jen / KJ J3N separate pending verification, Armando and the duo as distinct acts, Laura Torrez Studio as a KJ.

Karaoke Underground's website is still on only 1 of its 3 records. Not worth hand-syncing — #124 Phase 2 makes it a single registry field instead of three copies.

Stacked on #130.