### PR TITLE
#124 Phase 3: Submit form suggests known hosts and emits refs when they match

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -926,7 +926,7 @@ The form is structured as a short required-fields zone, then a single `<details>
 | Section | Fields |
 |---------|--------|
 | Tags | Tag checkboxes (chip-style) generated at load by fetching `tagDefinitions` from `js/data.json` — adding a tag there auto-surfaces here, no parallel hardcoded list. System tags (`dedicated`, `special-event`) and age tags are excluded from the grid; age restriction is its own radio (not sure / 21+ / 18+ / all-ages / family-friendly) whose value joins the `tags: []` array at submit time, matching the schema's "age is a tag" shape. |
-| Host / KJ Info | Host name, company, host website |
+| Who runs it | KJ name, company, website — either or both, mirroring the host model (§11). Both text inputs carry a `<datalist>` of names from the `kjs` / `companies` registries in `js/data.json`, so typing suggests hosts already in the directory. See "Host matching on submit" below. |
 | Venue Social Links | Website, Facebook, Instagram (3 fields — other platforms intentionally cut to reduce friction; curator can add via editor) |
 | Notes | Free-text textarea |
 | Your Contact Info | Submitter name (required if KJ); contact methods checkboxes (email, phone text, phone call, other), each reveals its input on check |
@@ -967,6 +967,19 @@ Hidden honeypot field `website_url` (positioned offscreen via `.hp-field` CSS) w
 ### Email body format
 
 `formatEmailBody()` produces a structured plaintext email containing the full venue object as JSON between two `----...----` delimiter lines, plus submitter metadata and a TODO checklist (verify info, geocode, add to data.json). The JSON block is intended to be copy-paste-ready for the curator's editor workflow.
+
+### Host matching on submit (#124 Phase 3)
+
+The form can't ask a visitor for a registry id, so both host fields stay free text — but they carry a `<datalist>` of every name in `kjs` and `companies`, so typing suggests hosts already in the directory and most submissions land on an exact name.
+
+At submit time each typed name is matched against its registry, exact and case-insensitive:
+
+- **Both sides resolve** (or one resolves and the other is blank) → the payload carries a **`{ kjId?, companyId? }` ref**, ready for the curator to accept as-is.
+- **Anything unrecognised** → the whole host falls back to the **legacy inline shape** for reconciliation. It's all-or-nothing per host, because the schema's `oneOf` forbids mixing ids with free text.
+
+The **host website** is dropped from the ref form deliberately: it belongs on the registry record rather than the venue, and a submitter can't say which of the two it's for. It's carried in the email body instead so nothing is lost.
+
+The email body gains a **HOST** section stating which path was taken — either the ids that matched, or which name is new and needs a registry entry created first.
 
 ### Payload shape contract (#101)
 
@@ -1270,6 +1283,7 @@ Each public page includes a `<link rel="canonical">` tag pointing to its canonic
 | 2026-07 | 1.0.24 | #88: Map venue card now hides `frequency: "once"` entries dated before today (both summary and detail schedule). Added `isPastOnceEvent()` helper to `js/utils/date.js`. VenueModal and VenueDetailPane unchanged. Updated Section 4. | Claude Code |
 | 2026-07 | 1.0.25 | #137: Compact card "Also …" indicator now omits past one-time events, reusing `isPastOnceEvent()`. Recurring entries unaffected; a venue whose only other entries are past shows no "Also" line. Updated Sections 2 and 6. | Claude Code |
 | 2026-07 | 1.0.26 | #131: KJ index gains a filter box matching KJ *and* company names, and sorts on `getSortableHostName()` so stage titles (KJ/DJ/MC) no longer scatter names alphabetically. "Affiliations" section renamed "Companies". Updated Section 10. | Claude Code |
+| 2026-07 | 1.0.27 | #124 Phase 3: submit form's host fields suggest known KJs/companies from the registries and emit a `{kjId, companyId}` ref when both sides match, falling back to the inline shape otherwise. Email body gains a HOST section saying which it was. Updated Section 15. | Claude Code |
 
 ---
 

--- a/submit.html
+++ b/submit.html
@@ -217,20 +217,23 @@
                             </fieldset>
 
                             <fieldset class="form-section">
-                                <legend><i class="fa-solid fa-microphone"></i> Host / KJ Info</legend>
+                                <legend><i class="fa-solid fa-microphone"></i> Who runs it</legend>
+                                <p class="form-hint">A KJ, a company, or both — whatever you know. Start typing and we'll suggest hosts already in the directory; picking a suggestion helps us match your submission to the right person.</p>
                                 <div class="form-row">
                                     <div class="form-group">
-                                        <label for="host-name">Host Name</label>
-                                        <input type="text" id="host-name" name="host-name" autocomplete="off" placeholder="e.g., DJ Mike">
+                                        <label for="host-name">KJ name</label>
+                                        <input type="text" id="host-name" name="host-name" autocomplete="off" list="known-kjs" placeholder="e.g., DJ Mike">
+                                        <datalist id="known-kjs"></datalist>
                                     </div>
                                     <div class="form-group">
-                                        <label for="affiliation">Affiliation</label>
-                                        <input type="text" id="affiliation" name="affiliation" autocomplete="off" placeholder="e.g., Karaoke Kings">
+                                        <label for="affiliation">Company</label>
+                                        <input type="text" id="affiliation" name="affiliation" autocomplete="off" list="known-companies" placeholder="e.g., Karaoke Kings">
+                                        <datalist id="known-companies"></datalist>
                                     </div>
                                 </div>
                                 <div class="form-row">
                                     <div class="form-group form-group--full">
-                                        <label for="host-website">Host / Affiliation Website</label>
+                                        <label for="host-website">KJ / company website</label>
                                         <input type="url" id="host-website" name="host-website" inputmode="url" placeholder="https://">
                                     </div>
                                 </div>
@@ -378,13 +381,42 @@
             '21+', '18+', 'all-ages', 'family-friendly',
         ]);
 
-        // Tag definitions are fetched from js/data.json (ADR-008) and cached here,
-        // so the submit handler can read the same id list without refetching.
-        // Only tagDefinitions is used — the venue listings are never needed here.
+        // Tag definitions and the host registries are fetched from js/data.json
+        // (ADR-008) and cached here, so the submit handler can read them without
+        // refetching. The venue listings are never needed on this page.
         let tagDefinitions = {};
+        let knownKjs = {};        // id → { name, ... }  (ADR-007 registries)
+        let knownCompanies = {};
 
         function getUserSelectableTagIds() {
             return Object.keys(tagDefinitions).filter(id => !TAG_GRID_EXCLUDE.has(id));
+        }
+
+        /**
+         * Resolve a typed host name to a registry id, exact and case-insensitive.
+         * A submitter who picks a datalist suggestion lands here; anyone typing a
+         * new name doesn't, and their text is passed through for the curator to
+         * reconcile. Returns null when there's no match.
+         */
+        function matchRegistryId(registry, typed) {
+            const q = (typed || '').trim().toLowerCase();
+            if (!q) return null;
+            const hit = Object.entries(registry).find(([, e]) => (e.name || '').trim().toLowerCase() === q);
+            return hit ? hit[0] : null;
+        }
+
+        /** Fill a <datalist> with the registry's names, so typing suggests known hosts. */
+        function populateHostSuggestions() {
+            for (const [listId, registry] of [['known-kjs', knownKjs], ['known-companies', knownCompanies]]) {
+                const list = document.getElementById(listId);
+                if (!list) continue;
+                list.innerHTML = Object.values(registry)
+                    .map(e => e.name)
+                    .filter(Boolean)
+                    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+                    .map(n => `<option value="${n.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;')}"></option>`)
+                    .join('');
+            }
         }
 
         // Generate the tag-checkbox grid from data.json's tagDefinitions so that
@@ -397,7 +429,11 @@
             try {
                 const response = await fetch('js/data.json');
                 if (!response.ok) throw new Error(`HTTP ${response.status}`);
-                tagDefinitions = (await response.json()).tagDefinitions || {};
+                const data = await response.json();
+                tagDefinitions = data.tagDefinitions || {};
+                knownKjs = data.kjs || {};
+                knownCompanies = data.companies || {};
+                populateHostSuggestions();
             } catch (error) {
                 console.error('Could not load tag definitions from js/data.json:', error);
                 grid.innerHTML = '<p class="validation-error">Could not load the tag list. Everything else on this form still works.</p>';
@@ -775,18 +811,57 @@
                 if (activePeriodEnd) venue.activePeriod.end = activePeriodEnd;
             }
 
-            // Optional: Host info. Schema requires name OR affiliation when host
+            // Optional: host info. Schema requires name OR affiliation when host
             // exists, so we don't emit a website-only host — the curator would
             // need at least one identifying field to do anything with it.
             const hostName = formData.get('host-name')?.trim();
             const affiliation = formData.get('affiliation')?.trim();
             const hostWebsite = formData.get('host-website')?.trim();
 
+            // Prefer a registry ref (ADR-007) when the typed names resolve to known
+            // hosts — that's a submission the curator can accept as-is. Anything
+            // unrecognised falls back to the legacy inline shape for reconciliation.
+            //
+            // It's all-or-nothing per host: the schema's oneOf forbids mixing ids
+            // with free text, so one new name means the whole host stays inline.
+            const kjId = matchRegistryId(knownKjs, hostName);
+            const companyId = matchRegistryId(knownCompanies, affiliation);
+            const kjResolved = !hostName || kjId;
+            const companyResolved = !affiliation || companyId;
+
+            let hostNote = '';
             if (hostName || affiliation) {
-                venue.host = {};
-                if (hostName) venue.host.name = hostName;
-                if (affiliation) venue.host.affiliation = affiliation;
-                if (hostWebsite) venue.host.website = hostWebsite;
+                if (kjResolved && companyResolved) {
+                    venue.host = {};
+                    if (kjId) venue.host.kjId = kjId;
+                    if (companyId) venue.host.companyId = companyId;
+
+                    const matched = [
+                        kjId ? `KJ "${hostName}" → kjs/${kjId}` : null,
+                        companyId ? `company "${affiliation}" → companies/${companyId}` : null,
+                    ].filter(Boolean).join('\n');
+                    hostNote = `Matched existing registry entries — host can be accepted as-is:\n${matched}`;
+
+                    // The website is deliberately dropped from the JSON: it belongs on
+                    // the registry record, not the venue, and the submitter can't say
+                    // which of the two it's for. Carried here so it isn't lost.
+                    if (hostWebsite) {
+                        hostNote += `\n\nSubmitter also gave a website: ${hostWebsite}`
+                            + `\n(Not in the JSON — add it to whichever registry entry it belongs to.)`;
+                    }
+                } else {
+                    venue.host = {};
+                    if (hostName) venue.host.name = hostName;
+                    if (affiliation) venue.host.affiliation = affiliation;
+                    if (hostWebsite) venue.host.website = hostWebsite;
+
+                    const unknown = [
+                        hostName && !kjId ? `KJ "${hostName}"` : null,
+                        affiliation && !companyId ? `company "${affiliation}"` : null,
+                    ].filter(Boolean).join(' and ');
+                    hostNote = `NOT in the registries yet: ${unknown}.`
+                        + `\nHost is written inline below — create the registry entry (or pick the right existing one) before adding.`;
+                }
             }
 
             // Optional: Venue socials
@@ -838,7 +913,8 @@
                 notes,
                 submitterName,
                 submitterType,
-                contactMethods
+                contactMethods,
+                hostNote
             };
         }
 
@@ -871,6 +947,13 @@
                 });
             }
             body += '\n';
+
+            // Host note: say whether the JSON below carries registry refs (accept
+            // as-is) or free text (needs reconciling), and carry any website that
+            // the ref shape can't hold.
+            if (data.hostNote) {
+                body += 'HOST:\n' + data.hostNote + '\n\n';
+            }
 
             body += 'VENUE JSON (copy/paste ready):\n';
             body += '-'.repeat(40) + '\n';


### PR DESCRIPTION
## Summary

The ticket scoped Phase 3 as *"keep free text, since submitters can''t know registry ids"*. That''s true, but the form already fetches `data.json` for its tag list — so it can do better without asking anything extra of the visitor.

Both host fields now carry a `<datalist>` of every name in the `kjs` / `companies` registries. Typing suggests hosts already in the directory, and when a name matches, the payload carries a **ref** the curator can accept as-is.

## Related Issue

#124 — Phase 3 of 5. Only Phase 5 (dropping legacy inline support) remains.

## How it decides

Each typed name is matched against its registry, exact and case-insensitive:

| Situation | Emitted |
|---|---|
| Both resolve, or one resolves and the other is blank | `{ kjId?, companyId? }` ref |
| Anything unrecognised | Legacy inline `{ name, affiliation, website }` |

All-or-nothing per host — the schema''s `oneOf` forbids mixing ids with free text, so one new name keeps the whole host inline.

The **host website is dropped from the ref form deliberately**: it belongs on the registry record rather than the venue, and a submitter can''t say which of the two it''s for. It''s carried in the email body instead, so nothing is lost.

The email gains a **HOST** section stating which path was taken — the ids that matched, or which name is new and needs a registry entry first.

## Changes

- `submit.html` — datalists populated from the registries; `matchRegistryId()`; ref-or-inline payload logic; HOST section in the email body; fieldset relabelled "Who runs it" with **KJ name** / **Company**
- Spec §15 — new "Host matching on submit" subsection, field table, changelog 1.0.27

## Testing Checklist

- [x] Manually tested the happy path — 24 KJ and 18 company suggestions load; "Xpider Cantu" + "Starling Karaoke" emits `{"kjId":"xpider-cantu","companyId":"starling-karaoke"}`
- [x] Tested edge cases — all four verified live:
  - **unknown KJ + known company** → inline fallback, note reads *NOT in the registries yet: KJ "Brand New Person"*
  - **company only, matched** → `{"companyId":"karaoke-underground"}`
  - **KJ only + website** → `{"kjId":"xpider-cantu"}`, website carried in the email note
  - **both matched** → both ids
- [x] Checked for regressions — every emitted venue validates against `venue.schema.json` **and** every ref resolves in the registries; validator and CSS gate pass; no console errors

## Note

This is why the schema keeps accepting the legacy inline shape — the fallback path still needs it. Phase 5 can only drop it if we''re willing to reject submissions naming a host we don''t know yet, which would be the wrong trade.