### PR TITLE
#171: ADR-011 — entity link contract, every linkable thing is {type, id}

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -573,6 +573,7 @@ Current ADRs:
 - [ADR-008](docs/adr/008-fetch-data-json-directly.md) — Browser fetches `js/data.json`, removing the generated `data.js` wrapper
 - [ADR-009](docs/adr/009-park-supabase.md) — Park Supabase: remove the dormant runtime path, keep the design
 - [ADR-010](docs/adr/010-static-on-netlify-only-constraint.md) — **Static output on Netlify is the only architectural constraint** (supersedes 002, 003)
+- [ADR-011](docs/adr/011-entity-link-contract.md) — Entity link contract: every linkable thing is `{type, id}` over a registry with stable ids
 
 ## Security Considerations
 - Always use `escapeHtml()` when rendering user-provided content

--- a/docs/adr/011-entity-link-contract.md
+++ b/docs/adr/011-entity-link-contract.md
@@ -1,0 +1,123 @@
+# ADR-011: Entity link contract — every linkable thing is `{type, id}`
+
+**Status:** Accepted
+**Date:** 2026-08-02
+**Issue:** [#171](https://github.com/Johnesco/karaokedirectory/issues/171)
+**Related:** [ADR-007](007-host-registry-normalization.md) (host registries) · [ADR-010](010-static-on-netlify-only-constraint.md) (static-on-Netlify is the only constraint) · [#174](https://github.com/Johnesco/karaokedirectory/issues/174) (SEO strategy — decides *rendering*, not identity)
+
+## Context
+
+The directory is close to letting you move between its entities — click a KJ, see their shows; click a tag, see that kind of venue. The destination for the KJ case already exists: `KJDossierView` renders one host's complete schedule across every venue.
+
+What is missing is **identity**, and the gap is not theoretical.
+
+ADR-007 gave every KJ and company a stable registry id. `js/utils/hosts.js:66-67` attaches `kjId`/`companyId` to every hydrated host, and its own docstring says why: *"The ids ride along on the result for id-aware consumers (KJ index, dossier links)."*
+
+A grep for those keys outside `hosts.js` returns **one comment**. The substrate was built, documented for exactly this purpose, and never connected.
+
+### The gap, measured against real data
+
+- **`?kj=` carries four different meanings** in one namespace: the sentinel `all`, the sentinel `none`, a KJ *display name*, and a company *display name*. Two registries plus two magic values, resolved by one substring match.
+- **Resolution is `containsIgnoreCase`, not lookup** (`js/services/venues.js:134-141`). This is a live defect, not a future risk:
+
+  ```
+  ?kj=Armando  →  3 venues, belonging to TWO different KJs
+      Dog 'n' Bone Pub        <- Armando
+      Hudson's On Mercer St.  <- Armando
+      Feral Housewife Wine    <- KJ Armando and Paola
+  ```
+
+  `armando` and `kj-armando-and-paola` are distinct registry entries. The dossier silently merges them.
+- **Links are built from display names** (`KJIndexView.js:242, :262, :274` all emit `?kj=${encodeURIComponent(name)}`), and `collectIndex()` keys on `name.toLowerCase()`, discarding the id it was handed. Renaming a KJ breaks every link to them.
+- **Only two entity types are linkable at all.** Tags render as inert `<span>` (`js/utils/tags.js:37`) despite having stable ids; cities are free text; and the host name on a venue card is a plain `<p>` (`js/utils/render.js:180`) — so the obvious click target for "see this KJ's other nights" is not a link anywhere outside the KJ index.
+
+[ADR-010](010-static-on-netlify-only-constraint.md) removed the constraint that made entity URLs impossible. The contract has to be settled before a router is written against the status quo.
+
+## Decision
+
+**Every linkable thing is a `{type, id}` pair, where `id` is a stable registry key — never a display name.**
+
+### 1. The entity types
+
+| Type | Id source | Count | Status |
+|---|---|---|---|
+| `venue` | `listings[].id` | 80 | exists, slug-safe |
+| `kj` | `kjs` registry key | 24 | exists, slug-safe |
+| `company` | `companies` registry key | 18 | exists, slug-safe |
+| `tag` | `tagDefinitions` key | 19 | exists — **two are not slug-safe**, see below |
+| `city` | *(none yet)* | — | blocked on [#170](https://github.com/Johnesco/karaokedirectory/issues/170) |
+
+Audited against `js/data.json`: all 80 venue, 24 KJ, and 18 company ids already match `^[a-z0-9]+(-[a-z0-9]+)*$`, and there are **zero collisions across the four namespaces**.
+
+### 2. Ids are the link, names are the label
+
+A link is built from the id. A display name is never an identifier. `KJIndexView` must carry the registry id through `collectIndex()` instead of discarding it, and resolution becomes an exact lookup rather than a substring scan — which is what fixes the Armando collision.
+
+### 3. Sentinels leave the id namespace
+
+`all` and `none` are not entities and must stop sharing a namespace with them. They become distinct routes (an index route and a filter route), not values of an id parameter.
+
+Both strings happen to be unused as ids today. That is luck, not design — the whole point is that a future KJ named "All" must not be able to break the index.
+
+### 4. `kj` and `company` are separate types
+
+They are two registries describing two different kinds of thing, and the KJ index already links both through the same `?kj=`. One namespace for two entity types is the same category error as the sentinels.
+
+They stay separately addressable even though a company page and a KJ page may look similar. ADR-007's rule — *the KJ↔company link lives on the show, not on the entities* — means a roster is derived by scanning shows, and that derivation works the same either way.
+
+### 5. Path-shaped URLs, not query parameters
+
+Entity URLs take the form `/<type>/<id>` — `/kj/armando`, `/venue/dog-n-bone-pub`, `/tag/lgbtq`.
+
+Query parameters describe a *filtered view of a page*; paths name a *thing*. That distinction is what makes an entity URL indexable, and Netlify already serves extensionless paths (`/bday` returns 200 today with no configuration).
+
+`?kj=` and `#venue=` must keep working as permanent redirects — they are in the wild, in the sitemap discussion, and in at least one live nav link.
+
+### 6. Two tag ids are not URL-safe
+
+`21+` and `18+` contain a character that means "space" when a URL is decoded as a query string, and that reads as an encoding bug in a path. This blocks `/tag/21+`.
+
+Resolve it in whichever way [#170](https://github.com/Johnesco/karaokedirectory/issues/170) prefers — a separate `slug` field on the tag definition, or renaming the ids to `age-21-plus`. **Do not** paper over it with percent-encoding: `/tag/21%2B` is not a URL anyone will type, share, or recognise.
+
+### 7. What this ADR does NOT decide
+
+**How entity pages get rendered for a crawler.** Pre-generated static files at build time, Netlify prerendering, or accepting client-side rendering are all still open, and they are [#174](https://github.com/Johnesco/karaokedirectory/issues/174)'s call.
+
+This contract is deliberately compatible with every one of those. Naming the identity model does not commit to a rendering strategy — but a rendering strategy chosen *without* the identity model would bake display names into URLs, which is the mistake this ADR exists to prevent.
+
+Also not decided: **which entity types actually get published pages.** `/tag/brewery` covering one venue is thin content, and 5 of 19 tags cover ≤2 venues while 3 cover none. Whether a type is *addressable* and whether it is *indexable* are separate questions; this ADR settles only the first.
+
+## Consequences
+
+### Positive
+
+- **The Armando collision becomes unrepresentable**, not merely fixed. Exact-id lookup has no substring semantics to get wrong.
+- **Renaming a KJ stops breaking links.** Ids are stable; display names are free to change, which matters for a directory whose hosts use stage names.
+- **`hosts.js`'s ids finally have a consumer** — the thing they were added for in ADR-007.
+- **Cross-linking and SEO stop being two projects.** `/kj/armando` is simultaneously the click target and the indexable page.
+- **JSON-LD gets `@id` for free.** Stable entity URLs are exactly what structured data wants, so [#164](https://github.com/Johnesco/karaokedirectory/issues/164) gets easier rather than harder.
+
+### Negative
+
+- **`?kj=` links in the wild need permanent redirects**, and they must be maintained indefinitely. Cheap on Netlify, but real.
+- **The tag id problem has to be solved before `/tag/` exists.** That is a data migration touching `tagDefinitions` and every `tags[]` array — small, but not free.
+- **A `city` type cannot ship until cities have a registry** (#170). Place is the one entity with no stable ids at all.
+
+### Neutral
+
+- **This changes no behaviour on its own.** No links, views, or routes are added by this ADR. It constrains work that was going to happen anyway.
+
+## Alternatives considered
+
+- **Keep `?kj=<name>` and just fix the substring match.** Cheapest, and it does fix Armando. Rejected: it leaves display names as identifiers, so renames still break links, and query parameters remain the wrong shape for an indexable page. It fixes the symptom and preserves the cause.
+- **One flat namespace for all entities** (`/e/armando`). Currently possible — there are zero cross-type id collisions. Rejected as fragile by construction: it makes the absence of collisions a permanent constraint on four independently-edited registries, and it loses the type information a reader gets free from `/kj/`.
+- **Keep sentinels as reserved ids** (`all`, `none` disallowed as registry keys, enforced by `validate-data.js`). Workable and cheap. Rejected as strictly worse than routing them separately: it spends a validator rule to preserve a category error, and the reserved list grows every time a new magic value is wanted.
+
+## Related work
+
+- **#171** — this ADR
+- **#124 Phase 5** — carries the "stable `?kj=<slug>` ids" bullet; this ADR is its contract
+- **#155 / #156** — router and view registry, both of which should be built against this rather than the status quo
+- **#174** — SEO strategy: decides rendering and which types get indexed
+- **#170** — cities registry, which a `city` entity type depends on
+- **#164** — JSON-LD, which gains `@id` from this

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ Format and threshold rule: see [sdlc-baseline `docs/adrs.md`](https://github.com
 | [008](008-fetch-data-json-directly.md) | Browser fetches `js/data.json` — remove the generated `js/data.js` wrapper | Accepted |
 | [009](009-park-supabase.md) | Park Supabase — remove the dormant runtime path, keep the design | Accepted |
 | [010](010-static-on-netlify-only-constraint.md) | Static output on Netlify is the only architectural constraint | Accepted |
+| [011](011-entity-link-contract.md) | Entity link contract — every linkable thing is `{type, id}` | Accepted |


### PR DESCRIPTION
## Summary

ADR-007 gave every KJ and company a stable registry id. `js/utils/hosts.js:66-67` attaches `kjId`/`companyId` to every hydrated host, and its own docstring says why:

> *"The ids ride along on the result for id-aware consumers (KJ index, dossier links)."*

A grep for those keys outside `hosts.js` returns **one comment**. The substrate was built, documented for exactly this purpose, and never connected to anything.

**Documentation only.** No links, views, routes, or behaviour change.

## Related Issue

Fixes #171

## The gap is live, not theoretical

I verified it against real data rather than reasoning about it:

```
?kj=Armando  →  3 venues, belonging to TWO different KJs

    Dog 'n' Bone Pub        <- Armando
    Hudson's On Mercer St.  <- Armando
    Feral Housewife Wine    <- KJ Armando and Paola
```

`armando` and `kj-armando-and-paola` are distinct registry entries. `venueMatchesHost`'s `containsIgnoreCase` (`js/services/venues.js:134-141`) silently merges them, so the dossier for one KJ shows another's venue.

## The contract

- **Ids are the link; display names are the label.** Renaming a KJ must not break links to them — which matters for a directory whose hosts use stage names.
- **Sentinels leave the id namespace.** `all` and `none` become routes, not id values. Both happen to be unused as ids today — that's luck, not design, and a future KJ named "All" shouldn't be able to break the index.
- **`kj` and `company` are separate types.** Two registries sharing one `?kj=` is the same category error as the sentinels.
- **Path-shaped URLs** (`/kj/armando`), because a query parameter describes a *filtered view of a page* while a path names a *thing*. `?kj=` and `#venue=` keep working as permanent redirects. Netlify already serves extensionless paths — `/bday` returns 200 today with no config.

## What the audit found

| Type | Ids | Slug-safe? |
|---|---|---|
| venue | 80 | ✅ all |
| kj | 24 | ✅ all |
| company | 18 | ✅ all |
| tag | 19 | ❌ **`21+` and `18+` are not** |

**Zero collisions across the four namespaces.** But two tag ids contain a character that decodes as a space in a URL, which blocks `/tag/21+`. That has to be resolved by #170 — a `slug` field or renamed ids. I explicitly rejected percent-encoding: `/tag/21%2B` is not a URL anyone will type, share, or recognise.

## What this deliberately does not decide

**How entity pages get rendered for a crawler.** Pre-generated static files, Netlify prerendering, or accepting client-side rendering are all still open — that's #174's call, and this contract is compatible with every one of them.

But the ordering matters: a rendering strategy chosen *without* the identity model would bake display names into URLs, which is the exact mistake this ADR prevents.

**Which types get published pages.** `/tag/brewery` covering one venue is thin content — 5 of 19 tags cover ≤2 venues and 3 cover none. *Addressable* and *indexable* are separate questions; this settles only the first.

## Documentation Checklist

- [ ] Project spec updated (if behavior changed) — no behaviour change
- [x] CLAUDE.md updated — ADR list
- [ ] README.md updated
- [ ] No documentation updates needed

Numbered **011** because #173 took 010.

## Testing Checklist

- [x] `npm run validate:all` passes
- [x] `npm run test:unit` passes — 66
- [ ] `npm test` (Playwright) — not run; this PR adds two markdown files and touches no code
- [x] Manually tested the happy path — the audit script above is the verification
- [ ] Tested edge cases
- [ ] Checked for regressions in related features
- [x] No testing needed (docs-only change)

## Follow-on effects

- **#124 Phase 5** carries the "stable `?kj=<slug>` ids" bullet — this is its contract
- **#155 / #156** (router, view registry) should be built against this rather than the status quo
- **#164** (JSON-LD) gains `@id` for free
- **#170** (cities registry) is now a prerequisite for a `city` entity type, and inherits the tag-slug fix
