### PR TITLE
#149: Repair the rotted e2e specs and run Playwright in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,33 @@ jobs:
 
       - name: Check CSS load order across HTML pages
         run: node scripts/check-css-load-order.js
+
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Chromium only — playwright.config.js defines a single chromium project,
+      # and the suite starts its own `serve` via the config's webServer block.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run end-to-end tests
+        run: npm test
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/search-filter.spec.js
+++ b/e2e/search-filter.spec.js
@@ -91,6 +91,13 @@ test.describe('Search & dedicated filter', () => {
   });
 
   test('search persists when switching views', async ({ page }) => {
+    // Baseline the unfiltered A-Z list so the assertion below is relative
+    await page.locator('[data-view="alphabetical"]').click();
+    await expect(page.locator('.alphabetical-view')).toBeVisible();
+    const visibleVenues = page.locator('.venue-card:visible');
+    const unfilteredCount = await visibleVenues.count();
+    await page.locator('[data-view="weekly"]').click();
+
     const searchInput = page.locator('[data-search="query"]');
     await searchInput.fill('Ego');
     await page.waitForTimeout(300);
@@ -103,10 +110,9 @@ test.describe('Search & dedicated filter', () => {
     await expect(searchInput).toHaveValue('Ego');
 
     // Filtered results should show in alphabetical view
-    const visibleVenues = page.locator('.venue-card:visible');
     const count = await visibleVenues.count();
     expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThan(70);
+    expect(count).toBeLessThan(unfilteredCount);
   });
 
 });

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -51,16 +51,20 @@ test.describe('Smoke tests', () => {
     const searchInput = page.locator('[data-search="query"]');
     await expect(searchInput).toBeVisible();
 
+    const visibleVenues = page.locator('.venue-card:visible');
+    const unfilteredCount = await visibleVenues.count();
+    expect(unfilteredCount).toBeGreaterThan(0);
+
     // Type a search query — "Ego's" is a well-known Austin karaoke venue
     await searchInput.fill('Ego');
     // Give the filter a moment to apply
     await page.waitForTimeout(300);
 
-    // Visible venue cards should be filtered down
-    const visibleVenues = page.locator('.venue-card:visible');
+    // Filtering must reduce the set, measured against what was actually there
+    // rather than a hard-coded venue count that drifts as the directory grows.
     const count = await visibleVenues.count();
     expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThan(70);
+    expect(count).toBeLessThan(unfilteredCount);
   });
 
 });

