### PR TITLE
#158: Bind the Escape handlers once instead of once per render

### DIFF
--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -293,7 +293,8 @@ export function renderNewComponent(data) {
 - `init()` runs in the constructor before `render()`. Don't query the DOM in `init()`.
 - Always use `this.addEventListener()` or `this.delegate()` instead of raw `element.addEventListener()` — the component's auto-cleanup only tracks listeners registered through these methods.
 - Always wrap state/event subscriptions with `this.subscribe()` for auto-cleanup.
-- `afterRender()` is called every time `render()` runs, not just the first time. Previously attached listeners are NOT automatically cleaned up between renders — `this.addEventListener()` adds to the list each time. If this is a concern, use event delegation via `this.delegate()` instead.
+- `afterRender()` is called every time `render()` runs, not just the first time. Previously attached listeners are NOT automatically cleaned up between renders — `this.addEventListener()` adds to the list each time. If this is a concern, use event delegation via `this.delegate()` instead, which de-duplicates by `event::selector`.
+- **Document-level listeners (Escape keys, outside-clicks) belong in `init()`, not `afterRender()`.** `delegate()` can't help here — it binds to `this.container`, and these fire on `document`. Binding in `init()` runs exactly once per instance, and `this.addEventListener(document, 'keydown', …)` still gets auto-removed on `destroy()`. A handler bound this way outlives individual renders, so it must check whether it should act — see `VenueModal`, whose Escape handler guards on `this.state.isOpen` (#158).
 
 ---
 

--- a/js/components/VenueModal.js
+++ b/js/components/VenueModal.js
@@ -20,8 +20,18 @@ export class VenueModal extends Component {
 
         // Listen for venue selection events. MODAL_CLOSE was subscribed here
         // too, but nothing ever emitted it — the modal closes through its own
-        // close button, backdrop, and Escape handlers (see afterRender).
+        // close button, backdrop, and Escape handlers.
         this.subscribe(on(Events.VENUE_SELECTED, (venue) => this.open(venue)));
+
+        // Escape closes the modal. Bound once, here, rather than per-render:
+        // afterRender() built a fresh closure and registered it with raw
+        // document.addEventListener every time it ran, tracking only the newest
+        // for removal. Selecting a venue while the modal was already open
+        // therefore orphaned one listener per selection. It guards on isOpen
+        // instead of relying on being unbound while closed.
+        this.addEventListener(document, 'keydown', (e) => {
+            if (e.key === 'Escape' && this.state.isOpen) this.close();
+        });
     }
 
     template() {
@@ -67,12 +77,6 @@ export class VenueModal extends Component {
             shareVenue(this.state.venue, e.currentTarget);
         });
 
-        // Escape key
-        this._escHandler = (e) => {
-            if (e.key === 'Escape') this.close();
-        };
-        document.addEventListener('keydown', this._escHandler);
-
         // Trap focus in modal
         this.trapFocus();
     }
@@ -93,9 +97,6 @@ export class VenueModal extends Component {
     }
 
     close() {
-        if (this._escHandler) {
-            document.removeEventListener('keydown', this._escHandler);
-        }
         document.body.style.overflow = '';
         this.setState({ isOpen: false });
         emit(Events.VENUE_CLOSED, this.state.venue);
@@ -115,9 +116,10 @@ export class VenueModal extends Component {
     }
 
     onDestroy() {
-        if (this._escHandler) {
-            document.removeEventListener('keydown', this._escHandler);
-        }
+        // The keydown listener is not unbound here — it went through
+        // this.addEventListener, so Component.destroy() has already removed it.
+        // Body scroll must still be restored: destroying a component while its
+        // modal is open would otherwise leave the page permanently unscrollable.
         document.body.style.overflow = '';
     }
 }

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -23,7 +23,6 @@ export class MapView extends Component {
         this.clusterGroup = null;
         this.selectedVenue = null;
         this.selectedMarker = null;
-        this._escHandler = null;
 
         // One subscription per key that affects which markers are shown.
         // `showDedicated` was previously covered twice — once here and once via
@@ -33,6 +32,8 @@ export class MapView extends Component {
             this.updateMarkers();
         }));
         this.subscribe(subscribe('searchQuery', () => this.updateMarkers()));
