### PR TITLE
Add three August Xpider dates at The Highball

### DIFF
--- a/js/data.json
+++ b/js/data.json
@@ -1248,6 +1248,39 @@
             "affiliation": "Story-Oke Austin",
             "website": "https://www.storyokeaustin.com/"
           }
+        },
+        {
+          "frequency": "once",
+          "date": "2026-08-01",
+          "startTime": "21:00",
+          "endTime": "01:00",
+          "eventName": "Karaoke with Xpider @ Highball!",
+          "host": {
+            "name": "Xpider Cantu",
+            "website": "https://www.xpidermagic.com/karaoke"
+          }
+        },
+        {
+          "frequency": "once",
+          "date": "2026-08-07",
+          "startTime": "21:00",
+          "endTime": "01:00",
+          "eventName": "Karaoke with Xpider @ Highball!",
+          "host": {
+            "name": "Xpider Cantu",
+            "website": "https://www.xpidermagic.com/karaoke"
+          }
+        },
+        {
+          "frequency": "once",
+          "date": "2026-08-22",
+          "startTime": "21:00",
+          "endTime": "01:00",
+          "eventName": "Karaoke with Xpider @ Highball!",
+          "host": {
+            "name": "Xpider Cantu",
+            "website": "https://www.xpidermagic.com/karaoke"
+          }
         }
       ],
       "socials": {


### PR DESCRIPTION
## Summary

Three one-time events for Xpider Cantu at The Highball — **Aug 1, Aug 7, Aug 22** — copied from the venue''s existing Xpider entry so the name, hours and host all match.

## Related Issue

No ticket — routine venue data curation, per the "Adding a New Venue" flow in CLAUDE.md. Happy to open one if you''d rather have it tracked on the board.

## Changes

Three `frequency: "once"` entries added to `the-highball`:

```json
{
  "frequency": "once",
  "date": "2026-08-01",
  "startTime": "21:00",
  "endTime": "01:00",
  "eventName": "Karaoke with Xpider @ Highball!",
  "host": { "name": "Xpider Cantu", "website": "https://www.xpidermagic.com/karaoke" }
}
```

…and the same for Aug 7 and Aug 22. Highball goes from 3 to 6 schedule entries.

**No `eventUrl`** — the source show doesn''t have one, and the Story-Oke Facebook links on neighbouring entries belong to different events, so nothing was borrowed.

## Documentation Checklist

- [x] No documentation updates needed (data-only change)

## Testing Checklist

- [x] Manually tested the happy path — rendered in the browser on the correct days: **Sat 8/1**, **Fri 8/7**, **Sat 8/22**, each showing "9:00 PM - 1:00 AM". No console errors
- [x] Tested edge cases — each entry matches its own date and not the day before; all three read as upcoming, while the existing Jun 27 Xpider entry still flags as past so the #88 map filter keeps hiding it
- [x] Checked for regressions — `validate-data.js` passes at 80 venues

## Notes for the reviewer

**Month assumption:** August 2026. Today is July 30, so the 1st/7th/22nd of July are past and August is the only forward-looking reading. Easy to change if a different month was meant.

**Curator master updated too.** The same three entries were added to `data-curated.js`, verified in sync afterwards (0 differing venues), so this doesn''t reopen the #125 drift.

**Pre-existing, now more visible:** the weekly card''s "Also" line lists every other one-time date at the venue including stale ones — Aug 1''s card reads *"Also May 30, Jun 27, Jun 27, Aug 7, Aug 22"*. Two are months past and Jun 27 repeats because two events share that date. Unlike the map card that #88 just fixed, that text has no past-date filter. Not addressed here.