--- a/e2e/submit-form.spec.js
+++ b/e2e/submit-form.spec.js
@@ -1,34 +1,29 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
+/**
+ * The New Venue / Report Issue tab UI these specs were written against was
+ * removed by the mobile-first redesign — `#new-mode`, `#report-mode`,
+ * `.submission-tab`, `#report-venue-name` and `.quick-report-options` no longer
+ * appear anywhere in submit.html. The four tests covering it are gone.
+ *
+ * The form is now a single flow with optional fields behind a
+ * `<details class="more-details">` disclosure, so anything below "Add more
+ * details" has to be expanded before it can be interacted with.
+ */
+
+/** Expand the optional-fields disclosure. Tags, age, and contact live inside it. */
+async function openMoreDetails(page) {
+  const details = page.locator('details.more-details');
+  await details.locator('summary').click();
+  await expect(details).toHaveAttribute('open', '');
+}
+
 test.describe('Venue submission form', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/submit.html');
     await expect(page.locator('.submit-form')).toBeVisible({ timeout: 10000 });
-  });
-
-  test('new venue form is shown by default', async ({ page }) => {
-    const newMode = page.locator('#new-mode');
-    await expect(newMode).toHaveClass(/active/);
-
-    const reportMode = page.locator('#report-mode');
-    await expect(reportMode).not.toHaveClass(/active/);
-  });
-
-  test('tab switching — New Venue to Report Issue', async ({ page }) => {
-    // Click report issue tab
-    const reportTab = page.locator('.submission-tab').filter({ hasText: 'Report' });
-    await reportTab.click();
-
-    await expect(page.locator('#report-mode')).toHaveClass(/active/);
-    await expect(page.locator('#new-mode')).not.toHaveClass(/active/);
-
-    // Switch back
-    const newTab = page.locator('.submission-tab').filter({ hasText: 'New' });
-    await newTab.click();
-
-    await expect(page.locator('#new-mode')).toHaveClass(/active/);
   });
 
   test('required fields are present', async ({ page }) => {
@@ -54,27 +49,21 @@ test.describe('Venue submission form', () => {
   });
 
   test('add another schedule entry', async ({ page }) => {
-    // Should start with 1 schedule entry
     const entries = page.locator('.schedule-entry');
     const initialCount = await entries.count();
 
-    // Click add button
-    const addBtn = page.getByText('Add Another Day');
-    await addBtn.click();
+    await page.locator('.add-schedule-btn').click();
 
-    // Should have one more entry
     await expect(entries).toHaveCount(initialCount + 1);
   });
 
   test('remove schedule entry', async ({ page }) => {
-    // Add a second entry first
-    await page.getByText('Add Another Day').click();
     const entries = page.locator('.schedule-entry');
+    await page.locator('.add-schedule-btn').click();
     await expect(entries).toHaveCount(2);
 
-    // Remove the last one
-    const removeBtn = entries.last().locator('button', { hasText: 'Remove' });
-    await removeBtn.click();
+    // Only added entries carry a remove button — the first one cannot be removed
+    await entries.last().locator('.remove-schedule-btn').click();
 
     await expect(entries).toHaveCount(1);
   });
@@ -107,25 +96,29 @@ test.describe('Venue submission form', () => {
   });
 
   test('contact method checkbox reveals input', async ({ page }) => {
-    const emailCheck = page.locator('input[name="contact-email-check"]');
-    await emailCheck.check();
+    await openMoreDetails(page);
 
-    // Email input should become visible
-    const emailInput = page.locator('input[name="contact-email"]');
-    await expect(emailInput).toBeVisible();
+    await page.locator('input[name="contact-email-check"]').check();
+
+    await expect(page.locator('input[name="contact-email"]')).toBeVisible();
   });
 
   test('tag checkboxes can be selected', async ({ page }) => {
-    const tagGrid = page.locator('.tag-checkbox-grid');
-    await expect(tagGrid).toBeVisible();
+    await openMoreDetails(page);
 
-    // Check a tag
-    const lgbtqTag = page.locator('input[value="lgbtq"]');
+    const tagGrid = page.locator('#tag-checkbox-grid');
+    await expect(tagGrid).toBeVisible();
+    // Grid is built from data.json's tagDefinitions at load, so wait for a row
+    await expect(tagGrid.locator('input[type="checkbox"]').first()).toBeAttached();
+
+    const lgbtqTag = page.locator('#tag-checkbox-grid input[value="lgbtq"]');
     await lgbtqTag.check();
     await expect(lgbtqTag).toBeChecked();
   });
 
   test('age restriction radios are mutually exclusive', async ({ page }) => {
+    await openMoreDetails(page);
+
     const radio21 = page.locator('input[name="age-restriction"][value="21+"]');
     const radioAll = page.locator('input[name="age-restriction"][value="all-ages"]');
 
@@ -137,25 +130,14 @@ test.describe('Venue submission form', () => {
     await expect(radio21).not.toBeChecked();
   });
 
-  test('report form has required venue name and issue checkboxes', async ({ page }) => {
-    // Switch to report tab
-    const reportTab = page.locator('.submission-tab').filter({ hasText: 'Report' });
-    await reportTab.click();
-    await expect(page.locator('#report-mode')).toHaveClass(/active/);
+  test('optional fields stay collapsed until the disclosure is opened', async ({ page }) => {
+    const details = page.locator('details.more-details');
+    await expect(details).not.toHaveAttribute('open', '');
+    await expect(page.locator('#tag-checkbox-grid')).not.toBeVisible();
 
-    await expect(page.locator('#report-venue-name')).toBeVisible();
-    await expect(page.locator('.quick-report-options')).toBeVisible();
-  });
+    await openMoreDetails(page);
 
-  test('report issue checkboxes toggle selected state', async ({ page }) => {
-    const reportTab = page.locator('.submission-tab').filter({ hasText: 'Report' });
-    await reportTab.click();
-
-    const option = page.locator('.quick-report-option').first();
-    const checkbox = option.locator('input[type="checkbox"]');
-
-    await option.click();
-    await expect(checkbox).toBeChecked();
+    await expect(page.locator('#tag-checkbox-grid')).toBeVisible();
   });
 
 });


### PR DESCRIPTION
## Summary

The suite was **64 passed / 9 failed**, with every failure in `submit-form.spec.js` — frozen against UI the mobile-first redesign removed or restructured. This repairs them and adds an `e2e` job to CI.

**Result: 70 passed, 0 failed.**

> **Stacked on #176.** Base is `148-track-playwright-config`, because a CI job running `npm test` is meaningless until `playwright.config.js` is tracked. GitHub will retarget this to `main` automatically when #176 merges. Review #176 first.

## Related Issue

Fixes #149

## Two causes, not one

The ticket assumed the 9 failures were one problem — dead UI to delete. They were three:

| Cause | Tests | Action |
|---|---|---|
| **UI genuinely removed.** `#new-mode`, `#report-mode`, `.submission-tab`, `#report-venue-name`, `.quick-report-options` — `grep -c` returns **0** for every one | 4 | Deleted |
| **Fields moved behind a disclosure.** Tags, age restriction, and contact method still exist, but now sit inside `<details class="more-details">` at `submit.html:171`, so they are not interactable until expanded | 3 | Retargeted via a shared `openMoreDetails()` helper |
| **Selector drift only.** The button reads "Add Another **Night**" now, and removal is `.remove-schedule-btn` | 2 | Retargeted to stable class selectors instead of button text |

Deleting all nine — which is what "the four mode-tab/report tests deleted" plus a vague retarget would have led to — would have thrown away five tests covering behaviour that still works.

## Changes

- Four tab/report tests deleted; the file now documents why, so nobody re-adds them
- `openMoreDetails()` helper; three tests use it
- Schedule add/remove retargeted to `.add-schedule-btn` / `.remove-schedule-btn` — class selectors do not drift when copy changes, which is exactly how these broke
- **New test:** asserts the disclosure starts collapsed and expands on click. That progressive disclosure is the behaviour that silently broke three specs, and nothing covered it
- Both `toBeLessThan(70)` assertions replaced with relative ones against the unfiltered count
- `e2e` job added to `.github/workflows/ci.yml` — chromium only, suite starts its own server via the config's `webServer` block, report uploaded as an artifact on failure

## Correction to the ticket

The "magic 70" AC was wrong and I struck it. Both sites are:

```js
expect(count).toBeLessThan(70);
```

That is an upper bound on *filtered* results — "filtering reduced the set" — not an assertion that the venue count is 70. **Both passed** against 80 venues. I still replaced them, because a filter matching 70+ venues would fail them for no good reason, but nothing was broken and the stated rationale was incorrect.

## Documentation Checklist

- [ ] Project spec updated (if behavior changed)
- [ ] CLAUDE.md updated (if architecture/structure changed)
- [ ] README.md updated (if public-facing features changed)
- [x] No documentation updates needed

Test-only plus CI config. CLAUDE.md's Testing section still documents only `?debug=1` and mentions neither the suite nor CI — that sweep is #152.

## Testing Checklist

- [x] Manually tested the happy path
- [x] Tested edge cases (empty input, missing data, etc.)
- [x] Checked for regressions in related features
- [ ] No testing needed (docs-only change)

**Full suite: 70 passed, 0 failed.**

Runtime fell from **3.9 min → 1.4 min**. Each of the 9 broken tests was burning a 30-second timeout, which is 4.5 minutes of pure waiting.

That also resolves the flake I flagged on #177: `navigation.spec.js:41` failed there under parallel load and passes in the full run now. The timing-out tests were starving workers and pushing a timing-sensitive test past its own timeout. Diagnosis confirmed — it was contention, not a regression.

## Note for the reviewer

`e2e/submit-form.spec.js` covers form *mechanics* only. It never submits, so nothing reaches `Code.gs` or an inbox. Worth keeping that way.
