### PR TITLE
#153: Retire js/data.js from the spec, submit.html, and scripts; fix ADR statuses

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -6,7 +6,5 @@
   - [Code Patterns](patterns.md)
 - **Architecture Decisions**
   - [ADR Index](adr/README.md)
-  - [001: Supabase JSONB schema](adr/001-supabase-schema-jsonb.md)
-  - [002: Vanilla JS, no build](adr/002-vanilla-js-no-build.md)
-  - [003: GitHub Pages deploy](adr/003-github-pages-deploy.md)
-  - [004: Parallel data source flag](adr/004-parallel-data-source-flag.md)
+- **Spikes**
+  - [Surface data unification](spikes/surface-data-unification.md)

--- a/docs/adr/001-supabase-schema-jsonb.md
+++ b/docs/adr/001-supabase-schema-jsonb.md
@@ -8,6 +8,8 @@
 
 ## Context
 
+> **Note (2026-08, #153):** `js/data.js` is referenced throughout this ADR as the static source. It was retired by [ADR-008](008-fetch-data-json-directly.md) — the browser now fetches `js/data.json` directly, and `scripts/audit-for-supabase.js` (cited below as the integrity gate) was deleted by #151, its surviving checks folded into `scripts/validate-data.js`. The prose below is left as written because it records the context at the time. See [ADR-005](005-venue-json-schema.md) for the current validation story.
+
 The project is moving to a Supabase backend in parallel with the static `js/data.js` source (production stays on JSON for Austin; Supabase engages behind a feature flag). Two schema shapes were viable.
 
 Constraints at decision time:

--- a/docs/adr/002-vanilla-js-no-build.md
+++ b/docs/adr/002-vanilla-js-no-build.md
@@ -96,7 +96,7 @@ Rejected because:
 
 ## Implementation notes
 
-- **Entry:** `index.html` loads `js/data.js` as a global, then imports `js/app.js` as a module.
+- **Entry:** `index.html` imports `js/app.js` as a module; `app.js` fetches `js/data.json` at runtime ([ADR-008](008-fetch-data-json-directly.md)). *(Corrected 2026-08 — this line previously described the `js/data.js` global, which ADR-008 removed. The decision itself is unaffected; ADR-008 strengthens it by deleting the one generation step ADR-006 had carved out.)*
 - **Component pattern:** `js/components/Component.js` — base class. Lifecycle: `constructor → init → template → render → afterRender → destroy`.
 - **State:** `js/core/state.js` — `getState`, `setState`, `subscribe` (observer pattern).
 - **Events:** `js/core/events.js` — `emit`, `on` with `Events` constants (pub/sub).

--- a/docs/adr/006-data-json-canonical.md
+++ b/docs/adr/006-data-json-canonical.md
@@ -1,6 +1,6 @@
 # ADR-006: `js/data.json` canonical, `js/data.js` auto-generated
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-008](008-fetch-data-json-directly.md) (2026-07)
 **Date:** 2026-06-10
 **Issue:** [#102](https://github.com/Johnesco/karaokedirectory/issues/102)
 **Related:** [ADR-002](002-vanilla-js-no-build.md) (no build step) · [ADR-005](005-venue-json-schema.md) (venue schema) · [ADR-004](004-parallel-data-source-flag.md) (parallel data source)
@@ -66,3 +66,11 @@ The substance of ADR-002 — "files served as-is, no toolchain to learn" — hol
 - **#100 / PR #104** authored the venue schema
 - **#101 / PR #105** aligned `submit.html` to the schema shape
 - This ticket finishes the loop: the canonical artifact becomes JSON, and `submit.html`'s emit step matches what `data.json` stores
+
+## Superseded (2026-07, #126 / ADR-008)
+
+The half of this decision that survives is that **`js/data.json` is canonical** — that still holds and is the basis of everything since.
+
+The half that did not survive is the generated `js/data.js` wrapper. [ADR-008](008-fetch-data-json-directly.md) deleted it: `app.js`'s `loadData()` was already async, so the synchronous-global requirement that justified the wrapper had evaporated, and `submit.html` was downloading ~73 KB of listings to render about thirteen tag checkboxes. With the wrapper gone, the "narrow exception to ADR-002's no-build rule" this ADR carved out is also gone — there is no generation step in the repo at all.
+
+The alternative listed above as *"Browser fetches `data.json` at runtime… saved for a follow-up"* is the one that won.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,6 @@ Format and threshold rule: see [sdlc-baseline `docs/adrs.md`](https://github.com
 | [003](003-github-pages-deploy.md) | GitHub Pages as deploy target | Accepted |
 | [004](004-parallel-data-source-flag.md) | Parallel data source via URL flag — production stays on JSON | Accepted |
 | [005](005-venue-json-schema.md) | Venue JSON Schema as single source of truth | Accepted |
-| [006](006-data-json-canonical.md) | `js/data.json` canonical, `js/data.js` auto-generated | Accepted |
+| [006](006-data-json-canonical.md) | `js/data.json` canonical, `js/data.js` auto-generated | Superseded by [008](008-fetch-data-json-directly.md) |
 | [007](007-host-registry-normalization.md) | Host normalization — KJ and company registries referenced by shows | Accepted |
 | [008](008-fetch-data-json-directly.md) | Browser fetches `js/data.json` — remove the generated `js/data.js` wrapper | Accepted |

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -273,7 +273,7 @@ The map isn't date-scoped, so "today" (`new Date()`) is the reference date. `Map
 
 ### Venue Count Info
 
-Displays "X of Y venues have map coordinates" at the bottom. If some venues lack coordinates, shows a hint to add them via the editor.
+Displays "X of Y venues have map coordinates" at the bottom. If some venues lack coordinates, shows a hint to add them — in practice via `node scripts/geocode-venues.js`, which patches `js/data.json` in place.
 
 ### Filtering
 
@@ -927,7 +927,7 @@ The form is structured as a short required-fields zone, then a single `<details>
 |---------|--------|
 | Tags | Tag checkboxes (chip-style) generated at load by fetching `tagDefinitions` from `js/data.json` — adding a tag there auto-surfaces here, no parallel hardcoded list. System tags (`dedicated`, `special-event`) and age tags are excluded from the grid; age restriction is its own radio (not sure / 21+ / 18+ / all-ages / family-friendly) whose value joins the `tags: []` array at submit time, matching the schema's "age is a tag" shape. |
 | Who runs it | KJ name, company, website — either or both, mirroring the host model (§11). Both text inputs carry a `<datalist>` of names from the `kjs` / `companies` registries in `js/data.json`, so typing suggests hosts already in the directory. See "Host matching on submit" below. |
-| Venue Social Links | Website, Facebook, Instagram (3 fields — other platforms intentionally cut to reduce friction; curator can add via editor) |
+| Venue Social Links | Website, Facebook, Instagram (3 fields — other platforms intentionally cut to reduce friction; the curator tool can add the rest) |
 | Notes | Free-text textarea |
 | Your Contact Info | Submitter name (required if KJ); contact methods checkboxes (email, phone text, phone call, other), each reveals its input on check |
 
@@ -989,9 +989,11 @@ The `venue` object inside the Apps Script payload validates against [`schema/ven
 
 ## 16 Venue Editing (out of scope for this repo)
 
-**Status:** The in-repo `editor.html` was removed. Venue editing now happens in a **local-only curator tool** maintained by the project owner outside this repo. That tool is a single-page HTML app that holds the venue data plus private curator metadata (sources, contacts, notes, last-verified dates), and exports a public-stripped `js/data.js` to publish.
+**Status:** The in-repo `editor.html` was removed. Venue editing now happens in a **local-only curator tool** maintained by the project owner outside this repo. That tool is a single-page HTML app that holds the venue data plus private curator metadata (sources, contacts, notes, last-verified dates), and exports a public-stripped `js/data.json` to publish.
 
-This spec section previously described the in-repo editor's UI in detail; that content is no longer applicable. If you're a contributor who needs to add or modify a venue and don't have access to the curator tool, edit `js/data.js` directly per the schema in §11 and open a PR — the owner will reconcile your change with the curator master.
+This spec section previously described the in-repo editor's UI in detail; that content is no longer applicable. If you're a contributor who needs to add or modify a venue and don't have access to the curator tool, edit `js/data.json` directly per the schema in §11, run `node scripts/validate-data.js`, and open a PR — the owner will reconcile your change with the curator master.
+
+`js/data.js` no longer exists. It was a generated browser wrapper around the same data and was deleted by [ADR-008](adr/008-fetch-data-json-directly.md); the browser now fetches `js/data.json` at runtime. Any instruction elsewhere to edit `data.js` is stale.
 
 ---
 

--- a/scripts/geocode-venues.js
+++ b/scripts/geocode-venues.js
@@ -182,8 +182,9 @@ function sleep(ms) {
  * Main function
  */
 async function main() {
-    // js/data.json is canonical (#102). data.js is regenerated from it
-    // by scripts/sync-data-js.js, so we patch data.json then sync.
+    // js/data.json is the single source (#102, ADR-006) and the browser fetches
+    // it directly (ADR-008), so patching it in place is the whole job — there is
+    // no generated copy to sync.
     const dataPath = path.join(__dirname, '..', 'js', 'data.json');
     console.log('Reading:', dataPath);
 

--- a/submit.html
+++ b/submit.html
@@ -768,7 +768,7 @@
             });
 
             // Collect tags — iterate the same id list used to render the grid
-            // so adding a tag in data.js flows through both directions automatically.
+            // so adding a tag in data.json flows through both directions automatically.
             const tags = [];
             getUserSelectableTagIds().forEach(tag => {
                 if (formData.get(`tag-${tag}`)) tags.push(tag);
@@ -968,7 +968,7 @@
             body += 'TODO:\n';
             body += '- [ ] Verify venue information\n';
             body += '- [ ] Add coordinates (lat/lng)\n';
-            body += '- [ ] Add to data.js\n';
+            body += '- [ ] Add to data.json (validate with: node scripts/validate-data.js)\n';
             if (isKJ) {
                 body += '- [ ] Contact KJ to confirm details\n';
             }

--- a/supabase/seed-from-data.js
+++ b/supabase/seed-from-data.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Seed script — converts js/data.js into SQL INSERT statements
+ * Seed script — converts js/data.json into SQL INSERT statements
  * for the JSONB-heavy schema defined in migrations/004_jsonb_redesign.sql
  *
  * Each venue becomes a single row: (id, name, active, data JSONB)
@@ -39,7 +39,7 @@ function escJsonb(obj) {
 const lines = [];
 
 lines.push('-- ============================================================================');
-lines.push('-- Seed data generated from js/data.js (JSONB schema — issue #47)');
+lines.push('-- Seed data generated from js/data.json (JSONB schema — issue #47)');
 lines.push(`-- Generated: ${new Date().toISOString()}`);
 lines.push('-- ============================================================================');
 lines.push('');

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,5 +1,5 @@
 -- ============================================================================
--- Seed data generated from js/data.js (JSONB schema — issue #47)
+-- Seed data generated from js/data.json (JSONB schema — issue #47)
 -- Generated: 2026-05-29T02:00:39.281Z
 -- ============================================================================
 


### PR DESCRIPTION
## Summary

ADR-008 deleted `js/data.js` in July. The instructions to edit it did not go with it.

The authoritative spec still told contributors to edit a file that does not exist — and `submit.html` shipped that instruction to the curator in the TODO checklist of **every single submission**.

## Related Issue

Fixes #153 · closes out the last unmet DoD box on #126 and the residue of #95

## Live instructional text corrected

| Where | Was | Now |
|---|---|---|
| spec §20 | "edit `js/data.js` directly per the schema in §11" | edit `js/data.json`, run `validate-data.js`, open a PR — plus an explicit note that `js/data.js` no longer exists |
| spec §4 | "add them via the editor" | names `scripts/geocode-venues.js`; the editor was removed in #95 |
| spec §15 | "curator can add via editor" | "the curator tool can add the rest" |
| `submit.html` emailed TODO | `- [ ] Add to data.js` | `- [ ] Add to data.json (validate with: node scripts/validate-data.js)` |
| `geocode-venues.js` comment | "data.js is regenerated by `scripts/sync-data-js.js`" | both were deleted by ADR-008 — corrected |
| `seed-from-data.js` + `seed.sql` header | "generated from js/data.js" | `js/data.json` |

I added a standalone line to §20 saying outright that `js/data.js` is gone and any instruction to edit it is stale — so the next reader doesn't have to reconstruct that from an ADR.

## ADR statuses

- **ADR-006 → Superseded by ADR-008**, in the file and the index. The new section separates the half that survived (`data.json` is canonical — still true, still the basis of everything) from the half that didn't (the generated wrapper). It notes that the runtime-fetch option ADR-006 itself listed and deferred is the one that ultimately won.
- **ADR-002's implementation note** claimed `index.html` loads `js/data.js` as a global. Corrected in place with a dated marker. The *decision* is unaffected — ADR-008 strengthens it, by removing the single generation step ADR-006 had carved out as an exception.
- **ADR-001** gains a note that both `data.js` and `audit-for-supabase.js` (which it cites as the integrity gate) are gone. Its prose is left as written — it records the context at the time, per the index's append-only rule.

## `docs/_sidebar.md`

Listed ADRs 001–004 individually, orphaning **005–008 and the entire `spikes/` directory** from the docs site. Collapsed to the ADR Index link so the list cannot drift again, and added a Spikes group. Verified every link target resolves.

## Deliberately not changed

- **The spec changelog and known-discrepancy rows** that mention `data.js`. Those are a historical record of what happened; rewriting them would be falsifying it.
- **ADR-004's status.** It is contradicted by the code too — it describes a `?supabase=true` mechanism that exists nowhere — but it belongs to the Supabase park (#159 / ADR-009). Correcting it here and there would conflict.

## One thing I did and undid

I regenerated `seed.sql` from the corrected generator, then reverted it. It is a 99-row data change entangled with #159's park decision, not a stale-string sweep — and making the file look freshly maintained would undercut the evidence that justifies parking it. Only the header comment changed.

## Documentation Checklist

- [x] Project spec updated (if behavior changed)
- [ ] CLAUDE.md updated (if architecture/structure changed)
- [ ] README.md updated (if public-facing features changed)
- [ ] No documentation updates needed

CLAUDE.md is #152's job and is deliberately untouched here.

## Testing Checklist

- [x] Manually tested the happy path
- [x] Tested edge cases (empty input, missing data, etc.)
- [x] Checked for regressions in related features
- [ ] No testing needed (docs-only change)

`submit.html` is not docs, so I exercised it rather than eyeballing the diff. Served over http and called the email builder in a browser:

```
TODO:
- [ ] Verify venue information
- [ ] Add coordinates (lat/lng)
- [ ] Add to data.json (validate with: node scripts/validate-data.js)
```

Tag grid hydrated with 13 checkboxes (so the `data.json` fetch path is intact), no console errors.

| Gate | Result |
|---|---|
| `npm test` (e2e) | 74 passed |
| `npm run validate:all` | passes, all 5 pages |
| Grep for live `data.js` instructions | none — every remaining mention is ADR history or a changelog row |
| Sidebar link targets | all 5 resolve |
