### PR TITLE
#150: Add a node --test unit suite for date.js and the pure venue helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
 
       # Pure-module unit tests via the built-in Node runner. Sub-second, no
       # browser, so they live in the fast job rather than alongside Playwright.
+      #
+      # `node --test` takes no path on purpose: it discovers test/*.test.mjs by
+      # Node's own naming convention. A glob argument needs Node 21+, and a bare
+      # directory argument stopped working in Node 24 — the no-arg form is the
+      # only one that behaves the same on every version we might run on.
       - name: Unit tests
         run: npm run test:unit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Check CSS load order across HTML pages
         run: node scripts/check-css-load-order.js
 
+      # Pure-module unit tests via the built-in Node runner. Sub-second, no
+      # browser, so they live in the fast job rather than alongside Playwright.
+      - name: Unit tests
+        run: npm run test:unit
+
   e2e:
     name: End-to-end tests
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",
+    "test:unit": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test \"test/**/*.test.mjs\"",
     "validate": "node scripts/validate-data.js",
     "validate:css": "node scripts/check-css-load-order.js",
     "validate:all": "npm run validate && npm run validate:css"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npx playwright test",
     "test:headed": "npx playwright test --headed",
     "test:ui": "npx playwright test --ui",
-    "test:unit": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test \"test/**/*.test.mjs\"",
+    "test:unit": "node --disable-warning=MODULE_TYPELESS_PACKAGE_JSON --test",
     "validate": "node scripts/validate-data.js",
     "validate:css": "node scripts/check-css-load-order.js",
     "validate:all": "npm run validate && npm run validate:css"

