### PR TITLE
#135: Warn when an active venue has no upcoming events

### DIFF
--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -5,8 +5,9 @@
  * (unique venue ids, tag-id and host-ref cross-reference) and data-quality
  * heuristics (minute-typo detection, noon end-time after evening start).
  *
- * Registry hygiene (unreferenced or same-named kjs/companies entries) is
- * reported as warnings — worth a look, but not a build failure.
+ * Registry hygiene (unreferenced or same-named kjs/companies entries) and
+ * stale venues (active, but every event is in the past) are reported as
+ * warnings — worth a look, but not a build failure.
  *
  * Exits non-zero on failure — suitable as a pre-commit / CI gate. Enforced
  * by .github/workflows/ci.yml.
@@ -171,6 +172,32 @@ for (const [label, registry] of [['kjs', KJS], ['companies', COMPANIES]]) {
             warnings.push(`${label} entries share the name "${registry[ids[0]].name}": ${ids.join(', ')} — merge?`);
         }
     }
+}
+
+// ---- Stale venue check (#135) ----
+// An active venue whose events are all in the past has nothing to advertise, but
+// still renders a marker on the map and a card in the A-Z listing. Warned rather
+// than failed: the fix needs real-world knowledge (did they stop hosting, or is
+// our data just behind?), and only the curator can tell those apart.
+const TODAY = new Date();
+TODAY.setHours(0, 0, 0, 0);
+
+for (const venue of data.listings) {
+    if (venue.active === false) continue;
+    const schedule = Array.isArray(venue.schedule) ? venue.schedule : [];
+
+    const hasRecurring = schedule.some(e => e.frequency !== 'once');
+    const hasUpcoming = schedule.some(e => {
+        if (e.frequency !== 'once' || !e.date) return false;
+        return new Date(e.date + 'T00:00:00') >= TODAY;
+    });
+    if (hasRecurring || hasUpcoming) continue;
+
+    const lastDate = schedule.map(e => e.date).filter(Boolean).sort().pop();
+    warnings.push(
+        `${venue.name} (${venue.id}) is active but has no upcoming events` +
+        (lastDate ? ` — most recent was ${lastDate}` : ' — no dated entries at all')
+    );
 }
 
 // ---- Output ----


### PR DESCRIPTION
## Summary

Five venues are marked active and pinned on the map while every event they have is in the past. `validate-data.js` now warns about them at commit time instead of leaving them to be noticed by a visitor.

## Related Issue

Fixes #135 (the tooling half — curating the five venues stays with you)

## Changes

`validate-data.js` warns for any active venue with **no recurring entries and no future-dated one-times**, naming the most recent date so the staleness is obvious:

```
=== 5 Warning(s) — not fatal ===
- Black Sparrow Music Parlor (black-sparrow-music-parlor) is active but has no upcoming events — most recent was 2026-02-05
- Cheer Up Charlie''s (cheer-up-charlies) is active but has no upcoming events — most recent was 2026-02-24
- The Highball (the-highball) is active but has no upcoming events — most recent was 2026-06-27
- Meridian Buda (meridian-buda) is active but has no upcoming events — most recent was 2026-05-23
- Wanderlust Wine (Shady Ln) (wanderlust-wine-shady) is active but has no upcoming events — most recent was 2026-07-25
```

## Why a warning and not a failure

The fix needs knowledge the repo doesn''t have: **did the venue stop hosting, or is our data just behind?** Only you can tell those apart, and `active: false` already exists for the first case. Auto-filtering them out of the map and A–Z (option 2 on the ticket) would conflate the two and silently hide venues whose data is merely stale.

This is option 3 from the ticket — the cheap part that turns "discovered by accident" into "the tooling tells you." Option 1, curating the five, is still yours.

## Documentation Checklist

- [x] No spec change — validator behavior, documented in the script header
- [x] CLAUDE.md / README.md — no change

## Testing Checklist

- [x] Manually tested the happy path — flags exactly the five known venues, **exits 0** so CI stays green
- [x] Tested edge cases — re-ran against the `#136` branch, where The Highball gains three August dates: it **drops off the list** (5 warnings → 4). Confirms the check clears on genuine upcoming events, not merely on the record being edited
- [x] Checked for regressions — no new errors; CSS-order gate passes

## Note

The Highball will stop being flagged the moment #136 merges. The other four need a real decision from you: current schedule, or `active: false`.