### PR TITLE
#149: Repair the rotted e2e specs and run Playwright in CI (re-proposed against main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,33 @@ jobs:
 
       - name: Check CSS load order across HTML pages
         run: node scripts/check-css-load-order.js
+
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Chromium only — playwright.config.js defines a single chromium project,
+      # and the suite starts its own `serve` via the config's webServer block.
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run end-to-end tests
+        run: npm test
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/e2e/search-filter.spec.js
+++ b/e2e/search-filter.spec.js
@@ -91,6 +91,13 @@ test.describe('Search & dedicated filter', () => {
   });
 
   test('search persists when switching views', async ({ page }) => {
+    // Baseline the unfiltered A-Z list so the assertion below is relative
+    await page.locator('[data-view="alphabetical"]').click();
+    await expect(page.locator('.alphabetical-view')).toBeVisible();
+    const visibleVenues = page.locator('.venue-card:visible');
+    const unfilteredCount = await visibleVenues.count();
+    await page.locator('[data-view="weekly"]').click();
+
     const searchInput = page.locator('[data-search="query"]');
     await searchInput.fill('Ego');
     await page.waitForTimeout(300);
@@ -103,10 +110,9 @@ test.describe('Search & dedicated filter', () => {
     await expect(searchInput).toHaveValue('Ego');
 
     // Filtered results should show in alphabetical view
-    const visibleVenues = page.locator('.venue-card:visible');
     const count = await visibleVenues.count();
     expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThan(70);
+    expect(count).toBeLessThan(unfilteredCount);
   });
 
 });

--- a/e2e/smoke.spec.js
+++ b/e2e/smoke.spec.js
@@ -51,16 +51,20 @@ test.describe('Smoke tests', () => {
     const searchInput = page.locator('[data-search="query"]');
     await expect(searchInput).toBeVisible();
 
+    const visibleVenues = page.locator('.venue-card:visible');
+    const unfilteredCount = await visibleVenues.count();
+    expect(unfilteredCount).toBeGreaterThan(0);
+
     // Type a search query — "Ego's" is a well-known Austin karaoke venue
     await searchInput.fill('Ego');
     // Give the filter a moment to apply
     await page.waitForTimeout(300);
 
-    // Visible venue cards should be filtered down
-    const visibleVenues = page.locator('.venue-card:visible');
+    // Filtering must reduce the set, measured against what was actually there
+    // rather than a hard-coded venue count that drifts as the directory grows.
     const count = await visibleVenues.count();
     expect(count).toBeGreaterThan(0);
-    expect(count).toBeLessThan(70);
+    expect(count).toBeLessThan(unfilteredCount);
   });
 
 });

--- a/e2e/submit-form.spec.js
+++ b/e2e/submit-form.spec.js
@@ -1,34 +1,29 @@
 // @ts-check
 const { test, expect } = require('@playwright/test');
 