--- a/test/date.test.mjs
+++ b/test/date.test.mjs
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for js/utils/date.js — schedule matching and date handling.
+ *
+ * Node's built-in runner: `npm run test:unit`. No devDependency, no build step
+ * (ADR-002). date.js imports nothing and touches no DOM, so it loads in Node
+ * unchanged.
+ *
+ * Why this module: schedule matching IS the product. A regression here sends
+ * someone to a bar on the wrong night, and the e2e suite cannot reach branches
+ * like `fifth` or the fourth-vs-last distinction unless data.json happens to
+ * contain such an entry inside the rendered window.
+ *
+ * Dates are constructed with `new Date(y, m, d)` (local midnight) so these
+ * assertions hold in any timezone.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  getDayName,
+  scheduleMatchesDate,
+  getScheduleExclusion,
+  getVenueExclusionForDate,
+  isPastOnceEvent,
+  parseLocalDate,
+  isDateInRange,
+  formatTime12,
+  formatTime24,
+  formatTimeRange,
+} from '../js/utils/date.js';
+
+// January 2026 has five Fridays: 2, 9, 16, 23, 30.
+// February 2026 has four:        6, 13, 20, 27.
+// That pair is what separates "fourth" from "last".
+const JAN = (d) => new Date(2026, 0, d);
+const FEB = (d) => new Date(2026, 1, d);
+
+describe('date fixtures are what the tests assume', () => {
+  it('January 2026 Fridays are 2, 9, 16, 23, 30', () => {
+    for (const d of [2, 9, 16, 23, 30]) {
+      assert.equal(getDayName(JAN(d)), 'friday', `Jan ${d} should be a Friday`);
+    }
+    // and Jan has no sixth Friday
+    assert.notEqual(getDayName(JAN(31)), 'friday');
+  });
+
+  it('February 2026 Fridays are 6, 13, 20, 27 — only four', () => {
+    for (const d of [6, 13, 20, 27]) {
+      assert.equal(getDayName(FEB(d)), 'friday', `Feb ${d} should be a Friday`);
+    }
+    assert.equal(FEB(28).getDate(), 28);
+    assert.notEqual(getDayName(FEB(28)), 'friday');
+  });
+});
+
+describe('scheduleMatchesDate — recurring frequencies', () => {
+  const every = { frequency: 'every', day: 'Friday' };
+  const fourth = { frequency: 'fourth', day: 'Friday' };
+  const fifth = { frequency: 'fifth', day: 'Friday' };
+  const last = { frequency: 'last', day: 'Friday' };
+
+  it('"every" matches every occurrence of the weekday', () => {
+    for (const d of [2, 9, 16, 23, 30]) {
+      assert.equal(scheduleMatchesDate(every, JAN(d)), true, `Jan ${d}`);
+    }
+  });
+
+  it('never matches a different weekday', () => {
+    assert.equal(scheduleMatchesDate(every, JAN(3)), false); // Saturday
+  });
+
+  it('day name matching is case-insensitive', () => {
+    assert.equal(scheduleMatchesDate({ frequency: 'every', day: 'FRIDAY' }, JAN(2)), true);
+    assert.equal(scheduleMatchesDate({ frequency: 'every', day: 'friday' }, JAN(2)), true);
+  });
+
+  it('"fourth" is the 4th occurrence, not the final one', () => {
+    assert.equal(scheduleMatchesDate(fourth, JAN(23)), true);
+    assert.equal(scheduleMatchesDate(fourth, JAN(30)), false);
+  });
+
+  it('"last" is the final occurrence — Jan 30, not Jan 23', () => {
+    assert.equal(scheduleMatchesDate(last, JAN(30)), true);
+    assert.equal(scheduleMatchesDate(last, JAN(23)), false);
+  });
+
+  it('"fourth" and "last" COINCIDE in a four-Friday month', () => {
+    // The whole reason both frequencies exist. Feb 27 is both.
+    assert.equal(scheduleMatchesDate(fourth, FEB(27)), true);
+    assert.equal(scheduleMatchesDate(last, FEB(27)), true);
+  });
+
+  it('"fifth" matches only in a five-Friday month', () => {
+    assert.equal(scheduleMatchesDate(fifth, JAN(30)), true);
+    // February has no fifth Friday, so nothing in the month matches
+    for (const d of [6, 13, 20, 27]) {
+      assert.equal(scheduleMatchesDate(fifth, FEB(d)), false, `Feb ${d}`);
+    }
+  });
+
+  it('"fifth" and "last" coincide when a fifth occurrence exists', () => {
+    assert.equal(scheduleMatchesDate(fifth, JAN(30)), true);
+    assert.equal(scheduleMatchesDate(last, JAN(30)), true);
+  });
+
+  it('an unknown frequency matches nothing rather than throwing', () => {
+    assert.equal(scheduleMatchesDate({ frequency: 'sixth', day: 'Friday' }, JAN(30)), false);
+  });
+});
+
+describe('scheduleMatchesDate — one-time events', () => {
+  it('matches the exact calendar date', () => {
+    const entry = { frequency: 'once', date: '2026-01-30' };
+    assert.equal(scheduleMatchesDate(entry, JAN(30)), true);
+    assert.equal(scheduleMatchesDate(entry, JAN(29)), false);
+    assert.equal(scheduleMatchesDate(entry, JAN(31)), false);
+  });
+
+  it('single-digit months and days are zero-padded when compared', () => {
+    // Guards the padStart logic: 2026-02-06, not 2026-2-6
+    assert.equal(scheduleMatchesDate({ frequency: 'once', date: '2026-02-06' }, FEB(6)), true);
+    assert.equal(scheduleMatchesDate({ frequency: 'once', date: '2026-2-6' }, FEB(6)), false);
+  });
+
+  it('ignores `day` entirely for one-time entries', () => {
+    // A "once" entry with a contradictory weekday still matches its date
+    const entry = { frequency: 'once', date: '2026-01-30', day: 'Monday' };
+    assert.equal(scheduleMatchesDate(entry, JAN(30)), true);
+  });
+});
+
+describe('getScheduleExclusion', () => {
+  const base = { frequency: 'every', day: 'Friday' };
+
+  it('returns null when there are no exclusions', () => {
+    assert.equal(getScheduleExclusion(base, JAN(2)), null);
+    assert.equal(getScheduleExclusion({ ...base, exclusions: [] }, JAN(2)), null);
+  });
+
+  it('matches the object form and carries the reason through', () => {
+    const s = { ...base, exclusions: [{ date: '2026-01-02', reason: 'Holiday' }] };
+    assert.deepEqual(getScheduleExclusion(s, JAN(2)), { date: '2026-01-02', reason: 'Holiday' });
+  });
+
+  it('defaults a missing reason to null rather than undefined', () => {
+    const s = { ...base, exclusions: [{ date: '2026-01-02' }] };
+    assert.deepEqual(getScheduleExclusion(s, JAN(2)), { date: '2026-01-02', reason: null });
+  });
+
+  it('accepts the bare-string shorthand', () => {
+    // CLAUDE.md documents this form; the JSON Schema does not accept it.
+    // See #169 — the shorthand is slated for removal. Until then the runtime
+    // takes it, and this test records that.
+    const s = { ...base, exclusions: ['2026-01-02'] };
+    assert.deepEqual(getScheduleExclusion(s, JAN(2)), { date: '2026-01-02', reason: null });
+  });
+
+  it('returns null on a non-excluded date', () => {
+    const s = { ...base, exclusions: [{ date: '2026-01-02' }] };
+    assert.equal(getScheduleExclusion(s, JAN(9)), null);
+  });
+
+  it('an exclusion does not stop the schedule from matching', () => {
+    // Deliberate: the card still renders, with a "closed" indicator
+    const s = { ...base, exclusions: [{ date: '2026-01-02' }] };
+    assert.equal(scheduleMatchesDate(s, JAN(2)), true);
+    assert.notEqual(getScheduleExclusion(s, JAN(2)), null);
+  });
+});
+
+describe('getVenueExclusionForDate', () => {
+  it('finds an exclusion on whichever entry matches the date', () => {
+    const venue = {
+      schedule: [
+        { frequency: 'every', day: 'Monday' },
+        { frequency: 'every', day: 'Friday', exclusions: [{ date: '2026-01-02', reason: 'Private event' }] },
+      ],
+    };
+    assert.deepEqual(getVenueExclusionForDate(venue, JAN(2)), { date: '2026-01-02', reason: 'Private event' });
+  });
+
+  it('returns null when the excluded entry does not match that date', () => {
+    const venue = {
+      schedule: [{ frequency: 'every', day: 'Monday', exclusions: [{ date: '2026-01-02' }] }],
+    };
+    // Jan 2 is a Friday, so the Monday entry never matches
+    assert.equal(getVenueExclusionForDate(venue, JAN(2)), null);
+  });
+
+  it('tolerates a venue with no schedule', () => {
+    assert.equal(getVenueExclusionForDate({}, JAN(2)), null);
+    assert.equal(getVenueExclusionForDate(null, JAN(2)), null);
+  });
+});
+
+describe('parseLocalDate', () => {
+  it('parses as local midnight, not UTC', () => {
+    // `new Date("2026-05-23")` is UTC midnight, which is the 22nd anywhere
+    // west of UTC. This is the bug from #60.
+    const d = parseLocalDate('2026-05-23');
+    assert.equal(d.getFullYear(), 2026);
+    assert.equal(d.getMonth(), 4);
+    assert.equal(d.getDate(), 23);
+    assert.equal(d.getHours(), 0);
+  });
+});
+
+describe('isDateInRange', () => {
+  it('is inclusive of both endpoints', () => {
+    assert.equal(isDateInRange(JAN(1), '2026-01-01', '2026-01-31'), true);
+    assert.equal(isDateInRange(JAN(31), '2026-01-01', '2026-01-31'), true);
+  });
+
+  it('excludes dates outside the range', () => {
+    assert.equal(isDateInRange(new Date(2025, 11, 31), '2026-01-01', '2026-01-31'), false);
+    assert.equal(isDateInRange(FEB(1), '2026-01-01', '2026-01-31'), false);
+  });
+
+  it('treats a null bound as open-ended', () => {
+    assert.equal(isDateInRange(JAN(1), null, '2026-01-31'), true);
+    assert.equal(isDateInRange(JAN(1), '2026-01-01', null), true);
+    assert.equal(isDateInRange(JAN(1), null, null), true);
+  });
+
+  it('a single-day window containing only that day matches it', () => {
+    // The #60 repro: activePeriod.start === end === the day being checked.
+    // Under the old UTC parsing this returned false in any timezone west of
+    // UTC, hiding a venue on the one day it was supposed to appear.
+    assert.equal(isDateInRange(JAN(15), '2026-01-15', '2026-01-15'), true);
+    assert.equal(isDateInRange(JAN(14), '2026-01-15', '2026-01-15'), false);
+    assert.equal(isDateInRange(JAN(16), '2026-01-15', '2026-01-15'), false);
+  });
+
+  it('ignores the time of day on the date being checked', () => {
+    const lateEvening = new Date(2026, 0, 31, 23, 45);
+    assert.equal(isDateInRange(lateEvening, '2026-01-01', '2026-01-31'), true);
+  });
+});
+
+describe('isPastOnceEvent', () => {
+  const asOf = JAN(15);
+
+  it('is true for a one-time event before the reference date', () => {
+    assert.equal(isPastOnceEvent({ frequency: 'once', date: '2026-01-14' }, asOf), true);
+  });
+
+  it('is false on the day itself — an event today has not passed', () => {
+    assert.equal(isPastOnceEvent({ frequency: 'once', date: '2026-01-15' }, asOf), false);
+  });
+
+  it('is false for a future one-time event', () => {
+    assert.equal(isPastOnceEvent({ frequency: 'once', date: '2026-01-16' }, asOf), false);
+  });
+
+  it('is false for recurring entries regardless of date', () => {
+    assert.equal(isPastOnceEvent({ frequency: 'every', day: 'Friday' }, asOf), false);
+  });
+
+  it('is false for a "once" entry with no date, and for junk input', () => {
+    assert.equal(isPastOnceEvent({ frequency: 'once' }, asOf), false);
+    assert.equal(isPastOnceEvent(null, asOf), false);
+    assert.equal(isPastOnceEvent(undefined, asOf), false);
+  });
+});
+
+describe('time formatting', () => {
+  it('formatTime12 converts 24-hour to 12-hour', () => {
+    assert.equal(formatTime12('21:00'), '9:00 PM');
+    assert.equal(formatTime12('01:00'), '1:00 AM');
+    assert.equal(formatTime12('00:00'), '12:00 AM');
+    assert.equal(formatTime12('12:00'), '12:00 PM');
+    assert.equal(formatTime12('12:30'), '12:30 PM');
+    assert.equal(formatTime12('09:05'), '9:05 AM');
+  });
+
+  it('formatTime12 returns empty string for missing input', () => {
+    assert.equal(formatTime12(''), '');
+    assert.equal(formatTime12(null), '');
+    assert.equal(formatTime12(undefined), '');
+  });
+
+  it('formatTime24 round-trips with formatTime12', () => {
+    for (const t of ['21:00', '01:00', '00:00', '12:00', '09:05']) {
+      assert.equal(formatTime24(formatTime12(t)), t, `round trip ${t}`);
+    }
+  });
+
+  it('formatTimeRange renders a range that crosses midnight', () => {
+    // 21:00 -> 01:00 is the single most common shape in data.json
+    assert.equal(formatTimeRange('21:00', '01:00'), '9:00 PM - 1:00 AM');
+  });
+
+  it('formatTimeRange shows "Close" when there is no end time', () => {
+    assert.equal(formatTimeRange('21:00', null), '9:00 PM - Close');
+    assert.equal(formatTimeRange('21:00', undefined), '9:00 PM - Close');
+  });
+});

