### PR TITLE
#147: Escape the ?kj= chip and search value; make escapeHtml attribute-safe

### DIFF
--- a/e2e/security.spec.js
+++ b/e2e/security.spec.js
@@ -1,0 +1,98 @@
+const { test, expect } = require('@playwright/test');
+
+/**
+ * Escaping regressions.
+ *
+ * `?kj=` and the live search box are the only two attacker-reachable inputs in
+ * the app — `app.js` reads `?kj=` straight off the query string into state, and
+ * `Navigation.js` renders both into markup. Both were unescaped, and the
+ * escapeHtml() they should have used did not escape quotes, so wrapping them in
+ * it would not have been enough on its own.
+ */
+
+// Breaks out of a quoted attribute, then out of the element.
+const ATTR_PAYLOAD = '" onfocus="window.__xss=1" autofocus x="';
+const TAG_PAYLOAD = '<img src=x onerror="window.__xss=1">';
+
+test.describe('escaping — URL and search input', () => {
+  test.beforeEach(async ({ page }) => {
+    page.on('dialog', (d) => d.dismiss());
+  });
+
+  test('?kj= tag payload renders as text, injects no element', async ({ page }) => {
+    await page.goto(`/?kj=${encodeURIComponent(TAG_PAYLOAD)}`);
+    await page.waitForSelector('.filter-chip__value');
+
+    // No injected node anywhere in the document
+    expect(await page.locator('img[src="x"]').count()).toBe(0);
+    expect(await page.evaluate(() => window.__xss)).toBeUndefined();
+
+    // ...and the payload survived intact as visible text
+    await expect(page.locator('.filter-chip__value')).toHaveText(TAG_PAYLOAD);
+  });
+
+  test('?kj= attribute-breakout payload does not create attributes', async ({ page }) => {
+    await page.goto(`/?kj=${encodeURIComponent(ATTR_PAYLOAD)}`);
+    const chip = page.locator('.filter-chip__value');
+    await chip.waitFor();
+
+    expect(await page.evaluate(() => window.__xss)).toBeUndefined();
+    await expect(chip).toHaveText(ATTR_PAYLOAD);
+
+    // The chip must carry no attribute the payload tried to smuggle in
+    const attrs = await chip.evaluate((el) => [...el.attributes].map((a) => a.name));
+    expect(attrs).not.toContain('onfocus');
+    expect(attrs).not.toContain('autofocus');
+    expect(attrs).not.toContain('x');
+  });
+
+  test('search value survives a quote payload without breaking out', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('[data-search="query"]').fill(ATTR_PAYLOAD);
+
+    // Navigation deliberately does NOT re-render on searchQuery, to preserve
+    // input focus — so typing alone never regenerates the markup. Toggling the
+    // dedicated filter does, and that is the render that writes searchQuery
+    // back into value="...". Without this the test passes vacuously.
+    await page.locator('[data-filter="dedicated"]').click();
+    await expect(page.locator('[data-search="query"]')).toHaveValue(ATTR_PAYLOAD);
+
+    const input = page.locator('[data-search="query"]');
+    expect(await page.evaluate(() => window.__xss)).toBeUndefined();
+
+    const attrs = await input.evaluate((el) => [...el.attributes].map((a) => a.name));
+    expect(attrs).not.toContain('onfocus');
+    expect(attrs).not.toContain('autofocus');
+    expect(attrs).not.toContain('x');
+  });
+
+  test('escapeHtml escapes quotes as well as angle brackets', async ({ page }) => {
+    await page.goto('/');
+    const result = await page.evaluate(async () => {
+      const { escapeHtml, html, raw } = await import('/js/utils/string.js');
+      const probe = document.createElement('div');
+      probe.innerHTML = `<input value="${escapeHtml('" onfocus=x autofocus y="')}">`;
+      return {
+        quote: escapeHtml('"'),
+        apostrophe: escapeHtml("'"),
+        angle: escapeHtml('<b>'),
+        amp: escapeHtml('a & b'),
+        brokeOut: probe.querySelector('input').hasAttribute('autofocus'),
+        // the tagged template escapes by default and honours raw()
+        tagEscapes: String(html`<p>${'<b>x</b>'}</p>`),
+        tagRaw: String(html`<p>${raw('<b>x</b>')}</p>`),
+        // false and 0 must survive — aria-expanded="${bool}" depends on it
+        tagFalse: String(html`<i a="${false}" b="${0}"></i>`),
+      };
+    });
+
+    expect(result.quote).toBe('&quot;');
+    expect(result.apostrophe).toBe('&#39;');
+    expect(result.angle).toBe('&lt;b&gt;');
+    expect(result.amp).toBe('a &amp; b');
+    expect(result.brokeOut).toBe(false);
+    expect(result.tagEscapes).toBe('<p>&lt;b&gt;x&lt;/b&gt;</p>');
+    expect(result.tagRaw).toBe('<p><b>x</b></p>');
+    expect(result.tagFalse).toBe('<i a="false" b="0"></i>');
+  });
+});