+/**
+ * The New Venue / Report Issue tab UI these specs were written against was
+ * removed by the mobile-first redesign — `#new-mode`, `#report-mode`,
+ * `.submission-tab`, `#report-venue-name` and `.quick-report-options` no longer
+ * appear anywhere in submit.html. The four tests covering it are gone.
+ *
+ * The form is now a single flow with optional fields behind a
+ * `<details class="more-details">` disclosure, so anything below "Add more
+ * details" has to be expanded before it can be interacted with.
+ */
+
+/** Expand the optional-fields disclosure. Tags, age, and contact live inside it. */
+async function openMoreDetails(page) {
+  const details = page.locator('details.more-details');
+  await details.locator('summary').click();
+  await expect(details).toHaveAttribute('open', '');
+}
+
 test.describe('Venue submission form', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/submit.html');
     await expect(page.locator('.submit-form')).toBeVisible({ timeout: 10000 });
-  });
-
-  test('new venue form is shown by default', async ({ page }) => {
-    const newMode = page.locator('#new-mode');
-    await expect(newMode).toHaveClass(/active/);
-
-    const reportMode = page.locator('#report-mode');
-    await expect(reportMode).not.toHaveClass(/active/);
-  });
-
-  test('tab switching — New Venue to Report Issue', async ({ page }) => {
-    // Click report issue tab
-    const reportTab = page.locator('.submission-tab').filter({ hasText: 'Report' });
-    await reportTab.click();
-
-    await expect(page.locator('#report-mode')).toHaveClass(/active/);
-    await expect(page.locator('#new-mode')).not.toHaveClass(/active/);
-
-    // Switch back
-    const newTab = page.locator('.submission-tab').filter({ hasText: 'New' });
-    await newTab.click();
-
-    await expect(page.locator('#new-mode')).toHaveClass(/active/);
   });
 
   test('required fields are present', async ({ page }) => {
@@ -54,27 +49,21 @@ test.describe('Venue submission form', () => {
   });
 
   test('add another schedule entry', async ({ page }) => {
-    // Should start with 1 schedule entry
     const entries = page.locator('.schedule-entry');
     const initialCount = await entries.count();
 
-    // Click add button
-    const addBtn = page.getByText('Add Another Day');
-    await addBtn.click();
+    await page.locator('.add-schedule-btn').click();
 
-    // Should have one more entry
     await expect(entries).toHaveCount(initialCount + 1);
   });
 
   test('remove schedule entry', async ({ page }) => {
-    // Add a second entry first
-    await page.getByText('Add Another Day').click();
     const entries = page.locator('.schedule-entry');
+    await page.locator('.add-schedule-btn').click();
     await expect(entries).toHaveCount(2);
 
-    // Remove the last one
-    const removeBtn = entries.last().locator('button', { hasText: 'Remove' });
-    await removeBtn.click();
+    // Only added entries carry a remove button — the first one cannot be removed
+    await entries.last().locator('.remove-schedule-btn').click();
 
     await expect(entries).toHaveCount(1);
   });
@@ -107,25 +96,29 @@ test.describe('Venue submission form', () => {
   });
 
   test('contact method checkbox reveals input', async ({ page }) => {
-    const emailCheck = page.locator('input[name="contact-email-check"]');
-    await emailCheck.check();
+    await openMoreDetails(page);
 
-    // Email input should become visible
-    const emailInput = page.locator('input[name="contact-email"]');
-    await expect(emailInput).toBeVisible();
+    await page.locator('input[name="contact-email-check"]').check();
+
+    await expect(page.locator('input[name="contact-email"]')).toBeVisible();
   });
 
   test('tag checkboxes can be selected', async ({ page }) => {
-    const tagGrid = page.locator('.tag-checkbox-grid');
-    await expect(tagGrid).toBeVisible();
+    await openMoreDetails(page);
 
-    // Check a tag
-    const lgbtqTag = page.locator('input[value="lgbtq"]');
+    const tagGrid = page.locator('#tag-checkbox-grid');
+    await expect(tagGrid).toBeVisible();
+    // Grid is built from data.json's tagDefinitions at load, so wait for a row
+    await expect(tagGrid.locator('input[type="checkbox"]').first()).toBeAttached();
+
+    const lgbtqTag = page.locator('#tag-checkbox-grid input[value="lgbtq"]');
     await lgbtqTag.check();
     await expect(lgbtqTag).toBeChecked();
   });
 
   test('age restriction radios are mutually exclusive', async ({ page }) => {
+    await openMoreDetails(page);
+
     const radio21 = page.locator('input[name="age-restriction"][value="21+"]');
     const radioAll = page.locator('input[name="age-restriction"][value="all-ages"]');
 
@@ -137,25 +130,14 @@ test.describe('Venue submission form', () => {
     await expect(radio21).not.toBeChecked();
   });
 
-  test('report form has required venue name and issue checkboxes', async ({ page }) => {
-    // Switch to report tab
-    const reportTab = page.locator('.submission-tab').filter({ hasText: 'Report' });
-    await reportTab.click();
-    await expect(page.locator('#report-mode')).toHaveClass(/active/);
+  test('optional fields stay collapsed until the disclosure is opened', async ({ page }) => {
+    const details = page.locator('details.more-details');
+    await expect(details).not.toHaveAttribute('open', '');
+    await expect(page.locator('#tag-checkbox-grid')).not.toBeVisible();
 
-    await expect(page.locator('#report-venue-name')).toBeVisible();
-    await expect(page.locator('.quick-report-options')).toBeVisible();
-  });
+    await openMoreDetails(page);
 
-  test('report issue checkboxes toggle selected state', async ({ page }) => {
-    const reportTab = page.locator('.submission-tab').filter({ hasText: 'Report' });
-    await reportTab.click();
-
-    const option = page.locator('.quick-report-option').first();
-    const checkbox = option.locator('input[type="checkbox"]');
-
-    await option.click();
-    await expect(checkbox).toBeChecked();
+    await expect(page.locator('#tag-checkbox-grid')).toBeVisible();
   });
 
 });


### PR DESCRIPTION
## Summary

**Re-proposing #149's work against `main`. It never landed.**

#178 was a stacked PR based on `148-track-playwright-config`. #176 merged that branch into `main` **first**, then #178 merged into the now-orphaned base. GitHub marked #178 "MERGED" — correctly, it did merge into its base — but that base never went to `main` again, so commit `f92a2c1` exists only on the two feature branches.

`main` today has no `e2e` CI job and still carries the nine broken `submit-form` specs. This fixes that.

## Related Issue

Fixes #149 (supersedes #178, which merged into a dead base)

## Contents

Identical to #178, plus a merge of current `main`:

- Four tab/report tests deleted — that UI no longer exists (`grep -c` returns 0 for all five selectors)
- Three tests retargeted through a shared `openMoreDetails()` helper — tags, age restriction, and contact method now live inside a `<details class="more-details">` disclosure
- Two tests retargeted from button text to `.add-schedule-btn` / `.remove-schedule-btn` — the copy changed to "Add Another Night"
- New test asserting the disclosure starts collapsed
- Both `toBeLessThan(70)` assertions made relative to the unfiltered count
- `e2e` job added to CI — chromium only, report uploaded on failure

## Verification on the combined tree

Merged `origin/main` in locally (clean, no conflicts) and ran everything:

- **74 passed, 0 failed** — #149's 70 plus the 4 security cases from #147, which this branch had never seen
- `npm run validate:all` passes, CSS load order OK on all five pages
- Suite runtime 1.5 min

## Process note

This is the stacked-PR failure mode, and it is worth avoiding rather than re-learning: **when a stack merges bottom-first, the upper PR silently lands nowhere.** GitHub only auto-retargets an open child PR when the parent merges — it cannot fix a child that merges afterward into an already-merged base.

If a stack comes up again, either merge top-down, or convert the child to target `main` before merging the parent.