--- a/test/venues.test.mjs
+++ b/test/venues.test.mjs
@@ -1,0 +1,224 @@
+/**
+ * Unit tests for the pure parts of the venue service and host hydration.
+ *
+ * These modules load in Node because they touch no DOM. `js/utils/render.js`
+ * (imported transitively by venues.js) became Node-safe once `escapeHtml` was
+ * rewritten to use string replacement instead of a detached div — see #147.
+ *
+ * View classes are deliberately NOT unit tested. They belong to the e2e suite.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { venuePasses, venueMatchesSearch, venueMatchesHost, byName } from '../js/services/venues.js';
+import { hydrateVenues, isHostRef, resolveHostRef } from '../js/utils/hosts.js';
+
+const JAN = (d) => new Date(2026, 0, d);
+
+/** Minimal venue; override whatever a test cares about. */
+const venue = (over = {}) => ({
+  id: 'test-venue',
+  name: 'Test Venue',
+  address: { city: 'Austin', state: 'TX' },
+  schedule: [{ frequency: 'every', day: 'Friday', startTime: '21:00', endTime: '01:00' }],
+  ...over,
+});
+
+describe('venuePasses', () => {
+  it('passes an ordinary venue', () => {
+    assert.equal(venuePasses(venue(), { date: JAN(2) }), true);
+  });
+
+  it('hides dedicated venues when includeDedicated is false', () => {
+    const v = venue({ dedicated: true });
+    assert.equal(venuePasses(v, { date: JAN(2), includeDedicated: false }), false);
+    assert.equal(venuePasses(v, { date: JAN(2), includeDedicated: true }), true);
+  });
+
+  it('keeps non-dedicated venues when the dedicated filter is off', () => {
+    assert.equal(venuePasses(venue({ dedicated: false }), { date: JAN(2), includeDedicated: false }), true);
+  });
+
+  it('applies the search query', () => {
+    assert.equal(venuePasses(venue(), { date: JAN(2), searchQuery: 'Test' }), true);
+    assert.equal(venuePasses(venue(), { date: JAN(2), searchQuery: 'nonexistent' }), false);
+  });
+
+  it('respects activePeriod on the supplied date', () => {
+    const v = venue({ activePeriod: { start: '2026-06-01', end: '2026-08-31' } });
+    assert.equal(venuePasses(v, { date: JAN(2) }), false);
+    assert.equal(venuePasses(v, { date: new Date(2026, 6, 15) }), true);
+  });
+
+  it('an activePeriod of a single day includes that day', () => {
+    // Same #60 shape as the date.js suite, one layer up
+    const v = venue({ activePeriod: { start: '2026-01-02', end: '2026-01-02' } });
+    assert.equal(venuePasses(v, { date: JAN(2) }), true);
+    assert.equal(venuePasses(v, { date: JAN(3) }), false);
+  });
+});
+
+describe('venueMatchesSearch', () => {
+  it('matches on name, city, and neighborhood, case-insensitively', () => {
+    const v = venue({ name: 'Ego\'s', address: { city: 'Austin', neighborhood: 'Downtown' } });
+    assert.equal(venueMatchesSearch(v, 'ego'), true);
+    assert.equal(venueMatchesSearch(v, 'AUSTIN'), true);
+    assert.equal(venueMatchesSearch(v, 'downtown'), true);
+  });
+
+  it('matches on host name and affiliation', () => {
+    const v = venue({ host: { name: 'KJ Stephanie', affiliation: 'Starling Karaoke' } });
+    assert.equal(venueMatchesSearch(v, 'stephanie'), true);
+    assert.equal(venueMatchesSearch(v, 'starling'), true);
+  });
+
+  it('returns true for an empty or whitespace query', () => {
+    assert.equal(venueMatchesSearch(venue(), ''), true);
+    assert.equal(venueMatchesSearch(venue(), '   '), true);
+  });
+
+  it('returns false for a term that appears nowhere', () => {
+    assert.equal(venueMatchesSearch(venue(), 'zzzznope'), false);
+  });
+
+  it('does NOT match event names', () => {
+    // Recorded deliberately: CLAUDE.md claims eventName is searchable and it is
+    // not. Whichever way #37 modality 1 is resolved — implement it or fix the
+    // doc — this assertion has to be revisited, which is the point.
+    const v = venue({
+      schedule: [{ frequency: 'once', date: '2026-01-30', eventName: 'Halloween Spooktacular' }],
+    });
+    assert.equal(venueMatchesSearch(v, 'spooktacular'), false);
+  });
+});
+
+describe('venueMatchesHost', () => {
+  it('matches venue-level host name and affiliation', () => {
+    const v = venue({ host: { name: 'KJ Stephanie', affiliation: 'Starling Karaoke' } });
+    assert.equal(venueMatchesHost(v, 'Stephanie'), true);
+    assert.equal(venueMatchesHost(v, 'Starling'), true);
+  });
+
+  it('matches a per-show host override', () => {
+    const v = venue({
+      schedule: [{ frequency: 'every', day: 'Friday', host: { name: 'Guest KJ' } }],
+    });
+    assert.equal(venueMatchesHost(v, 'Guest'), true);
+  });
+
+  it('returns true for an empty query', () => {
+    assert.equal(venueMatchesHost(venue(), ''), true);
+  });
+
+  it('matches on SUBSTRING, so distinct KJs collide', () => {
+    // Not an endorsement — this is the live defect behind the ?kj= identity
+    // work (#124 Phase 5, #171). A query of "Joe" matches "Average Joe" and
+    // would equally match any other Joe. When ?kj= moves to registry ids this
+    // test should be replaced by an exact-id assertion.
+    const v = venue({ host: { name: 'Average Joe' } });
+    assert.equal(venueMatchesHost(v, 'Joe'), true);
+    assert.equal(venueMatchesHost(v, 'ave'), true);
+  });
+});
+
+describe('byName — leading articles are ignored', () => {
+  it('sorts "The Highball" under H', () => {
+    const sorted = [
+      { name: 'The Highball' },
+      { name: 'Alcove' },
+      { name: 'Knomad' },
+    ].sort(byName).map((v) => v.name);
+    assert.deepEqual(sorted, ['Alcove', 'The Highball', 'Knomad']);
+  });
+});
+
+describe('isHostRef', () => {
+  it('recognises a ref by either id key', () => {
+    assert.equal(isHostRef({ kjId: 'kj-stephanie' }), true);
+    assert.equal(isHostRef({ companyId: 'starling-karaoke' }), true);
+    assert.equal(isHostRef({ kjId: 'a', companyId: 'b' }), true);
+  });
+
+  it('rejects a legacy inline host and empty values', () => {
+    assert.equal(isHostRef({ name: 'KJ Stephanie' }), false);
+    assert.equal(isHostRef({}), false);
+    assert.equal(isHostRef(null), false);
+    assert.equal(isHostRef(undefined), false);
+  });
+});
+
+describe('resolveHostRef', () => {
+  const registries = {
+    kjs: { 'kj-stephanie': { name: 'KJ Stephanie' } },
+    companies: { 'starling-karaoke': { name: 'Starling Karaoke', website: 'https://starling.example' } },
+  };
+
+  it('resolves a KJ-only ref', () => {
+    const h = resolveHostRef({ kjId: 'kj-stephanie' }, registries);
+    assert.equal(h.name, 'KJ Stephanie');
+    assert.equal(h.affiliation, undefined);
+    assert.equal(h.kjId, 'kj-stephanie');
+  });
+
+  it('resolves a company-only ref into the affiliation slot', () => {
+    const h = resolveHostRef({ companyId: 'starling-karaoke' }, registries);
+    assert.equal(h.name, undefined);
+    assert.equal(h.affiliation, 'Starling Karaoke');
+    assert.equal(h.website, 'https://starling.example');
+  });
+
+  it('lets the company fill a website the KJ lacks', () => {
+    const h = resolveHostRef({ kjId: 'kj-stephanie', companyId: 'starling-karaoke' }, registries);
+    assert.equal(h.name, 'KJ Stephanie');
+    assert.equal(h.affiliation, 'Starling Karaoke');
+    assert.equal(h.website, 'https://starling.example');
+  });
+
+  it('returns null when neither id resolves', () => {
+    assert.equal(resolveHostRef({ kjId: 'nope' }, registries), null);
+  });
+});
+
+describe('hydrateVenues', () => {
+  const data = {
+    kjs: { 'kj-stephanie': { name: 'KJ Stephanie' } },
+    companies: { 'starling-karaoke': { name: 'Starling Karaoke' } },
+    listings: [
+      { id: 'a', name: 'A', host: { kjId: 'kj-stephanie' }, schedule: [] },
+      { id: 'b', name: 'B', host: { name: 'Legacy Inline KJ' }, schedule: [] },
+      {
+        id: 'c',
+        name: 'C',
+        schedule: [{ frequency: 'every', day: 'Friday', host: { companyId: 'starling-karaoke' } }],
+      },
+    ],
+  };
+
+  it('resolves a venue-level ref into the display shape', () => {
+    const [a] = hydrateVenues(data);
+    assert.equal(a.host.name, 'KJ Stephanie');
+  });
+
+  it('leaves a legacy inline host untouched', () => {
+    const b = hydrateVenues(data)[1];
+    assert.equal(b.host.name, 'Legacy Inline KJ');
+  });
+
+  it('resolves per-show refs on schedule entries', () => {
+    const c = hydrateVenues(data)[2];
+    assert.equal(c.schedule[0].host.affiliation, 'Starling Karaoke');
+  });
+
+  it('does not mutate the input listings', () => {
+    const input = JSON.parse(JSON.stringify(data));
+    hydrateVenues(input);
+    assert.deepEqual(input.listings[0].host, { kjId: 'kj-stephanie' });
+  });
+
+  it('tolerates missing registries and empty data', () => {
+    assert.deepEqual(hydrateVenues({ listings: [] }), []);
+    assert.deepEqual(hydrateVenues({}), []);
+    assert.deepEqual(hydrateVenues(null), []);
+  });
+});


