### PR TITLE
#131: Make the KJ index searchable and sort past stage titles

### DIFF
--- a/css/views.css
+++ b/css/views.css
@@ -1297,6 +1297,44 @@ body.view--map .app-layout__detail {
     font-size: var(--font-size-base);
 }
 
+.kj-index__filter {
+    position: relative;
+    margin-top: var(--spacing-md);
+}
+
+.kj-index__filter-icon {
+    position: absolute;
+    left: var(--spacing-sm);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-secondary);
+    pointer-events: none;
+    font-size: var(--font-size-sm);
+}
+
+.kj-index__filter-input {
+    width: 100%;
+    /* Left padding clears the icon; 44px min-height keeps the tap target usable */
+    padding: var(--spacing-sm) var(--spacing-sm) var(--spacing-sm) calc(var(--spacing-sm) * 2 + 1em);
+    min-height: 44px;
+    font-size: var(--font-size-base);
+    color: var(--text-primary);
+    background: var(--bg-card);
+    border: 1px solid var(--border-color);
+    border-radius: var(--border-radius);
+}
+
+.kj-index__filter-input:focus {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+.kj-index__no-matches {
+    margin: var(--spacing-lg) 0;
+    text-align: center;
+    color: var(--text-secondary);
+}
+
 .kj-index__empty {
     color: var(--text-secondary);
     font-size: var(--font-size-base);

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -521,6 +521,9 @@ Venues with an `activePeriod` field only appear when the current date falls with
 - **URL-driven:** `index.html?kj=all` renders `KJIndexView` — an alphabetical directory of every unique KJ name in the dataset.
 - **Source:** Walks every active venue and collects names from `venue.host.{name,company}` and per-show `schedule[N].host.{name,company}`. Case-insensitive de-dupe (display name preserved from first occurrence).
 - **Each entry:** KJ name + venue count, linking to `?kj=<encoded name>` (real anchor — page reloads into `KJDossierView`).
+- **Two sections:** "Companies" (each a clickable parent with its KJs nested beneath) and "Independent KJs" (no company recorded).
+- **Sorting ignores stage titles.** Entries sort on `getSortableHostName()` from `js/utils/string.js`, which strips a leading `KJ`/`DJ`/`MC` and then applies the same article handling as venue names. Display is unchanged — this is the sort key only. Without it, sorting is literal and scatters people by prefix: "KJ Armando and Paola" lands eight rows from "Armando", and "DJ Cysum & Mo" files under D instead of C.
+- **Filter box:** matches **both** KJ and company names as you type, so either half of what a visitor remembers finds the row. A company stays visible if it matches *or* any of its KJs does; when only a KJ matches, the company is shown with just that KJ beneath it (searching "Stephanie" surfaces her via Starling Karaoke). Sections with no surviving rows hide entirely; when nothing matches, "No KJ or company matches that." Filtering is done in the DOM rather than by re-rendering, so the input keeps focus and caret position between keystrokes.
 - **Chip:** Reads "All KJs" (special-cased) instead of the literal "all". × exits to weekly view.
 - **Empty state:** "No KJs found in the directory." (renders when data has zero host fields populated).
 
@@ -1266,6 +1269,7 @@ Each public page includes a `<link rel="canonical">` tag pointing to its canonic
 | 2026-06 | 1.0.23 | Exclusion Dates feature (#3–#8): recurring shows can be marked closed on specific dates via `schedule[].exclusions` (`"YYYY-MM-DD"` shorthand or `{date, reason}`). Weekly cards dim with a "Closed" banner; Map dims the marker and shows a "Closed Today" card banner; detail modal/pane/map-expanded show a "Closed Today" banner plus an "Upcoming closures" list (next 60 days). Added `getVenueExclusionForDate()` and `getUpcomingExclusions()` to `date.js`. New §11 "Schedule Exclusions"; updated §2, §4, §7, §8. | Claude Code |
 | 2026-07 | 1.0.24 | #88: Map venue card now hides `frequency: "once"` entries dated before today (both summary and detail schedule). Added `isPastOnceEvent()` helper to `js/utils/date.js`. VenueModal and VenueDetailPane unchanged. Updated Section 4. | Claude Code |
 | 2026-07 | 1.0.25 | #137: Compact card "Also …" indicator now omits past one-time events, reusing `isPastOnceEvent()`. Recurring entries unaffected; a venue whose only other entries are past shows no "Also" line. Updated Sections 2 and 6. | Claude Code |
+| 2026-07 | 1.0.26 | #131: KJ index gains a filter box matching KJ *and* company names, and sorts on `getSortableHostName()` so stage titles (KJ/DJ/MC) no longer scatter names alphabetically. "Affiliations" section renamed "Companies". Updated Section 10. | Claude Code |
 
 ---
 

--- a/js/utils/string.js
+++ b/js/utils/string.js
@@ -55,6 +55,33 @@ export function getSortableName(name) {
     return name;
 }
 
+// Stage titles that precede a host's actual name. Sorting on the literal string
+// scatters people by their prefix — "KJ Average Joe" lands under K, eight rows
+// from "Average Joe" — so these are stripped for sort purposes only.
+const HOST_TITLES = ['kj', 'dj', 'mc'];
+
+/**
+ * Get sortable host name: drops a leading stage title, then applies the same
+ * article handling as venue names. Display is never changed — this is the sort
+ * key only.
+ *
+ *   "KJ Average Joe"          → "Average Joe"
+ *   "DJ Cysum & Mo"           → "Cysum & Mo"
+ *   "The Karaoke Underground" → "Karaoke Underground, The"
+ *
+ * @param {string} name - Host or company name
+ * @returns {string} Sortable form
+ */
+export function getSortableHostName(name) {
+    if (!name) return '';
+    const words = name.trim().split(/\s+/);
+    const lead = words[0].toLowerCase().replace(/\./g, '');
+    const withoutTitle = words.length > 1 && HOST_TITLES.includes(lead)
+        ? words.slice(1).join(' ')
+        : name;
+    return getSortableName(withoutTitle);
+}
+
 /**
  * Convert string to URL-safe slug
  * @param {string} str - String to slugify

--- a/js/views/KJIndexView.js
+++ b/js/views/KJIndexView.js
@@ -20,9 +20,60 @@
 import { Component } from '../components/Component.js';
 import { getAllVenues } from '../services/venues.js';
 import { getVenueHosts } from '../utils/render.js';
-import { escapeHtml } from '../utils/string.js';
+import { escapeHtml, getSortableHostName } from '../utils/string.js';
 
 export class KJIndexView extends Component {
+    /**
+     * Filter rows in place against the search box. Done in the DOM rather than by
+     * re-rendering so the input keeps focus and the caret between keystrokes.
+     *
+     * A company row survives if the company matches OR any of its KJs does; when
+     * only a KJ matches, the company stays visible but shows just that KJ — so
+     * searching either half of "KJ Stephanie / Starling Karaoke" finds the show.
+     */
+    applyFilter(query) {
+        const q = query.trim().toLowerCase();
+        let visible = 0;
+
+        for (const group of this.$$('.kj-index__group')) {
+            const companyMatch = !q || (group.dataset.search || '').includes(q);
+            let kjMatches = 0;
+
+            for (const sub of group.querySelectorAll('.kj-index__subitem')) {
+                const hit = !q || companyMatch || (sub.dataset.search || '').includes(q);
+                sub.hidden = !hit;
+                if (hit) kjMatches++;
+            }
+
+            const show = companyMatch || kjMatches > 0;
+            group.hidden = !show;
+            if (show) visible++;
+        }
+
+        for (const item of this.$$('.kj-index__item')) {
+            const hit = !q || (item.dataset.search || '').includes(q);
+            item.hidden = !hit;
+            if (hit) visible++;
+        }
+
+        // Hide a section entirely once every row inside it is filtered out
+        for (const section of this.$$('.kj-index__section')) {
+            const anyVisible = [...section.querySelectorAll('.kj-index__group, .kj-index__item')]
+                .some(el => !el.hidden);
+            section.hidden = !anyVisible;
+        }
+
+        const empty = this.$('.kj-index__no-matches');
+        if (empty) empty.hidden = visible > 0;
+    }
+
+    afterRender() {
+        const input = this.$('.kj-index__filter-input');
+        if (!input) return;
+        this.addEventListener(input, 'input', (e) => this.applyFilter(e.target.value));
+        this.addEventListener(input, 'search', (e) => this.applyFilter(e.target.value));
+    }
+
     template() {
         const { affiliations, independents, noHostCount } = this.collectIndex();
 
@@ -48,15 +99,24 @@ export class KJIndexView extends Component {
                         All KJs
                     </h2>
                     <p class="kj-index__stats">
-                        ${affiliations.length} affiliation${affiliations.length !== 1 ? 's' : ''}
+                        ${affiliations.length} compan${affiliations.length !== 1 ? 'ies' : 'y'}
                         · ${totalKjs} KJ${totalKjs !== 1 ? 's' : ''}.
                         Click any name to see their venues.
                     </p>
+                    <div class="kj-index__filter">
+                        <i class="fa-solid fa-magnifying-glass kj-index__filter-icon"></i>
+                        <input type="search" class="kj-index__filter-input"
+                               placeholder="Filter by KJ or company…"
+                               aria-label="Filter by KJ or company name"
+                               autocomplete="off" autocapitalize="off" spellcheck="false">
+                    </div>
                 </header>
+
+                <p class="kj-index__no-matches" hidden>No KJ or company matches that.</p>
 
                 ${affiliations.length > 0 ? `
                     <section class="kj-index__section">
-                        <h3 class="kj-index__section-title">Affiliations</h3>
+                        <h3 class="kj-index__section-title">Companies</h3>
                         <ul class="kj-index__list">
                             ${affiliations.map(a => this.renderAffiliation(a)).join('')}
                         </ul>
@@ -155,8 +215,11 @@ export class KJIndexView extends Component {
             if (!attributed) noHostCount++;
         });
 
+        // Sort on the stage-title-stripped form so "KJ Average Joe" files under A
+        // next to "Average Joe", and "DJ Cysum & Mo" under C rather than D.
         const sortByName = (a, b) =>
-            a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+            getSortableHostName(a.name).localeCompare(
+                getSortableHostName(b.name), undefined, { sensitivity: 'base' });
 
         const affiliationList = [...affiliations.values()]
             .map(a => ({
@@ -185,7 +248,7 @@ export class KJIndexView extends Component {
             `
             : '';
         return `
-            <li class="kj-index__group">
+            <li class="kj-index__group" data-search="${escapeHtml(name.toLowerCase())}">
                 <a class="kj-index__link kj-index__link--affiliation" href="${href}">
                     <span class="kj-index__name">${escapeHtml(name)}</span>
                     <span class="kj-index__count">${venueCount} venue${venueCount !== 1 ? 's' : ''}</span>
@@ -198,7 +261,7 @@ export class KJIndexView extends Component {
     renderKjUnderAffiliation({ name, venueCount }) {
         const href = `?kj=${encodeURIComponent(name)}`;
         return `
-            <li class="kj-index__subitem">
+            <li class="kj-index__subitem" data-search="${escapeHtml(name.toLowerCase())}">
                 <a class="kj-index__link kj-index__link--kj" href="${href}">
                     <span class="kj-index__name">${escapeHtml(name)}</span>
                     <span class="kj-index__count">${venueCount} venue${venueCount !== 1 ? 's' : ''}</span>
@@ -210,7 +273,7 @@ export class KJIndexView extends Component {
     renderIndependent({ name, venueCount }) {
         const href = `?kj=${encodeURIComponent(name)}`;
         return `
-            <li class="kj-index__item">
+            <li class="kj-index__item" data-search="${escapeHtml(name.toLowerCase())}">
                 <a class="kj-index__link" href="${href}">
                     <span class="kj-index__name">${escapeHtml(name)}</span>
                     <span class="kj-index__count">${venueCount} venue${venueCount !== 1 ? 's' : ''}</span>


### PR DESCRIPTION
## Summary

Two things made the KJ index hard to search, both of them visible in the rendered output.

**Sorting was literal**, so a stage title decided where someone filed:

> Andy Hartsock, Armando, Bee Purrs, Dan DeSetto, **DJ Cysum & Mo**, Erin Hierholzer, John Roberts, Kevin, **KJ Armando and Paola**, …

"KJ Armando and Paola" sat eight rows from "Armando", and "DJ Cysum & Mo" filed under D. Before #132 merged, "Average Joe" and "KJ Average Joe" were at opposite ends of Starling''s roster.

**And there was no search** on a 30-row page — you had to know whether your KJ was independent or under a company before you could find them.

## Related Issue

Fixes #131 (the parts that don''t depend on #124 Phase 2 — id-based `?kj=` links remain open there)

## Changes

- `getSortableHostName()` added to `js/utils/string.js` — strips a leading `KJ`/`DJ`/`MC`, then reuses `getSortableName()`''s article handling. **Sort key only; display is untouched**
- `KJIndexView` sorts on it, at both the top level and inside company rosters
- **Filter box** matching KJ *and* company names together. A company survives if it matches or any of its KJs does; when only a KJ matches, the company shows with just that KJ beneath it
- Filtering runs over the DOM instead of re-rendering, so the input keeps focus and caret between keystrokes
- "Affiliations" section renamed **"Companies"**, matching the language used everywhere else
- Spec §10 and changelog 1.0.26

## Documentation Checklist

- [x] Project spec updated — §10 KJ Index, changelog
- [x] CLAUDE.md — no architecture change
- [x] README.md — no public-facing structural change

## Testing Checklist

- [x] Manually tested the happy path — sort order now reads: Andy Hartsock, **Armando, KJ Armando and Paola**, Bee Purrs, **DJ Cysum & Mo**, Dan DeSetto, … (duo adjacent to Armando; Cysum under C)
- [x] Tested edge cases — all four filter paths verified live:
  - `starling` → company + full roster
  - `stephanie` → Starling shown with **only** KJ Stephanie
  - `xpider` → independent only, companies hidden
  - `zzzz` → "No KJ or company matches that."
  - cleared → everything restored
- [x] Checked for regressions — validator and CSS-order gate pass; no console errors; at 375px the input is a **44px tap target** with no horizontal scroll

## Still open on #131

The id-based `?kj=` links (killing the substring collision where `?kj=Armando` also matches the duo) need the registries from #124 Phase 2, so they stay on the ticket.