+
+        this.bindEscape();
     }
 
     /**
@@ -169,18 +170,27 @@ export class MapView extends Component {
             }
         });
 
-        // Escape key to exit map view or close card
-        this._escHandler = (e) => {
-            if (e.key === 'Escape') {
-                if (this.selectedVenue) {
-                    this.hideVenueCard();
-                } else {
-                    // Exit to weekly view
-                    setState({ view: 'weekly' });
-                }
+    }
+
+    /**
+     * Escape closes the venue card first, then exits the map to the calendar.
+     *
+     * Registered in init(), not afterRender(): afterRender runs on every render,
+     * and each pass built a fresh closure and called raw
+     * `document.addEventListener` on it — orphaning the previous one, since only
+     * the newest was tracked for removal. init() runs exactly once per instance,
+     * and this.addEventListener records the listener so destroy() removes it.
+     */
+    bindEscape() {
+        this.addEventListener(document, 'keydown', (e) => {
+            if (e.key !== 'Escape') return;
+            if (this.selectedVenue) {
+                this.hideVenueCard();
+            } else {
+                // Exit to weekly view
+                setState({ view: 'weekly' });
             }
-        };
-        document.addEventListener('keydown', this._escHandler);
+        });
     }
 
     async loadLeaflet() {
@@ -233,6 +243,16 @@ export class MapView extends Component {
     initMap() {
         const container = this.$('#venue-map');
         if (!container || !window.L) return;
+
+        // Tear down any previous instance before building another. Nothing
+        // calls initMap twice per instance today — the dedicated toggle stopped
+        // re-rendering in #157 — but L.map() on a container that already hosts a
+        // map throws "Map container is already initialized", and the orphaned
+        // instance keeps its own document-level listeners alive.
+        if (this.map) {
+            this.map.remove();
+            this.map = null;
+        }
 
         // Default center on Austin, TX
         const austinCenter = [30.2672, -97.7431];
@@ -496,10 +516,8 @@ export class MapView extends Component {
     }
 
     onDestroy() {
-        // Remove escape key handler
-        if (this._escHandler) {
-            document.removeEventListener('keydown', this._escHandler);
-        }
+        // The keydown listener is not unbound here — it went through
+        // this.addEventListener, so Component.destroy() has already removed it.
 
         // Clean up cluster group
         if (this.clusterGroup) {


### PR DESCRIPTION
Closes #158.

## What I found before changing anything

I measured the ticket's claims against `main` first. **Half of #158 was already fixed by #157.**

| Ticket claim | Measured on main |
|---|---|
| "toggling dedicated on the map accumulates orphaned handlers" | **Already clean.** 10 toggles → 0 new listeners |
| "`initMap()` leaks a whole Leaflet instance per toggle" | **Already clean.** 10 toggles → 0 new `L.Map` |
| MapView dedicated toggle should update the button in place | **Done in #157** |
| Handlers registered via `this.addEventListener` | Not done — this PR |

#157 removed the `this.render()` call from the map's dedicated toggle, and that call *was* the mechanism: it re-ran `afterRender()` (new Escape closure, old one orphaned) and `loadLeaflet().then(initMap)` (new `L.Map`). With it gone, the repro passes. Switching map ↔ weekly 4× also leaked nothing — `onDestroy()` was already calling `this.map.remove()`.

**The modal leak was real and still present:**

```
select #1: 1 keydown listener      select #4: 4 keydown listeners
select #2: 2 keydown listeners     select #5: 5 keydown listeners
select #3: 3 keydown listeners     select #6: 6 keydown listeners
→ closing removes only 1, leaving 5 orphaned permanently
```

`afterRender()`'s `if (!this.state.isOpen) return` guard is what keeps the ordinary open→close cycle clean (I verified 5 cycles stay at 1 listener). The leak needs a *selection while the modal is already open*.

**Reachability — I want to be straight about this:** that path is **not reachable from the UI today.** With the modal open I probed five points across the viewport and every one hits modal chrome, never a venue card. So this is a latent trap, not a live user-facing bug. It goes live the moment anything selects a venue programmatically while the modal is up. Worth fixing structurally; not worth calling a production defect.

## The fix

Both handlers now bind **once, in `init()`**, via `this.addEventListener(document, 'keydown', …)`.

That's the part the ticket's AC1 gets right but for a subtler reason than stated. `this.addEventListener` does **not** de-duplicate — unlike `delegate()`, which keys on `event::selector`. Simply swapping the raw call for `this.addEventListener` inside `afterRender()` would still stack one listener per render; it would only guarantee they all get removed at `destroy()`. Binding in `init()` — which runs exactly once per instance — makes the orphaning structurally impossible.

`VenueModal`'s handler now guards on `this.state.isOpen`, since it's no longer unbound while closed.

`initMap()` gets the AC3 guard. Nothing calls it twice per instance today, but `L.map()` on an already-initialized container throws.

Both `onDestroy()` methods drop their manual `removeEventListener`, with a note saying why. `VenueModal.onDestroy` still restores `body.overflow` — destroying while open would otherwise leave the page permanently unscrollable.

## Docs

`patterns.md` already had the rule this violated ("Always use `this.addEventListener()` … instead of raw `element.addEventListener()`") and, two lines down, the caveat that it stacks per render with "use `this.delegate()` instead."

But `delegate()` binds to `this.container` and cannot cover a `document` listener — so for this case the docs pointed at a non-solution. Added the third option: document-level listeners belong in `init()`, and a handler bound that way must check whether it should act.

## Verification

| Gate | Result |
|---|---|
| `npm run test:unit` | **124 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean |

In-browser, same probes as the "before" measurements:

- **6 re-selections → 0 new listeners** (was 6)
- Escape still closes the modal; `body.overflow` restored
- Escape is **inert while closed** (0 `VENUE_CLOSED` emits across 5 presses) and emits **exactly one** when open
- Map: first Escape closes the venue card and stays on the map, second exits to the calendar
- 3 map mounts → 3 `L.Map` created, 3 removed, 0 listeners left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)