### PR DESCRIPTION
## Summary

Schedule matching *is* the product — a regression there sends someone to a bar on the wrong night — and it had no unit coverage. The e2e suite cannot reach branches like `fifth` or the fourth-vs-last distinction unless `data.json` happens to contain such an entry inside the rendered window.

**66 tests, ~140 ms**, built-in Node runner. No new devDependency, no build step (ADR-002 holds).

## Related Issue

Fixes #150

## Contents

**`test/date.test.mjs` — 39 tests**

- **Fixture guards** asserting January 2026 has five Fridays and February has four. If that assumption is ever wrong the guard fails loudly, instead of silently weakening every case built on it.
- **`fourth` vs `last` vs `fifth`**, including the case that justifies having both frequencies: in a four-Friday month they are the *same date* (Feb 27), and in a five-Friday month they are not (Jan 23 vs Jan 30).
- **Exclusions** in object and bare-string form, plus the deliberate behaviour that an exclusion does **not** stop the schedule matching — the card still renders, with a closed indicator.
- **`isDateInRange` with `start === end ===` the day being checked** — the exact #60 repro. That issue's only unmet DoD box was "add a regression test".
- 21:00 → 01:00 midnight crossing; `formatTime24`/`formatTime12` round trip.

**`test/venues.test.mjs` — 27 tests**

