### PR TITLE
#157: Make state.js the single change channel and prune the dead protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,9 +337,11 @@ Tags are rendered as color-coded badges in VenueCard, VenueModal, and VenueDetai
 
 ### State Management
 - `js/core/state.js`: `getState(key)`, `setState(obj)`, `subscribe(key, callback)` — simple observer pattern
+- **The single change channel.** Change something with `setState`, react with `subscribe(key, …)`. Never announce a state change on the event bus as well — subscribers have already run, and the second notification re-renders every listening view (#157)
 
 ### Event Bus
-- `js/core/events.js`: `emit(event, data)`, `on(event, callback)` — pub/sub with `Events` constants
+- `js/core/events.js`: `emit(event, data)`, `on(event, callback)`, `off(event, callback)`
+- Only for one-shots that are **not** state transitions. That is exactly two events: `VENUE_SELECTED` and `VENUE_CLOSED`. Nine others were deleted in #157 — eight had only one end (no emitter or no listener), and `FILTER_CHANGED` duplicated the state keys it accompanied
 
 ### Component Lifecycle
 `constructor` → `init()` → `template()` → `render()` → `afterRender()` → `destroy()`
@@ -350,7 +352,7 @@ Tags are rendered as color-coded badges in VenueCard, VenueModal, and VenueDetai
 - Escape key: closes card first, then exits to Calendar view
 
 ### Search Feature
-- Navigation updates `searchQuery` state; all views listen for `FILTER_CHANGED` events
+- Navigation updates `searchQuery` state; the views subscribe to that key. State is the only change channel — never `setState` and then `emit` the same change (#157)
 - `venues.js` → `venueMatchesSearch()` matches: venue name, city, neighborhood, venue-level host name/affiliation, per-show host name/affiliation, and tags (ID + label)
 - It does **not** match event names. This file claimed otherwise for months; `venueMatchesSearch` never reads `entry.eventName`. Adding it is a one-line change tracked on #37 — until that lands, the omission is the truth
 - Empty results collapse day cards to header-only (`.day-card--empty`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -316,17 +316,20 @@ sequenceDiagram
 
 | Event Constant | String | Emitted By | Listened By | Payload |
 |---------------|--------|------------|-------------|---------|
-| `VENUE_SELECTED` | `venue:selected` | app.js, VenueCard, WeeklyView, AlphabeticalView | app.js, VenueModal, VenueDetailPane | venue object |
+| `VENUE_SELECTED` | `venue:selected` | app.js, VenueCard, MapView, venue-selection | app.js, VenueModal, VenueDetailPane | venue object |
 | `VENUE_CLOSED` | `venue:closed` | VenueModal | app.js, VenueDetailPane | — |
-| `VENUE_DETAIL_SHOWN` | `venue:detail-shown` | VenueDetailPane | — | venue object |
-| `VIEW_CHANGED` | `view:changed` | Navigation, MapView | — | view name string |
-| `WEEK_CHANGED` | `week:changed` | Navigation | — | — |
-| `FILTER_CHANGED` | `filter:changed` | Navigation, MapView | WeeklyView, AlphabeticalView, MapView | — |
-| `SEARCH_CHANGED` | `search:changed` | — | — | _(defined but unused)_ |
-| `MODAL_OPEN` | `modal:open` | VenueModal | — | — |
-| `MODAL_CLOSE` | `modal:close` | — | VenueModal | _(defined but unused as emitter)_ |
-| `DATA_LOADED` | `data:loaded` | app.js | — | karaokeData object |
-| `DATA_ERROR` | `data:error` | app.js | — | error object |
+
+Two events, both with a real emitter and a real listener. That is deliberate:
+**state changes belong in `state.js`, not on the bus.** A component that needs
+to react to `showDedicated`, `searchQuery`, `weekStart`, `view`, or `hostFilter`
+subscribes to that key — see the state-subscription table in
+[functional spec §21](functional-spec.md).
+
+Nine constants were removed in #157. Eight of them had only one end (emitted
+with nothing listening, or listened for with nothing emitting), and this table
+had been documenting them as `—` for months. The ninth, `FILTER_CHANGED`,
+duplicated the state keys it was emitted alongside, so every filter change
+rendered each listening view twice.
 
 ### Venue Selection Flow
 
@@ -348,13 +351,11 @@ sequenceDiagram
     alt Window width < 1400px AND view !== 'map'
         EventBus->>VenueModal: VENUE_SELECTED handler
         VenueModal->>VenueModal: Show modal with venue data
-        VenueModal->>EventBus: emit(MODAL_OPEN)
     end
 
     alt Window width >= 1400px
         EventBus->>VenueDetailPane: VENUE_SELECTED handler
         VenueDetailPane->>VenueDetailPane: Show venue in sidebar
-        VenueDetailPane->>EventBus: emit(VENUE_DETAIL_SHOWN, venue)
     end
 
     Note over User: User closes detail view
@@ -372,7 +373,6 @@ sequenceDiagram
 sequenceDiagram
     participant User
     participant Navigation
-    participant EventBus as Event Bus
     participant state.js
     participant WeeklyView
     participant AlphabeticalView
@@ -380,20 +380,20 @@ sequenceDiagram
 
     User->>Navigation: Type in search / toggle dedicated
     Navigation->>state.js: setState({ searchQuery }) or setState({ showDedicated })
-    Navigation->>EventBus: emit(FILTER_CHANGED)
 
-    par All views re-render
-        EventBus->>WeeklyView: FILTER_CHANGED handler
+    par state.js notifies subscribers of that key
+        state.js->>WeeklyView: searchQuery / showDedicated subscriber
         WeeklyView->>WeeklyView: render()
     and
-        EventBus->>AlphabeticalView: FILTER_CHANGED handler
+        state.js->>AlphabeticalView: searchQuery / showDedicated subscriber
         AlphabeticalView->>AlphabeticalView: render()
     and
-        EventBus->>MapView: FILTER_CHANGED handler
+        state.js->>MapView: searchQuery / showDedicated subscriber
         MapView->>MapView: updateMarkers()
     end
 
     Note over Navigation: Navigation does NOT re-render (preserves input focus)
+    Note over state.js: The event bus is not involved. Before #157 Navigation<br/>also emitted FILTER_CHANGED here, which the same three<br/>views listened to — so each rendered twice per change.
 ```
 
 ---
@@ -404,15 +404,21 @@ sequenceDiagram
 
 | Key | Type | Default | Writers | Readers | Subscribers |
 |-----|------|---------|---------|---------|-------------|
-| `venues` | array | `[]` | app.js (via initVenues) | venues.js | — |
-| `filteredVenues` | array | `[]` | — | — | — |
-| `filters` | object | `{...}` | — | — | — |
-| `view` | string | `'weekly'` | Navigation, MapView, app.js | Navigation, MapView | app.js → renderView() |
+| `view` | string | `'weekly'` | Navigation, MapView, app.js | Navigation, MapView, router.resolveView | app.js → renderView(), Navigation → render() |
 | `weekStart` | Date | today | Navigation | WeeklyView, Navigation | WeeklyView → render(), Navigation → render() |
 | `showDedicated` | boolean | `true` | Navigation, MapView | All views, Navigation | WeeklyView, AlphabeticalView, MapView, Navigation |
-| `searchQuery` | string | `''` | Navigation | All views (via getVenuesForDate/getVenuesSorted) | — _(uses FILTER_CHANGED event instead)_ |
+| `searchQuery` | string | `''` | Navigation | All views (via getVenuesForDate/getVenuesSorted) | WeeklyView, AlphabeticalView, MapView |
+| `hostFilter` | string | `''` | Navigation, app.js | Navigation, KJDossierView, router.resolveView | app.js → writeLocation() + renderView() |
 | `selectedVenue` | object/null | `null` | VenueModal, VenueDetailPane | — | — |
 | `isLoading` | boolean | `false` | — | — | — |
+
+`venues`, `filteredVenues`, and `filters` used to head this table with empty
+Writers/Readers columns. #157 deleted them — venue data lives in
+`js/services/venues.js`, which is the "Service-Level State" pattern below.
+
+Note that `searchQuery` now has real subscribers. It previously showed `—`
+here, annotated *"uses FILTER_CHANGED event instead"* — the views did react to
+it, just through a second channel that also fired for every other filter.
 
 ### Three Mutation Patterns
 
@@ -446,9 +452,9 @@ graph LR
 Components use `this.subscribe()` to register unsubscribe functions. On `destroy()`, all stored functions are called automatically:
 
 ```javascript
-// In a component's init() method:
+// In a component's init() method — one subscription per state key it reads:
 this.subscribe(subscribe('weekStart', () => this.render()));
-this.subscribe(on(Events.FILTER_CHANGED, () => this.render()));
+this.subscribe(subscribe('searchQuery', () => this.render()));
 
 // Component.subscribe() stores the unsubscribe function:
 subscribe(subscribeFn) {

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -109,8 +109,8 @@ When viewing the current week, the page scrolls to today's day card after render
 ### Filtering
 
 - Respects the "Show dedicated" toggle
-- Respects the search query — day cards with no matching venues collapse to `.day-card--empty`
-- Re-renders on `FILTER_CHANGED` event
+- Respects the search query - day cards with no matching venues collapse to `.day-card--empty`
+- Re-renders on the `weekStart`, `showDedicated`, and `searchQuery` state keys
 
 ### Extended Sections
 
@@ -189,7 +189,7 @@ If no venues match the current search/filter, displays "No venues match your sea
 
 - Respects the "Show dedicated" toggle
 - Respects the search query
-- Re-renders on `FILTER_CHANGED` event
+- Re-renders on the `showDedicated` and `searchQuery` state keys
 
 ---
 
@@ -428,8 +428,9 @@ When the modal is open, `document.body.style.overflow = 'hidden'` prevents backg
 
 ### Events Emitted
 
-- `MODAL_OPEN` when opening
 - `VENUE_CLOSED` when closing
+
+A `MODAL_OPEN` emit on open was removed in #157 - nothing listened for it.
 
 ---
 
@@ -453,9 +454,10 @@ When no venue is selected, shows a microphone icon and the text: "Select a venue
 
 ### State
 
-- Listens to `VENUE_SELECTED` — updates with venue data
-- Listens to `VENUE_CLOSED` — clears to empty state
-- Emits `VENUE_DETAIL_SHOWN` when displaying a venue
+- Listens to `VENUE_SELECTED` - updates with venue data
+- Listens to `VENUE_CLOSED` - clears to empty state
+
+A `VENUE_DETAIL_SHOWN` emit was removed in #157 - nothing listened for it. Card highlighting is applied by the `VENUE_SELECTED` handler in `app.js`.
 
 ---
 
@@ -468,7 +470,7 @@ The app includes a global search bar that filters venues across all views.
 Located in the Navigation component. Visible inline on desktop and phablets (561px+); on phones (≤560px) hidden behind a magnifying-glass toggle button in the navigation bar.
 - **Placeholder:** "Search venues, tags, hosts..."
 - **Clear button** (X icon) appears when search has text; clicking clears input and refocuses it
-- Typing updates the `searchQuery` state and emits `FILTER_CHANGED`
+- Typing updates the `searchQuery` state; the views subscribe to that key
 - **Phone toggle (≤560px):** opening expands the input as a full-width row and focuses it; closing the toggle while a query is active clears the query (prevents invisible active filters). The row stays expanded while a query is active.
 
 ### What Search Matches Against
@@ -500,7 +502,7 @@ The Weekly view's extended sections (Next Week, Later in Month, Next Month) are 
 
 The Navigation component does **not** re-render when search changes, to preserve keyboard focus in the input field. Only the views re-render.
 
-> **Implementation note:** Navigation updates `searchQuery` state and emits `FILTER_CHANGED` but does NOT subscribe to `searchQuery` — this prevents Navigation from re-rendering (which would destroy and recreate the input element, losing keyboard focus). Views subscribe to `FILTER_CHANGED` via the event bus and independently call `this.render()`. The search matching logic lives in `venueMatchesSearch()` in `js/services/venues.js`, which handles all field matching (name, city, neighborhood, host, company, tags by ID and label, dedicated keyword).
+> **Implementation note:** Navigation updates `searchQuery` state but does NOT subscribe to it — that would re-render Navigation, destroying and recreating the input element and losing keyboard focus mid-typing. The views subscribe to `searchQuery` directly and call `this.render()` themselves. (Before #157 they reached it via a `FILTER_CHANGED` event instead, which also fired for every other filter change.) The search matching logic lives in `venueMatchesSearch()` in `js/services/venues.js`, which handles all field matching (name, city, neighborhood, host, company, tags by ID and label, dedicated keyword).
 
 ---
 
@@ -546,8 +548,8 @@ Venues with an `activePeriod` field only appear when the current date falls with
 
 1. User changes filter (dedicated toggle, search input) or loads a URL with `?kj=`
 2. State updated (`showDedicated`, `searchQuery`, or `hostFilter`)
-3. `FILTER_CHANGED` event emitted
-4. All views re-render with filtered results
+3. `state.js` notifies that key's subscribers
+4. Each subscribing view re-renders once with filtered results
 
 ---
 
@@ -1101,52 +1103,74 @@ No analytics tag loads until the visitor consents. See **§23 Analytics and Cons
 
 Centralized state with observer pattern.
 
+**State is the single change channel.** Anything that changes goes through
+`setState`; anything that needs to react subscribes to the key. A state change
+is never *also* announced on the event bus — subscribers have already run, and a
+second notification renders every listening view a second time.
+
 | Key | Type | Default | Purpose |
 |-----|------|---------|---------|
-| `venues` | array | `[]` | All active venues |
-| `filteredVenues` | array | `[]` | Filtered venue results |
-| `filters` | object | `{ day: null, city: null, search: '', dedicatedOnly: false }` | Filter settings |
-| `view` | string | `'weekly'` | Current view: `weekly`, `alphabetical`, or `map` |
+| `view` | string | `'weekly'` | Base view: `weekly`, `alphabetical`, or `map`. What is actually on screen also depends on `hostFilter` — `router.resolveView()` combines the two |
 | `weekStart` | Date | Today | Start date for weekly view |
 | `showDedicated` | boolean | `true` | Whether dedicated venues are shown |
 | `searchQuery` | string | `''` | Current search text |
+| `hostFilter` | string | `''` | KJ/host filter, URL-driven via `?kj=`. `all` and `none` are route sentinels, not host names (ADR-011) |
 | `selectedVenue` | object/null | `null` | Currently selected venue |
 | `isLoading` | boolean | `false` | Loading indicator |
+
+Which view subscribes to which key:
+
+| View | Subscribes to |
+|---|---|
+| `WeeklyView` | `weekStart`, `showDedicated`, `searchQuery` |
+| `AlphabeticalView` | `showDedicated`, `searchQuery` |
+| `MapView` | `showDedicated`, `searchQuery` |
+| `KJDossierView` | *(nothing)* — its only input is `hostFilter`, and a `hostFilter` change replaces the view instance outright |
+| `KJIndexView` | *(nothing)* — static listing |
+| `Navigation` | `view`, `weekStart`, `showDedicated`, `hostFilter`. Deliberately **not** `searchQuery`, which would re-render the input and lose focus mid-typing |
 
 ### API
 
 - `getState(key)` — read a state value (or entire state without key)
 - `setState(updates)` — update state and notify subscribers
 - `subscribe(key, callback)` — subscribe to changes for a specific key; returns unsubscribe function
-- `subscribeAll(callback)` — subscribe to all state changes
 - `navigateWeek(weeks)` — move weekStart by N weeks
 - `goToCurrentWeek()` — reset weekStart to today
 
+> **Removed in #157.** The keys `venues`, `filteredVenues`, and `filters` were
+> documented here as the app's data model, but no code ever read or wrote them —
+> venue data lives in `js/services/venues.js`. `subscribeAll()`, `setFilters()`,
+> and `resetState()` were likewise unused and are gone.
+
 ### Events (`js/core/events.js`)
 
-Pub/sub event bus for component communication.
+Pub/sub bus for genuine one-shots — things that are **not** state transitions.
+If what you want to announce is already a state key, subscribe to the key
+instead (see State above).
 
-| Event | Constant | Trigger |
-|-------|----------|---------|
-| `venue:selected` | `VENUE_SELECTED` | User clicks/selects a venue |
-| `venue:closed` | `VENUE_CLOSED` | Venue detail dismissed |
-| `venue:detail-shown` | `VENUE_DETAIL_SHOWN` | Venue detail displayed |
-| `view:changed` | `VIEW_CHANGED` | User switches views |
-| `week:changed` | `WEEK_CHANGED` | Week navigation occurs |
-| `filter:changed` | `FILTER_CHANGED` | Any filter state changes |
-| `search:changed` | `SEARCH_CHANGED` | Search query changes |
-| `modal:open` | `MODAL_OPEN` | Modal opens |
-| `modal:close` | `MODAL_CLOSE` | Modal closes |
-| `data:loaded` | `DATA_LOADED` | Venue data loaded successfully |
-| `data:error` | `DATA_ERROR` | Data loading failed |
+| Event | Constant | Trigger | Emitters | Listeners |
+|-------|----------|---------|----------|-----------|
+| `venue:selected` | `VENUE_SELECTED` | User clicks/selects a venue | `app.js`, `VenueCard`, `MapView`, `venue-selection` | `app.js`, `VenueModal`, `VenueDetailPane` |
+| `venue:closed` | `VENUE_CLOSED` | Venue detail dismissed | `VenueModal` | `app.js`, `VenueDetailPane` |
+
+That is the whole bus. Both events have a real emitter *and* a real listener,
+and neither duplicates a state key.
 
 ### API
 
 - `on(event, callback)` — subscribe; returns unsubscribe function
-- `once(event, callback)` — subscribe for one execution
 - `off(event, callback)` — unsubscribe specific callback
 - `emit(event, data)` — fire event to all subscribers (errors caught per-handler)
-- `clear(event?)` — remove listeners for one or all events
+
+> **Removed in #157.** The bus carried eleven event names. Eight had only one
+> end: `VENUE_DETAIL_SHOWN`, `VIEW_CHANGED`, `WEEK_CHANGED`, `MODAL_OPEN`,
+> `DATA_LOADED`, and `DATA_ERROR` were emitted with nothing listening;
+> `MODAL_CLOSE` was listened for with nothing emitting; `SEARCH_CHANGED` had
+> neither. The ninth, `FILTER_CHANGED`, was emitted immediately after a
+> `setState` that had already notified the same components — so a single
+> dedicated-toggle click rendered each view twice, and on the map ran
+> `updateMarkers` three times and rebuilt the Leaflet instance. The unused
+> `once()` and `clear()` helpers went with them.
 
 ### URL Hash Sync and Shareable Links
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -129,12 +129,14 @@ Full venue with all optional fields:
 ```javascript
 import { Component } from '../components/Component.js';
 import { getState, subscribe } from '../core/state.js';
-import { on, Events } from '../core/events.js';
 
 export class NewView extends Component {
     init() {
-        // Subscribe to filter changes so the view re-renders
-        this.subscribe(on(Events.FILTER_CHANGED, () => this.render()));
+        // One subscription per state key this view reads in template().
+        // Do NOT also listen on the event bus — state.js already notified you,
+        // and a second channel means a second render (#157).
+        this.subscribe(subscribe('searchQuery', () => this.render()));
+        this.subscribe(subscribe('showDedicated', () => this.render()));
     }
 
     template() {
@@ -180,7 +182,9 @@ Find the view switcher buttons in `template()` and add a new button:
 </button>
 ```
 
-The existing click handler in Navigation uses `dataset.view` to emit `VIEW_CHANGED` — no additional JS needed.
+The existing click handler in Navigation reads `dataset.view` and calls
+`setState({ view, hostFilter: '' })` — no additional JS needed. `app.js`
+subscribes to the `view` key and re-renders through the view registry.
 
 **Step 4 — Add styles in `css/views.css`:**
 
@@ -193,8 +197,8 @@ The existing click handler in Navigation uses `dataset.view` to emit `VIEW_CHANG
 
 - Views are destroyed and recreated on every view switch. Don't store important state in `this.state` — use global state or localStorage.
 - The `init()` method is called in the constructor. Don't access `this.container` in `init()` — it exists but the DOM isn't rendered yet.
-- Always subscribe to `FILTER_CHANGED` so search and dedicated filter work.
-- If your view needs map-like immersive mode, toggle a body class in `app.js`'s `renderView()` function.
+- Subscribe to each state key your `template()` reads — typically `searchQuery` and `showDedicated` — so search and the dedicated filter work.
+- If your view needs map-like immersive mode, give it a `bodyClass` in the `VIEWS` registry in `app.js`. `renderView()` applies and clears them from the table; don't hand-toggle classes.
 
 ---
 
@@ -223,7 +227,7 @@ export class NewComponent extends Component {
         this.subscribe(subscribe('someKey', (value) => {
             this.render();
         }));
-        this.subscribe(on(Events.FILTER_CHANGED, () => {
+        this.subscribe(subscribe('anotherKey', () => {
             this.render();
         }));
     }
@@ -475,7 +479,8 @@ init() {
 
 - `setState()` uses reference equality (`!==`) to detect changes. Mutating an object in place and passing it back won't trigger subscribers — always create a new object.
 - Subscribers are notified after ALL updates in a single `setState()` call are applied. This means a subscriber for key A can safely read key B's new value if both were updated together.
-- Navigation intentionally does NOT subscribe to `searchQuery` — it emits `FILTER_CHANGED` instead so views re-render without the Navigation component itself re-rendering (which would steal keyboard focus from the search input).
+- Navigation intentionally does NOT subscribe to `searchQuery`. Re-rendering Navigation would destroy and recreate the input element, stealing keyboard focus mid-typing. The views subscribe to `searchQuery` themselves, so they update while Navigation stays put.
+- Never `setState(...)` and then `emit(...)` the same change. Subscribers have already run; the emit just renders everything again. The event bus is for one-shots that are not state transitions — currently only `VENUE_SELECTED` and `VENUE_CLOSED` (#157).
 
 ---
 

--- a/js/app.js
+++ b/js/app.js
@@ -134,11 +134,14 @@ async function init() {
     renderView();
 
     // Keep ?kj= in the URL in sync with hostFilter state and re-render the view
-    // (toggle between KJDossierView and the regular weekly/alphabetical/map views).
+    // (toggle between the KJ views and the regular weekly/alphabetical/map ones).
+    //
+    // renderView() builds a fresh view instance, so it has already rendered by
+    // the time this returns. The FILTER_CHANGED emit that used to follow landed
+    // on that brand-new instance and rendered it a second time.
     subscribe('hostFilter', (value) => {
         writeLocation({ hostFilter: value });
         renderView();
-        emit(Events.FILTER_CHANGED, { hostFilter: value });
     });
 
     // Expose helper for map popups
@@ -187,7 +190,6 @@ async function loadData() {
         initTagConfig(data.tagDefinitions);
 
         initVenues(data);
-        emit(Events.DATA_LOADED, data);
 
         // Update debug indicator with data source
         if (isDebugMode()) {
@@ -198,7 +200,6 @@ async function loadData() {
         }
     } catch (error) {
         console.error('Failed to load venue data:', error);
-        emit(Events.DATA_ERROR, error);
 
         // Show error to user
         const container = document.querySelector('#main-content');

--- a/js/components/Navigation.js
+++ b/js/components/Navigation.js
@@ -16,7 +16,6 @@
 
 import { Component } from './Component.js';
 import { getState, setState, subscribe, navigateWeek, goToCurrentWeek } from '../core/state.js';
-import { emit, Events } from '../core/events.js';
 import { formatWeekRange, getWeekStart, isCurrentWeek } from '../utils/date.js';
 import { resolveView, isKJView } from '../core/router.js';
 import { html } from '../utils/string.js';
@@ -198,12 +197,14 @@ export class Navigation extends Component {
     }
 
     afterRender() {
+        // Every handler below changes state and stops. Subscribers to the key
+        // do the rendering. These used to setState AND emit an event that the
+        // same components also listened to, so one click rendered twice (#157).
+
         // View toggle buttons. Always clear hostFilter so clicking from a KJ
         // page exits KJ mode cleanly. No-op when hostFilter is already empty.
         this.delegate('click', '[data-view]', (e, target) => {
-            const view = target.dataset.view;
-            setState({ view, hostFilter: '' });
-            emit(Events.VIEW_CHANGED, view);
+            setState({ view: target.dataset.view, hostFilter: '' });
         });
 
         // Week navigation
@@ -214,20 +215,17 @@ export class Navigation extends Component {
             } else {
                 navigateWeek(parseInt(action, 10));
             }
-            emit(Events.WEEK_CHANGED, getState('weekStart'));
         });
 
         // Dedicated toggle
         this.delegate('change', '[data-filter="dedicated"]', (e, target) => {
             setState({ showDedicated: target.checked });
-            emit(Events.FILTER_CHANGED, { showDedicated: target.checked });
         });
 
         // Search input
         this.delegate('input', '[data-search="query"]', (e, target) => {
             const query = target.value;
             setState({ searchQuery: query });
-            emit(Events.FILTER_CHANGED, { searchQuery: query });
 
             // Update clear button visibility without full re-render
             const clearBtn = this.container.querySelector('[data-search="clear"]');
@@ -264,7 +262,6 @@ export class Navigation extends Component {
                 const clearBtn = this.container.querySelector('[data-search="clear"]');
                 if (clearBtn) clearBtn.remove();
                 setState({ searchQuery: '' });
-                emit(Events.FILTER_CHANGED, { searchQuery: '' });
             }
         });
 
@@ -281,7 +278,6 @@ export class Navigation extends Component {
                 input.focus();
             }
             setState({ searchQuery: '' });
-            emit(Events.FILTER_CHANGED, { searchQuery: '' });
 
             // Remove clear button
             const clearBtn = this.container.querySelector('[data-search="clear"]');

--- a/js/components/VenueDetailPane.js
+++ b/js/components/VenueDetailPane.js
@@ -6,7 +6,7 @@
 import { Component } from './Component.js';
 import { escapeHtml } from '../utils/string.js';
 import { shareVenue } from '../utils/url.js';
-import { on, emit, Events } from '../core/events.js';
+import { on, Events } from '../core/events.js';
 import { getState } from '../core/state.js';
 import { renderTags } from '../utils/tags.js';
 import { renderVenueDetailSections } from '../utils/render.js';
@@ -71,8 +71,10 @@ export class VenueDetailPane extends Component {
             return;
         }
         this.setState({ venue });
-        // Emit event so VenueCard can show selected state
-        emit(Events.VENUE_DETAIL_SHOWN, venue);
+        // A VENUE_DETAIL_SHOWN emit used to follow, commented "so VenueCard can
+        // show selected state". VenueCard never listened for it; the selected
+        // class is applied by app.js's VENUE_SELECTED handler, which has
+        // already run by this point.
     }
 
     clearVenue() {

--- a/js/components/VenueModal.js
+++ b/js/components/VenueModal.js
@@ -18,9 +18,10 @@ export class VenueModal extends Component {
             isOpen: false
         };
 
-        // Listen for venue selection events
+        // Listen for venue selection events. MODAL_CLOSE was subscribed here
+        // too, but nothing ever emitted it — the modal closes through its own
+        // close button, backdrop, and Escape handlers (see afterRender).
         this.subscribe(on(Events.VENUE_SELECTED, (venue) => this.open(venue)));
-        this.subscribe(on(Events.MODAL_CLOSE, () => this.close()));
     }
 
     template() {
@@ -89,7 +90,6 @@ export class VenueModal extends Component {
 
         this.setState({ venue, isOpen: true });
         document.body.style.overflow = 'hidden';
-        emit(Events.MODAL_OPEN, venue);
     }
 
     close() {

--- a/js/core/events.js
+++ b/js/core/events.js
@@ -1,6 +1,19 @@
 /**
- * Simple event bus for component communication
- * Allows components to communicate without direct dependencies
+ * Event bus — for genuine one-shots only.
+ *
+ * This bus once carried eleven event names. Eight of them had only one end:
+ * emitted with nothing listening, or listened for with nothing emitting. The
+ * ninth, `filter:changed`, was emitted immediately after a `setState` that
+ * already notified the same subscribers, so every filter change rendered each
+ * view twice.
+ *
+ * The rule now (#157): **state changes go through `state.js`.** If a view needs
+ * to react to something, it subscribes to the state key. The bus is only for
+ * events that are not state transitions — right now that is exactly two, both
+ * about a venue being opened or dismissed.
+ *
+ * Before adding a name here, check that the thing being announced is not
+ * already a state key. If it is, subscribe to the key instead.
  */
 
 const listeners = new Map();
@@ -19,20 +32,6 @@ export function on(event, callback) {
 
     // Return unsubscribe function
     return () => off(event, callback);
-}
-
-/**
- * Subscribe to an event for one-time execution
- * @param {string} event - Event name
- * @param {Function} callback - Handler function
- * @returns {Function} Unsubscribe function
- */
-export function once(event, callback) {
-    const wrapper = (...args) => {
-        off(event, wrapper);
-        callback(...args);
-    };
-    return on(event, wrapper);
 }
 
 /**
@@ -64,37 +63,23 @@ export function emit(event, data) {
 }
 
 /**
- * Remove all listeners for an event (or all events)
- * @param {string} [event] - Event name (optional, clears all if not provided)
+ * The complete set of events.
+ *
+ * Both of these have a real emitter and a real listener, and neither duplicates
+ * a state key. A venue being selected is a one-shot announcement that several
+ * unrelated components (modal, detail pane, card highlighting) each act on
+ * differently — that is what a bus is for.
+ *
+ * Deleted in #157, with the reason each was dead:
+ *   VENUE_DETAIL_SHOWN, VIEW_CHANGED, WEEK_CHANGED,
+ *   MODAL_OPEN, DATA_LOADED, DATA_ERROR ... emitted, never listened for
+ *   MODAL_CLOSE ......................... listened for, never emitted
+ *   SEARCH_CHANGED ...................... neither
+ *   FILTER_CHANGED ...................... redundant with the state keys
+ *                                         (showDedicated, searchQuery,
+ *                                         hostFilter) it was emitted alongside
  */
-export function clear(event) {
-    if (event) {
-        listeners.delete(event);
-    } else {
-        listeners.clear();
-    }
-}
-
-// Common event names (for reference)
 export const Events = {
-    // Venue events
     VENUE_SELECTED: 'venue:selected',
     VENUE_CLOSED: 'venue:closed',
-    VENUE_DETAIL_SHOWN: 'venue:detail-shown',
-
-    // View events
-    VIEW_CHANGED: 'view:changed',
-    WEEK_CHANGED: 'week:changed',
-
-    // Filter events
-    FILTER_CHANGED: 'filter:changed',
-    SEARCH_CHANGED: 'search:changed',
-
-    // UI events
-    MODAL_OPEN: 'modal:open',
-    MODAL_CLOSE: 'modal:close',
-
-    // Data events
-    DATA_LOADED: 'data:loaded',
-    DATA_ERROR: 'data:error'
 };

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -1,27 +1,30 @@
 /**
- * Reactive state store with subscribe/get/set + key-scoped subscribers.
+ * Reactive state store — the single channel for anything that changes.
  *
- * State keys:
- * - view: Current view ('weekly', 'alphabetical', 'map')
+ * Change something with `setState`, react to it with `subscribe(key, fn)`. That
+ * is the whole protocol. Do not announce a state change on the event bus as
+ * well: subscribers already ran, and the second notification renders everything
+ * a second time (#157).
+ *
+ * State keys — every one is read and written by real code:
+ * - view: Current base view ('weekly', 'alphabetical', 'map'). What is actually
+ *   on screen also depends on hostFilter; router.resolveView() combines them.
  * - weekStart: Date for current week in weekly view
  * - showDedicated: Whether to show dedicated karaoke venues
  * - searchQuery: Global search filter text
  * - hostFilter: KJ/host name filter, URL-driven via ?kj= (substring match against host name/company only)
  * - selectedVenue: Currently selected venue object (for modal/detail pane)
  * - isLoading: Loading indicator state
+ *
+ * `venues`, `filteredVenues`, and `filters` used to sit here too. Nothing ever
+ * read or wrote them — venue data lives in services/venues.js — but the spec
+ * documented them as live, so they read as the app's data model to anyone
+ * arriving cold. Removed in #157.
  */
 
 const subscribers = new Map();
 
 const state = {
-    venues: [],
-    filteredVenues: [],
-    filters: {
-        day: null,
-        city: null,
-        search: '',
-        dedicatedOnly: false
-    },
     view: 'weekly',
     weekStart: new Date(),
     showDedicated: true,
@@ -50,27 +53,13 @@ export function subscribe(key, callback) {
 }
 
 /**
- * Subscribe to any state change
- * @param {Function} callback - Called with full state when any value changes
- * @returns {Function} Unsubscribe function
- */
-export function subscribeAll(callback) {
-    return subscribe('*', callback);
-}
-
-/**
  * Notify subscribers of a state change
  * @param {string} key - State key that changed
  * @param {*} value - New value
  */
 function notify(key, value) {
-    // Notify specific key subscribers
     if (subscribers.has(key)) {
         subscribers.get(key).forEach(callback => callback(value, key));
-    }
-    // Notify wildcard subscribers
-    if (subscribers.has('*')) {
-        subscribers.get('*').forEach(callback => callback(state, key));
     }
 }
 
@@ -99,36 +88,6 @@ export function setState(updates) {
  */
 export function getState(key) {
     return key ? state[key] : { ...state };
-}
-
-/**
- * Reset state to initial values
- */
-export function resetState() {
-    setState({
-        venues: [],
-        filteredVenues: [],
-        filters: {
-            day: null,
-            city: null,
-            search: '',
-            dedicatedOnly: false
-        },
-        view: 'weekly',
-        weekStart: new Date(),
-        showDedicated: true,
-        selectedVenue: null,
-        isLoading: false
-    });
-}
-
-/**
- * Update filters and trigger filtering
- * @param {Object} filterUpdates - Filter updates
- */
-export function setFilters(filterUpdates) {
-    const newFilters = { ...state.filters, ...filterUpdates };
-    setState({ filters: newFilters });
 }
 
 /**

--- a/js/views/AlphabeticalView.js
+++ b/js/views/AlphabeticalView.js
@@ -9,15 +9,14 @@ import { Component } from '../components/Component.js';
 import { renderVenueCard } from '../components/VenueCard.js';
 import { attachVenueSelectionListener } from '../components/venue-selection.js';
 import { getState, subscribe } from '../core/state.js';
-import { on, Events } from '../core/events.js';
 import { getVenuesSorted } from '../services/venues.js';
 import { getSortableName } from '../utils/string.js';
 
 export class AlphabeticalView extends Component {
     init() {
-        // Re-render when relevant state changes
+        // One subscription per state key this view reads (#157).
         this.subscribe(subscribe('showDedicated', () => this.render()));
-        this.subscribe(on(Events.FILTER_CHANGED, () => this.render()));
+        this.subscribe(subscribe('searchQuery', () => this.render()));
     }
 
     template() {

--- a/js/views/KJDossierView.js
+++ b/js/views/KJDossierView.js
@@ -11,7 +11,6 @@
 
 import { Component } from '../components/Component.js';
 import { getState } from '../core/state.js';
-import { on, Events } from '../core/events.js';
 import { getAllVenues, venueMatchesHost } from '../services/venues.js';
 import { escapeHtml, containsIgnoreCase, getSortableName } from '../utils/string.js';
 import {
@@ -23,7 +22,15 @@ import { resolveHostFor, getVenueHosts } from '../utils/render.js';
 
 export class KJDossierView extends Component {
     init() {
-        this.subscribe(on(Events.FILTER_CHANGED, () => this.render()));
+        // No subscriptions, deliberately. This view's only input is
+        // `hostFilter`, and a hostFilter change replaces the view outright —
+        // app.js re-renders through the registry and builds a new instance,
+        // so there is nothing for a live instance to react to.
+        //
+        // It used to subscribe to FILTER_CHANGED, which also fired on every
+        // searchQuery keystroke. This view never reads searchQuery, so those
+        // were full re-renders producing byte-identical output (#157). KJ mode
+        // does not even show a search input.
     }
 
     template() {

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -7,7 +7,7 @@
 
 import { Component } from '../components/Component.js';
 import { getState, setState, subscribe } from '../core/state.js';
-import { emit, on, Events } from '../core/events.js';
+import { emit, Events } from '../core/events.js';
 import { getVenuesWithCoordinates, getAllVenues } from '../services/venues.js';
 import { escapeHtml } from '../utils/string.js';
 import { buildDirectionsUrl, shareVenue } from '../utils/url.js';
@@ -25,8 +25,27 @@ export class MapView extends Component {
         this.selectedMarker = null;
         this._escHandler = null;
 
-        this.subscribe(subscribe('showDedicated', () => this.updateMarkers()));
-        this.subscribe(on(Events.FILTER_CHANGED, () => this.updateMarkers()));
+        // One subscription per key that affects which markers are shown.
+        // `showDedicated` was previously covered twice — once here and once via
+        // FILTER_CHANGED — so a single toggle ran updateMarkers three times.
+        this.subscribe(subscribe('showDedicated', () => {
+            this.syncDedicatedButton();
+            this.updateMarkers();
+        }));
+        this.subscribe(subscribe('searchQuery', () => this.updateMarkers()));
+    }
+
+    /**
+     * Update the floating "Hide/Show Dedicated" button to match state, without
+     * re-rendering the view. A full render rebuilds the Leaflet map from
+     * scratch, so the label is patched in place instead.
+     */
+    syncDedicatedButton() {
+        const btn = this.$('[data-action="toggle-dedicated"]');
+        if (!btn) return;
+        const showDedicated = getState('showDedicated');
+        btn.classList.toggle('map-controls__btn--active', showDedicated);
+        btn.textContent = showDedicated ? 'Hide Dedicated' : 'Show Dedicated';
     }
 
     /**
@@ -113,17 +132,22 @@ export class MapView extends Component {
 
         // View switcher buttons
         this.delegate('click', '[data-view]', (e, target) => {
-            const view = target.dataset.view;
-            setState({ view });
-            emit(Events.VIEW_CHANGED, view);
+            setState({ view: target.dataset.view });
         });
 
-        // Dedicated toggle
+        // Dedicated toggle. setState and stop — the `showDedicated` subscriber
+        // updates the markers and this button's own label.
+        //
+        // This used to call this.render() as well, just to refresh the label,
+        // which tears the whole Leaflet instance down and builds a new one
+        // (fresh tile requests, re-bound handlers, discarded cluster group).
+        // Patching the label in place avoids that.
+        //
+        // The viewport still shifts on a toggle, because updateMarkers() fits
+        // bounds to whatever markers remain — that is its own behaviour and is
+        // unchanged here.
         this.delegate('click', '[data-action="toggle-dedicated"]', () => {
-            const showDedicated = !getState('showDedicated');
-            setState({ showDedicated });
-            emit(Events.FILTER_CHANGED, { showDedicated });
-            this.render(); // Re-render to update button state
+            setState({ showDedicated: !getState('showDedicated') });
         });
 
         // Close venue card
@@ -153,7 +177,6 @@ export class MapView extends Component {
                 } else {
                     // Exit to weekly view
                     setState({ view: 'weekly' });
-                    emit(Events.VIEW_CHANGED, 'weekly');
                 }
             }
         };

--- a/js/views/WeeklyView.js
+++ b/js/views/WeeklyView.js
@@ -10,18 +10,17 @@ import { renderDayCard } from '../components/DayCard.js';
 import { renderExtendedSection, attachExtendedSectionListeners } from '../components/ExtendedSection.js';
 import { attachVenueSelectionListener } from '../components/venue-selection.js';
 import { getState, subscribe } from '../core/state.js';
-import { on, Events } from '../core/events.js';
 import { getWeekDates, getWeekStart, getNextWeekRange, getThisMonthRange, getNextMonthRange, getMonthName } from '../utils/date.js';
 import { getVenuesForDate } from '../services/venues.js';
 
 export class WeeklyView extends Component {
     init() {
-        // Re-render when relevant state changes
+        // One subscription per state key this view reads. FILTER_CHANGED used
+        // to be a fourth subscription covering the same keys, so every filter
+        // change rendered twice (#157).
         this.subscribe(subscribe('weekStart', () => this.render()));
         this.subscribe(subscribe('showDedicated', () => this.render()));
-
-        // Listen for filter changes
-        this.subscribe(on(Events.FILTER_CHANGED, () => this.render()));
+        this.subscribe(subscribe('searchQuery', () => this.render()));
     }
 
     template() {


### PR DESCRIPTION
Closes #157. **Stacked on #190 (#156)** — review that first; this PR's base will fast-forward once it merges.

## The seam

Two notification systems ran in parallel. Every filter mutation called `setState` **and** emitted `FILTER_CHANGED`, and the same views subscribed to both.

I measured this on #156's deploy preview before changing anything, so the "before" numbers are the real shipped code, not a reconstruction:

| Action | Before | After |
|---|---|---|
| Dedicated toggle, list views | **2** renders | **1** |
| Dedicated toggle, map | `initMap` **×1**, `updateMarkers` **×3** | `initMap` **×0**, `updateMarkers` **×1** |
| Search keystroke | 1 render | 1 render *(unchanged)* |

The map row is the interesting one. `initMap` ×1 means the entire Leaflet instance was being torn down and rebuilt to relabel a button.

## What changed

**Views subscribe by state key.** `WeeklyView` → `weekStart`, `showDedicated`, `searchQuery`. `AlphabeticalView` and `MapView` → `showDedicated`, `searchQuery`.

**`KJDossierView` subscribes to nothing**, deliberately. Its only input is `hostFilter`, and a `hostFilter` change replaces the instance outright through the view registry. Its old `FILTER_CHANGED` subscription fired on every `searchQuery` keystroke and re-rendered byte-identical output — KJ mode doesn't even show a search input. My first pass mechanically swapped it for `subscribe('searchQuery')`, which faithfully reproduced the waste; measuring it is what caught that.

**`MapView`'s dedicated toggle** no longer calls `this.render()`. `syncDedicatedButton()` patches the label in place instead.

**`Events` is down to two:** `VENUE_SELECTED` and `VENUE_CLOSED`. Both have a real emitter and a real listener and neither duplicates a state key.

**`state.js`** loses `venues` / `filteredVenues` / `filters` — nothing ever read or wrote them — plus `setFilters`, `resetState`, `subscribeAll`, and the now-unreachable `'*'` branch in `notify()`.

## Correction to the ticket

The ticket says "the six emitter-less or listener-less `Events` constants". The actual count is **eight**, nine including `FILTER_CHANGED`:

| Constant | Why it was dead |
|---|---|
| `VENUE_DETAIL_SHOWN` | emitted, never listened for |
| `VIEW_CHANGED` | emitted, never listened for |
| `WEEK_CHANGED` | emitted, never listened for |
| `MODAL_OPEN` | emitted, never listened for |
| `DATA_LOADED` | emitted, never listened for |
| `DATA_ERROR` | emitted, never listened for |
| `MODAL_CLOSE` | listened for, never emitted |
| `SEARCH_CHANGED` | neither end |
| `FILTER_CHANGED` | duplicated the state keys it accompanied |

`architecture.md` had been documenting eight of these with `—` in the Listeners column for months. The information was sitting there in the table; nothing acted on it.

## Docs

Every place that described the old protocol as live:

- **spec §21** — the state table listed `venues`/`filteredVenues`/`filters` as the app's data model and omitted `hostFilter`, a real key, entirely. Now carries a per-view subscription table.
- **architecture.md** — event map, state table, and two mermaid sequence diagrams (the Filter Change Flow routed through an Event Bus participant that no longer takes part).
- **patterns.md** — this one mattered most. The "add a view" recipe *instructed* contributors to `subscribe(on(Events.FILTER_CHANGED, ...))`, and its Gotchas said "Always subscribe to `FILTER_CHANGED`". Left alone, every future view would have inherited the double render.
- **CLAUDE.md** — Event Bus and Search sections.

## Verification

| Gate | Result |
|---|---|
| `npm run test:unit` | **124 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean (4 known #135 stale-venue warnings) |

Deleting an event is only safe if nothing depended on it, so I exercised each affected path in the browser rather than trusting the grep:

- **`MODAL_CLOSE` was dead** — modal still closes via close button, backdrop, and Escape; `body.overflow` restored and card selection cleared each time.
- **`VIEW_CHANGED` was dead** — map's floating switcher still leaves to A-Z; Escape still exits the map to weekly.
- **`VENUE_DETAIL_SHOWN` was dead** — detail pane still populates ("The Austin Eagle") and the card still gets `.venue-card--selected`; that class comes from `app.js`'s `VENUE_SELECTED` handler, not from the deleted event, despite a code comment claiming otherwise.
- **Filtering still filters** — alphabetical: 75 unfiltered → 69 dedicated-hidden → 75 restored; `"ego"` → Ego's. Weekly: 269 → 149 on search, 173 on dedicated-off, 269 restored. Week nav and the Today button unaffected.
- **Dossier** — 0 renders on an irrelevant key change (was 1); a `hostFilter` change still swaps to the KJ index and rewrites the URL.
- Console clean throughout.

**One thing I want to flag rather than bury:** removing the map's `this.render()` does *not* preserve pan/zoom, and an earlier draft of my comment claimed it did. `updateMarkers()` calls `fitBounds()` on the remaining markers, so the viewport still shifts on a toggle. That behaviour is untouched here — the win is not rebuilding the map, not viewport stability. Worth its own ticket if the shift is unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
