### PR TITLE
#88: Hide past one-time events from map venue card

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -245,6 +245,7 @@ A card that appears over the map when a marker is selected. Has two states:
 - "Details" button expands the card and shows a back arrow
 - "Back to Summary" returns to compact view
 - Clicking the map background (not a marker or card) dismisses the card
+- **Past one-time events are hidden** — `frequency: "once"` entries dated before today are filtered out of both the summary and detail schedule. Recurring entries always show; the modal/pane surfaces opened from the calendar view still display the full schedule unfiltered.
 - **Sizing:** full-width bottom sheet on mobile; on desktop (≥1024px) a fixed 350px-wide card anchored right (explicit width so it doesn't shrink to its content). The floating "Hide Dedicated" map control and the analytics consent-banner buttons are ≥44px tall (touch targets).
 
 ### Exclusion Dates on the Map
@@ -1261,6 +1262,7 @@ Each public page includes a `<link rel="canonical">` tag pointing to its canonic
 | 2026-02 | 1.0.21 | Shareable venue links: URL hash syncs with venue selection (`#venue={id}`), share button on all detail surfaces (modal, pane, map card) with Web Share API / clipboard fallback. Added `shareVenue()` to `url.js`. Updated Sections 4, 7, 21. | Claude Code |
 | 2026-02 | 1.0.22 | SEO quick wins: Added meta descriptions, Open Graph tags, Twitter Card tags, and canonical URLs to all 5 public pages. Created `robots.txt` and `sitemap.xml`. Added `noindex` to `editor.html`. New Section 22. Renumbered Sections 22–23 → 23–24. | Claude Code |
 | 2026-06 | 1.0.23 | Exclusion Dates feature (#3–#8): recurring shows can be marked closed on specific dates via `schedule[].exclusions` (`"YYYY-MM-DD"` shorthand or `{date, reason}`). Weekly cards dim with a "Closed" banner; Map dims the marker and shows a "Closed Today" card banner; detail modal/pane/map-expanded show a "Closed Today" banner plus an "Upcoming closures" list (next 60 days). Added `getVenueExclusionForDate()` and `getUpcomingExclusions()` to `date.js`. New §11 "Schedule Exclusions"; updated §2, §4, §7, §8. | Claude Code |
+| 2026-07 | 1.0.24 | #88: Map venue card now hides `frequency: "once"` entries dated before today (both summary and detail schedule). Added `isPastOnceEvent()` helper to `js/utils/date.js`. VenueModal and VenueDetailPane unchanged. Updated Section 4. | Claude Code |
 
 ---
 

--- a/js/utils/date.js
+++ b/js/utils/date.js
@@ -240,6 +240,26 @@ export function getUpcomingExclusions(venue, days = 60) {
 }
 
 /**
+ * Is this schedule entry a one-time event whose date has already passed?
+ * Recurring entries (`every`, `first`, …) always return `false` — they have
+ * no fixed date to compare. Uses `parseLocalDate` so the YYYY-MM-DD string
+ * is interpreted in the viewer's timezone (matches how the rest of the app
+ * treats schedule dates).
+ *
+ * @param {Object} entry - Schedule entry (may be any frequency)
+ * @param {Date} [asOf] - "Now" reference; defaults to today at local midnight
+ * @returns {boolean} True if entry is a past one-time event
+ */
+export function isPastOnceEvent(entry, asOf) {
+    if (entry?.frequency !== 'once' || !entry.date) return false;
+    const today = asOf ? new Date(asOf) : new Date();
+    today.setHours(0, 0, 0, 0);
+    const entryDate = parseLocalDate(entry.date);
+    entryDate.setHours(0, 0, 0, 0);
+    return entryDate < today;
+}
+
+/**
  * Convert 24-hour time to 12-hour format
  * @param {string} time24 - Time in 24-hour format (e.g., "21:00")
  * @returns {string} Time in 12-hour format (e.g., "9:00 PM")

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -13,7 +13,7 @@ import { escapeHtml } from '../utils/string.js';
 import { buildDirectionsUrl, shareVenue } from '../utils/url.js';
 import { renderTags } from '../utils/tags.js';
 import { renderScheduleCompact, renderVenueDetailSections } from '../utils/render.js';
-import { getVenueExclusionForDate } from '../utils/date.js';
+import { getVenueExclusionForDate, isPastOnceEvent } from '../utils/date.js';
 
 export class MapView extends Component {
     init() {
@@ -378,7 +378,10 @@ export class MapView extends Component {
         const cardEl = this.$('#map-venue-card');
         if (!cardEl || !venue) return;
 
-        const scheduleHtml = renderScheduleCompact(venue.schedule);
+        // The map card is a forward-looking snapshot: past one-time events are
+        // clutter here even though they're still part of the venue's schedule.
+        const upcomingSchedule = (venue.schedule || []).filter(s => !isPastOnceEvent(s));
+        const scheduleHtml = renderScheduleCompact(upcomingSchedule);
 
         // Build directions URL
         const directionsUrl = buildDirectionsUrl(venue.address, venue.name);
@@ -422,6 +425,13 @@ export class MapView extends Component {
 
         const tagsHtml = renderTags(venue.tags, { dedicated: venue.dedicated });
 
+        // Strip past one-time events from the schedule table — the map detail
+        // view, like the compact card, is forward-looking.
+        const venueForDisplay = {
+            ...venue,
+            schedule: (venue.schedule || []).filter(s => !isPastOnceEvent(s))
+        };
+
         cardEl.innerHTML = `
             <button class="map-venue-card__close" data-action="close-card" type="button" aria-label="Close">
                 <i class="fa-solid fa-xmark"></i>
@@ -434,7 +444,7 @@ export class MapView extends Component {
             </div>
             ${tagsHtml}
             <div class="map-venue-card__detail-content">
-                ${renderVenueDetailSections(venue, { classPrefix: 'map-venue-card', hostSocialSize: '' })}
+                ${renderVenueDetailSections(venueForDisplay, { classPrefix: 'map-venue-card', hostSocialSize: '' })}
             </div>
         `;
 


### PR DESCRIPTION
## Summary

The floating map card rendered every `frequency: "once"` entry including past dates, so stale one-offs crowded out (or stood in for) current events. The map card is a forward-looking snapshot; this filters past one-times out of both the compact summary and the expanded detail.

Recurring entries always show. `VenueModal` and `VenueDetailPane` are untouched — those open from the calendar, where the full schedule is the point.

## Related Issue

Fixes #88

## Changes

- `isPastOnceEvent(entry, asOf)` added to `js/utils/date.js` — returns false for any recurring frequency, uses `parseLocalDate` so dates are read in the viewer's timezone like the rest of the app
- `js/views/MapView.js` filters the schedule at both call sites (compact summary, expanded detail)
- Spec §4 and changelog updated

## Provenance

This commit was authored 2026-06-04 and never pushed. Rebased onto current `main` for this PR. Three conflicts, all additive, resolved by keeping both sides:

- `date.js` — the exclusion helpers landed in the same spot since June; both kept
- `MapView.js` — merged two separate imports of `date.js` into one line
- spec — map-card section and changelog took both entries; this one renumbered 1.0.23 → 1.0.24

## Documentation Checklist

- [x] Project spec updated — §4 map card behavior, changelog 1.0.24
- [x] CLAUDE.md — no architecture change
- [x] README.md — no public-facing feature change

## Testing Checklist

- [x] Manually tested the happy path — verified against live data: Moonlight (recurring only) is unaffected, 1 entry before and after
- [x] Tested edge cases — see below
- [x] Checked for regressions — `validate-data.js` and the CSS-order gate pass

## Reviewer note: this makes five map cards schedule-less

Five active venues with coordinates have **only** past one-time events, so filtering leaves their card schedule empty:

| Venue | Only event |
|---|---|
| Black Sparrow Music Parlor | Feb 5, 2026 |
| Cheer Up Charlie's | Feb 24, 2026 |
| Meridian Buda | May 23, 2026 |
| The Highball | Jun 27, 2026 (3 past entries) |
| Wanderlust Wine (Shady Ln) | Jul 25, 2026 |

`renderScheduleCompact([])` returns an empty string, so the card shows name, tags, address and directions with no schedule line.

I'd argue that's still better than the current behavior, which presents a five-month-old event as though it were live. But the real problem it exposes is data staleness, not display: these venues are marked active and pinned on the map with nothing upcoming. Filed separately rather than widening this PR.