- `venuePasses` across the dedicated toggle, search, and `activePeriod`
- `hydrateVenues` for KJ-only, company-only, and combined refs, the legacy inline shape, and that it does not mutate its input
- `resolveHostRef` field precedence — KJ wins, company fills gaps

## Two tests pin behaviour that is wrong on purpose

Both carry a comment naming the ticket that will change them:

```js
it('does NOT match event names', ...)        // CLAUDE.md claims it does — #37 / #152
it('matches on SUBSTRING, so distinct KJs collide', ...)  // #124 Phase 5, #171
```

These are not endorsements. They are tripwires: whichever way those tickets resolve, the assertion has to be revisited, which is exactly what you want from a test covering known-wrong behaviour.

## Mutation-checked, not assumed

A green suite proves nothing on its own. I reintroduced three real bugs and confirmed each is caught:

| Mutation | Tests failed |
|---|---|
| `parseLocalDate` parses as UTC (the #60 bug) | **6** |
| `last` collapsed into the 4th occurrence | **2** |
| Ordinal guard narrowed so `fifth` falls through | **2** |
| *(unmutated)* | 0 — 39 pass |

## Why these modules load in Node at all

`venues.js` imports `render.js`, which imports `escapeHtml`. That used to build a detached `<div>`, so it threw outside a browser. #147 rewrote it as string replacement, which made `render.js` unit-testable as a side effect. Worth knowing before anyone "simplifies" it back.

## Documentation Checklist

- [ ] Project spec updated (if behavior changed)
- [ ] CLAUDE.md updated (if architecture/structure changed)
- [ ] README.md updated (if public-facing features changed)
- [x] No documentation updates needed

No behaviour change. CLAUDE.md's Testing section documents only `?debug=1` and mentions neither suite nor CI — #152 owns that sweep, and it now has a third thing to add.

## Testing Checklist

- [x] Manually tested the happy path
- [x] Tested edge cases (empty input, missing data, etc.)
- [x] Checked for regressions in related features
- [ ] No testing needed (docs-only change)

All three gates on this branch:

| Gate | Result |
|---|---|
| `npm run test:unit` | 66 passed, 0 failed (~140 ms) |
| `npm test` (e2e) | 74 passed, 0 failed (1.3 min) |
| `npm run validate:all` | passes; CSS load order OK on all 5 pages |

Wired into the **fast** CI job, beside the validators — sub-second and browser-free, so it gives a failure signal long before Playwright finishes.

## One small thing

I suppressed `MODULE_TYPELESS_PACKAGE_JSON` on the `test:unit` script only. Node emits it for every `js/**` ES module because the extension is `.js` and `package.json` has no `type` field. The obvious fix — adding `"type": "module"` — would break `playwright.config.js` and the CommonJS files in `scripts/`, both of which use `require`/`module.exports`. Verified both still load after the change.
