### PR TITLE
#146: Deactivate the karaoke lyric ticker in the site header

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,24 @@
 -->
 
     <header class="site-header">
+        <!--
+             Karaoke lyric ticker (DISABLED).
+
+             Cycles song excerpts across the header like a karaoke screen, hiding the
+             title and tagline while a song plays. Driver: the guarded IIFE near the
+             end of this file. Styles: css/layout.css (.karaoke-video-bg,
+             .karaoke-lyrics, .lyric-line, .scanlines) — left in place and inert.
+
+             Parked in a <template> rather than wrapped in an HTML comment (the way the
+             seasonal snowfall block above is) because the markup carries its own
+             per-song comments, and their terminator would close an enclosing comment
+             early — leaving the rest of the lyrics to render as live markup. Template
+             content is parsed but never rendered, and no styles apply to it.
+
+             To re-enable: delete the <template> open and close tags below. The driver
+             guard passes on its own once these nodes are back in the document.
+        -->
+        <template id="karaoke-ticker">
         <div class="karaoke-video-bg">
             <!-- Song 1: "Lights" by Journey -->
             <div class="karaoke-lyrics" data-song="0">
@@ -77,6 +95,7 @@
 
             <div class="scanlines"></div>
         </div>
+        </template>
 
         <div class="site-header__content">
             <h1 class="site-header__title">Greater Austin Karaoke Directory</h1>
@@ -204,11 +223,17 @@
 
     <script>
         // Header karaoke lyrics animation: cycles through 4 songs with the title shown between.
+        // Currently dormant — the markup is parked in the #karaoke-ticker <template>.
         (function() {
             const header = document.querySelector('.site-header');
             const videoBg = document.querySelector('.karaoke-video-bg');
             const songs = document.querySelectorAll('.karaoke-lyrics');
             const TOTAL_SONGS = songs.length;
+
+            // Ticker disabled: the markup lives inside a <template>, so it is not in the
+            // document and these selectors find nothing. Bail out rather than letting the
+            // first timer fire into an empty song list. Unwrap the template to re-enable.
+            if (!videoBg || TOTAL_SONGS === 0) return;
 
             const TITLE_DISPLAY_TIME = 10000;
             const LYRIC_DISPLAY_TIME = 2500;


### PR DESCRIPTION
## Summary

Deactivates the karaoke lyric ticker in the `index.html` site header. The mechanism stays fully intact and re-enablable — nothing was deleted, the diff is 25 insertions and 0 deletions.

The header now renders statically: gradient, title, tagline, no cycling and no content fade.

## Related Issue

Fixes #146

## Changes

- Ticker markup (`.karaoke-video-bg` and its four song blocks) wrapped in `<template id="karaoke-ticker">` — parsed but never rendered, and no styles apply to it
- Driver IIFE guarded with `if (!videoBg || TOTAL_SONGS === 0) return;` so it no-ops instead of firing its 10s timer into an empty song list
- `css/layout.css` untouched — those rules are inert without the markup and are the part worth keeping

### Why a `<template>` and not the snowfall comment idiom

The seasonal snowfall block directly above is disabled by wrapping it in an HTML comment. That does **not** work here: the lyric markup carries its own `<!-- Song N -->` comments, and the first inner terminator would close the enclosing comment early, leaving the remaining lyrics to render as live markup on the homepage.

Re-enabling is deleting the two `<template>` tags. The driver guard passes on its own once the nodes are back in the document.

## Documentation Checklist

- [ ] Project spec updated (if behavior changed)
- [ ] CLAUDE.md updated (if architecture/structure changed)
- [ ] README.md updated (if public-facing features changed)
- [x] No documentation updates needed

*Neither the spec nor CLAUDE.md documents the lyric ticker — which is itself a gap, now covered by the CLAUDE.md file-tree/spec sweep in #152.*

## Testing Checklist

- [x] Manually tested the happy path
- [x] Tested edge cases (empty input, missing data, etc.)
- [x] Checked for regressions in related features
- [ ] No testing needed (docs-only change)

Verified against the dev server on `localhost:8000`:

| Check | Result |
|---|---|
| Live `.karaoke-lyrics` / `.lyric-line` nodes | `0` / `0` |
| Preserved inside the template | 4 songs, 16 lyric lines |
| `.site-header__content` computed opacity | `1` — title and tagline always visible |
| Header gradient | intact (`linear-gradient(135deg, rgb(30,58,95), rgb(15,39,68))`) |
| Console after 26s idle | no errors — past both the 10s first timer and a full ~22s song cycle |
| `npm run validate:all` | passes; CSS load order OK on all 5 pages |

## Screenshots

Not included — the change is the *absence* of an animation, and the DOM assertions above are stronger evidence than a still frame.

## Note for the reviewer

The four song excerpts are copyrighted lyrics (Journey ×2, Queen, Neil Diamond) and remain in the served HTML even though they are now inert. If the ticker is not coming back soon, replacing them with public-domain or original placeholder text would remove that exposure while keeping the mechanism demonstrable. Not done here — it is a content decision, and this PR is scoped to deactivation.
