### PR TITLE
Credit Poppy at Jackalope South Shore (Showpony Lounge)

### DIFF
--- a/js/data.json
+++ b/js/data.json
@@ -1674,7 +1674,9 @@
           "endTime": "02:00"
         }
       ],
-      "host": null,
+      "host": {
+        "companyId": "poppin-off-with-poppy-karaoke"
+      },
       "socials": {
         "facebook": "https://www.facebook.com/thejackalopebaratx/",
         "instagram": "https://www.instagram.com/thejackalopebar/",


### PR DESCRIPTION
## Summary

Sets the venue-level host for **Jackalope South Shore (Showpony Lounge)** to Poppin'' Off with Poppy Karaoke — was `host: null`, one of the venues flagged hostless in the earlier audit.

## Related Issue

No ticket — routine venue data curation, per the "Adding a New Venue" flow in CLAUDE.md (same precedent as #136, #144).

## Changes

```json
"host": {
  "companyId": "poppin-off-with-poppy-karaoke"
}
```

Reuses the existing registry entry — same company already credited at Shooters (Austin) and Shooters (Cedar Park). No new registry entry needed.

25 venues share `host: null`, so the edit needed a large context block (the venue''s full Thu/Fri/Sun schedule shape plus its Facebook URL) to land on the right record without touching the others.

## Documentation Checklist

- [x] No documentation updates needed (data-only change)

## Testing Checklist

- [x] Manually tested the happy path — `validate-data.js` passes clean, no new issues or warnings
- [x] Tested edge cases — schedule unchanged (3 entries, all still 21:00 start), host resolves live to "Poppin'' Off with Poppy Karaoke", null-host count drops 25 -> 24
- [x] Checked for regressions — no console errors; CSS load-order gate passes

## Note

The curator''s `data-curated.js` carries the same change, verified to match the repo.