--- a/js/components/Navigation.js
+++ b/js/components/Navigation.js
@@ -16,6 +16,7 @@ import { Component } from './Component.js';
 import { getState, setState, subscribe, navigateWeek, goToCurrentWeek } from '../core/state.js';
 import { emit, Events } from '../core/events.js';
 import { formatWeekRange, getWeekStart } from '../utils/date.js';
+import { html } from '../utils/string.js';
 
 export class Navigation extends Component {
     init() {
@@ -51,13 +52,16 @@ export class Navigation extends Component {
                 chipValue = 'No host listed';
                 chipIcon = 'fa-circle-question';
             }
-            return `
+            // chipValue is `?kj=` verbatim (app.js reads it straight off the
+            // query string), so it is the one attacker-reachable value in the
+            // app. The html tag escapes it.
+            return html`
                 <nav class="navigation navigation--dossier">
                     ${this.renderViewSwitcher({ view, kjIndexActive: isIndex })}
                     <div class="navigation__active-filters">
                         <span class="filter-chip" role="status">
                             <i class="fa-solid ${chipIcon}"></i>
-                            ${chipLabel ? `<span class="filter-chip__label">${chipLabel}</span>` : ''}
+                            ${chipLabel ? html`<span class="filter-chip__label">${chipLabel}</span>` : ''}
                             <span class="filter-chip__value">${chipValue}</span>
                             <button class="filter-chip__clear" data-filter="clear-kj" type="button" aria-label="Exit KJ view">
                                 <i class="fa-solid fa-xmark"></i>
@@ -75,11 +79,11 @@ export class Navigation extends Component {
         const searchQuery = getState('searchQuery') || '';
         const searchOpen = this.searchOpen || !!searchQuery;
 
-        return `
+        return html`
             <nav class="navigation${searchOpen ? ' navigation--search-open' : ''}">
                 ${this.renderViewSwitcher({ view, kjIndexActive: false })}
 
-                ${view === 'weekly' ? `
+                ${view === 'weekly' ? html`
                     <div class="navigation__week">
                         <button class="nav-btn nav-btn--icon" data-week="-1" type="button" title="Previous week">
                             <i class="fa-solid fa-chevron-left"></i>
@@ -88,7 +92,7 @@ export class Navigation extends Component {
                         <button class="nav-btn nav-btn--icon" data-week="1" type="button" title="Next week">
                             <i class="fa-solid fa-chevron-right"></i>
                         </button>
-                        ${!isCurrentWeek ? `
+                        ${!isCurrentWeek ? html`
                             <button class="nav-btn nav-btn--small" data-week="today" type="button">
                                 Today
                             </button>
@@ -106,7 +110,7 @@ export class Navigation extends Component {
                             data-search="query"
                             value="${searchQuery}"
                         >
-                        ${searchQuery ? `
+                        ${searchQuery ? html`
                             <button class="search-input__clear" data-search="clear" type="button" title="Clear search">
                                 <i class="fa-solid fa-xmark"></i>
                             </button>
@@ -158,7 +162,7 @@ export class Navigation extends Component {
         // still holds the prior selection — the user isn't in those views.
         const inKJMode = !!getState('hostFilter');
         const cls = (active) => `nav-btn nav-btn--labeled${active ? ' nav-btn--active' : ''}`;
-        return `
+        return html`
             <div class="navigation__views">
                 <button class="${cls(!inKJMode && view === 'weekly')}" data-view="weekly" type="button">
                     <i class="fa-regular fa-calendar"></i>

--- a/js/utils/string.js
+++ b/js/utils/string.js
@@ -9,16 +9,105 @@
  */
 export const SORT_ARTICLES = ['a', 'an', 'the', 'le', 'la', 'l\'', 'les', 'un', 'une', 'des', 'el', 'lo', 'los', 'las', 'uno', 'una', 'unos', 'unas', 'il', 'i', 'gli', 'un\'', 'o', 'os', 'as', 'um', 'uma', 'uns', 'umas'];
 
+const HTML_ESCAPES = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+};
+
 /**
- * Escape HTML special characters to prevent XSS
- * @param {string} str - String to escape
- * @returns {string} Escaped string
+ * Escape HTML special characters to prevent XSS.
+ *
+ * Safe in both text and quoted-attribute position — quotes are escaped, which
+ * the previous implementation did not do. It set `textContent` and read back
+ * `innerHTML`, and the HTML serializer only escapes `&`, `<`, `>` in a text
+ * node; `"` and `'` came through untouched. Every
+ * `attr="${escapeHtml(value)}"` site in the app was therefore one quote away
+ * from attribute injection (see the regression cases in e2e/security.spec.js).
+ *
+ * `&quot;` and `&#39;` render as `"` and `'` in text position, so escaping
+ * them costs nothing there.
+ *
+ * @param {*} str - Value to escape; non-strings are coerced
+ * @returns {string} Escaped string, safe to interpolate into markup
  */
 export function escapeHtml(str) {
     if (!str) return '';
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
+    return String(str).replace(/[&<>"']/g, ch => HTML_ESCAPES[ch]);
+}
+
+/**
+ * Marker for values that are already trusted markup.
+ *
+ * `toString()` matters: `html` returns one of these, and `Component.render()`
+ * does `container.innerHTML = this.template()`, which coerces. It also makes
+ * nested `html` templates interpolate verbatim without needing `raw()` — the
+ * outer tag recognises the marker.
+ *
+ * @see raw
+ */
+class RawMarkup {
+    constructor(value) {
+        this.value = value;
+    }
+
+    toString() {
+        return this.value;
+    }
+}
+
+/**
+ * Mark a string as trusted markup so the `html` tag interpolates it verbatim.
+ *
+ * Use for nested template output — never for anything derived from a URL, a
+ * form field, or venue data.
+ *
+ * @param {string} markup - Pre-rendered, already-safe HTML
+ * @returns {RawMarkup}
+ */
+export function raw(markup) {
+    return new RawMarkup(markup == null ? '' : String(markup));
+}
+
+/**
+ * Tagged template that escapes every `${}` by default.
+ *
+ * Inverts the app's default: markup is safe unless a value is explicitly
+ * wrapped in `raw()`, so forgetting to escape is no longer possible — you have
+ * to opt in to danger.
+ *
+ *   html`<span>${userInput}</span>`              // escaped
+ *   html`<div>${html`<b>${x}</b>`}</div>`        // nested: verbatim, x escaped
+ *   html`<div>${raw(legacyStringBuilder())}</div>` // opt out explicitly
+ *
+ * Arrays are joined with no separator, each element escaped unless raw, which
+ * makes `${items.map(...)}` behave as expected without a trailing `.join('')`.
+ *
+ * Only `null` and `undefined` collapse to an empty string. `false` and `0`
+ * render as "false" and "0" — `aria-expanded="${isOpen}"` has to keep working,
+ * so conditionals must be written as explicit ternaries ending in `: ''`,
+ * which is the pattern this codebase already uses.
+ *
+ * @param {TemplateStringsArray} strings
+ * @param {...*} values
+ * @returns {RawMarkup} Assembled markup; stringifies on use
+ */
+export function html(strings, ...values) {
+    return new RawMarkup(strings.reduce((out, chunk, i) => {
+        const value = values[i - 1];
+        return out + interpolate(value) + chunk;
+    }));
+}
+
+function interpolate(value) {
+    if (value instanceof RawMarkup) return value.value;
+    if (Array.isArray(value)) return value.map(interpolate).join('');
+    if (value == null) return '';
+    // String() first: escapeHtml short-circuits on falsy input, so a bare
+    // `false` or `0` would otherwise disappear from the output.
+    return escapeHtml(String(value));
 }
 
 /**


### PR DESCRIPTION
## Summary

`?kj=` is read verbatim off the query string into state (`app.js:107`) and was interpolated into Navigation markup with **no escaping at all**, so a crafted link executed script on the page.

Fixing that surfaced a wider problem the ticket did not know about: **`escapeHtml()` did not escape quotes**, so the fix as specified would not have worked.

## Related Issue

Fixes #147

## The escapeHtml problem

`escapeHtml` set `textContent` and read back `innerHTML`. The HTML serializer only escapes `&`, `<`, `>` in a text node — `"` and `'` pass through untouched. Verified in the browser before changing anything:

```js
escapeHtml('" onfocus=alert(1) autofocus x="')
// → '" onfocus=alert(1) autofocus x="'   (completely unchanged)
```

Feeding that into `<input value="${escaped}">` produced an element carrying `onfocus`, `autofocus`, and `x` attributes. It broke straight out.

There are **10 `attr="${escapeHtml(value)}"` sites** across `VenueCard.js`, `render.js`, and `KJIndexView.js`. All were one quote away from attribute injection. Most take curated `data.json` values so they were not *reachable*, but the primitive was wrong everywhere. Fixing the primitive fixes all ten.

## Changes

- **`escapeHtml` now escapes `& < > " '`** via string replace — correct in text *and* quoted-attribute position, and no DOM allocation per call.
- **Added an `html` tagged template and `raw()`** to `js/utils/string.js`. Escapes every `${}` by default, inverting the app's posture: you now opt in to danger rather than opting in to safety. `html` returns a marked object with `toString()`, so nested templates compose without `raw()` and `Component.render()`'s `innerHTML =` coerces cleanly.
- **`Navigation.js` adopts the tag** for every template it renders.
- **`e2e/security.spec.js`** — 4 cases covering both payload shapes against `?kj=` and the search value, plus the escaping primitives directly.

### One subtlety worth reviewing

Only `null`/`undefined` collapse to `''` in the tag. `false` and `0` render as `"false"` and `"0"`, because `aria-expanded="${searchOpen}"` would otherwise emit an empty attribute. `escapeHtml` short-circuits on falsy input, so `interpolate` coerces with `String()` first. Verified live: the toggle still renders `aria-expanded="false"`.

Conditionals must therefore stay explicit ternaries ending in `: ''` — which is the pattern this file already used.

## Documentation Checklist

- [ ] Project spec updated (if behavior changed)
- [ ] CLAUDE.md updated (if architecture/structure changed)
- [ ] README.md updated (if public-facing features changed)
- [x] No documentation updates needed

No behaviour change. Spec §20 Security already states the escaping invariant this restores. Adopting the `html` tag beyond `Navigation.js` is deliberately out of scope — 11 other files still use bare `escapeHtml`, which is now *correct*, just not enforced-by-default.

## Testing Checklist

- [x] Manually tested the happy path
- [x] Tested edge cases (empty input, missing data, etc.)
- [x] Checked for regressions in related features
- [ ] No testing needed (docs-only change)

**Regression tests confirmed load-bearing.** Reverting `escapeHtml` to the old implementation and re-running: **2 of 4 fail**. The other 2 cover the original unescaped-`?kj=` bug — text position, which the old `escapeHtml` would have caught had it been called at all.

I also found and fixed a **vacuous test of my own**: the first version of the search-value case dispatched a `resize` event to force a re-render, but `Navigation` deliberately does not re-render on `searchQuery` (to preserve input focus), so the vulnerable markup was never regenerated and the test passed for free. It now toggles the dedicated filter, which is a real re-render path — and it correctly fails without the fix.

Verified live in a browser against `?kj=<img src=x onerror=...>`:

| Check | Result |
|---|---|
| Script fired | no |
| Injected `<img>` elements | 0 |
| Chip child elements | 0 |
| Chip innerHTML | `&lt;img src=x onerror="window.__xss=1"&gt;` |
| `aria-expanded` on search toggle | `"false"` (literal, not empty) |
| Console errors | none |
| Nav intact | view buttons, active state, week range, KJs link, dedicated toggle, 17 day cards |

Full suite: **67 passed, 10 failed.** 9 failures are the pre-existing `submit-form.spec.js` rot (#149).

The 10th — `navigation.spec.js:41` — is **flakiness, not a regression**. It passes 2/2 serially and 54/54 under 4-worker load with `--repeat-each=3`. The cause is contention: each of the 9 broken submit-form tests burns a 30s timeout and starves workers, pushing a timing-sensitive test past its own. It should clear when #149 lands; worth re-checking then.

`npm run validate:all` passes.

## Base branch note

Branched from `main`, so it does not depend on #176 — but the e2e suite is only runnable from a clean clone once #176 merges. Merge that one first.
