### PR TITLE
#160: Delete the dead card schedule picker and close the sanitize gaps

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -381,7 +381,9 @@ When debug mode is enabled (`?debug=1`), compact cards show the schedule match r
 - Clicking links (address, social, event URL) opens the link directly without triggering venue detail
 - In Weekly and Alphabetical views, clicking anywhere on the card (except links) also triggers `VENUE_SELECTED`
 
-> **Implementation note:** Compact cards are rendered via `renderVenueCard()`, which creates a temporary VenueCard instance, calls `template()`, and returns the HTML string — no persistent component instance is kept. Schedule display uses `getScheduleForDate()` which prioritizes `once` entries (special events) over recurring entries for the matching date. Full-mode cards (Alphabetical view) render all schedule entries. The `formatHostDisplay()` function from `js/utils/render.js` generates the compact "Presented by" line.
+> **Implementation note:** Compact cards are rendered via `renderVenueCard()`, which creates a temporary VenueCard instance, calls `template()`, and returns the HTML string — no persistent component instance is kept. The **caller supplies the schedule entry**: `getVenueEventsForDate()` emits one `{venue, schedule}` pair per matching entry, and `DayCard` passes that entry straight through, which is why a venue with two shows on one date renders two cards with the right time on each. Full-mode cards (Alphabetical view) render all schedule entries. The `formatHostDisplay()` function from `js/utils/render.js` generates the compact "Presented by" line.
+>
+> This note previously described a `getScheduleForDate()` selector inside the card, "which prioritizes `once` entries over recurring entries for the matching date." That function existed but was unreachable, and it did not do what the sentence claimed — it matched on weekday alone with no frequency check, then fell back to `schedule[0]`. It was deleted in #160 rather than fixed, because the real selection had already moved to the service layer.
 
 ---
 

--- a/js/components/VenueCard.js
+++ b/js/components/VenueCard.js
@@ -5,7 +5,7 @@
 
 import { Component } from './Component.js';
 import { escapeHtml } from '../utils/string.js';
-import { formatTimeRange, scheduleMatchesDate, getScheduleExclusion, getDayName } from '../utils/date.js';
+import { formatTimeRange, getScheduleExclusion } from '../utils/date.js';
 import { buildMapUrl, formatAddress, sanitizeUrl } from '../utils/url.js';
 import { emit, Events } from '../core/events.js';
 import { isDebugMode, getDebugHtml } from '../utils/debug.js';
@@ -37,11 +37,21 @@ export class VenueCard extends Component {
         return this.fullTemplate(venue);
     }
 
-    compactTemplate(venue, date, showSchedule, scheduleProp) {
-        // Prefer explicit schedule prop (so callers can pick the specific event
-        // when a venue has multiple matches on the same date). Fall back to
-        // auto-detection when no prop is passed.
-        const schedule = scheduleProp || this.getScheduleForDate(venue, date);
+    compactTemplate(venue, date, showSchedule, schedule) {
+        // `schedule` is required in compact mode: the caller already knows which
+        // entry matched the date it is rendering, so it passes that entry.
+        //
+        // A getScheduleForDate() fallback used to sit here for callers that
+        // omitted it. It matched on weekday alone with no frequency check — so
+        // a "first Monday" show would have been picked for any Monday — and
+        // then fell back to schedule[0], an unrelated entry with the wrong
+        // time. Nothing ever reached it (getVenueEventsForDate always supplies
+        // the matched entry), so it was a wrong-time bug one call site away
+        // from activating rather than a live one. Deleted in #160.
+        if (!schedule) {
+            console.warn(`VenueCard: compact mode needs a schedule entry (venue: ${venue?.id})`);
+        }
+
         const timeDisplay = schedule
             ? formatTimeRange(schedule.startTime, schedule.endTime)
             : '';
@@ -69,7 +79,8 @@ export class VenueCard extends Component {
         // (avoids "Also May 30" appearing on a card already rendered for May 30).
         const { frequencyHtml, moreNightsHtml } = renderScheduleContext(venue, schedule, date);
 
-        // Build full address string and map URL
+        // formatAddress escapes its own fields (#160) — do not wrap this in
+        // escapeHtml, or the separators it emits get escaped too.
         const fullAddress = formatAddress(venue.address);
         const mapsUrl = buildMapUrl(venue.address, venue.name);
 
@@ -101,7 +112,7 @@ export class VenueCard extends Component {
                 <div class="venue-card__location">
                     <a href="${mapsUrl}" target="_blank" rel="noopener noreferrer" class="venue-card__map-link">
                         <i class="fa-solid fa-location-dot"></i>
-                        ${escapeHtml(fullAddress)}
+                        ${fullAddress}
                     </a>
                 </div>
                 ${hostDisplay ? `
@@ -134,20 +145,6 @@ export class VenueCard extends Component {
                 ${renderVenueDetailSections(venue, { classPrefix: 'venue-card', actions: false })}
             </div>
         `;
-    }
-
-    getScheduleForDate(venue, date) {
-        if (!date || !venue.schedule) return venue.schedule?.[0] || null;
-
-        // Check for one-time event on this exact date first
-        const onceEntry = venue.schedule.find(s =>
-            s.frequency === 'once' && scheduleMatchesDate(s, date)
-        );
-        if (onceEntry) return onceEntry;
-
-        // Fall back to the recurring entry for this weekday
-        const dayName = getDayName(date);
-        return venue.schedule.find(s => s.day?.toLowerCase() === dayName) || venue.schedule[0];
     }
 
     afterRender() {

--- a/js/utils/debug.js
+++ b/js/utils/debug.js
@@ -3,7 +3,7 @@
  * Enable with ?debug=1 in URL or localStorage.setItem('debug', '1')
  */
 
-import { scheduleMatchesDate, getDayName } from './date.js';
+import { scheduleMatchesDate } from './date.js';
 
 let debugMode = false;
 
@@ -61,7 +61,6 @@ export function getVenueDebugInfo(venue, date) {
         };
     }
 
-    const dayName = getDayName(date);
     const matchingSchedules = [];
 
     for (const sched of venue.schedule) {
@@ -79,9 +78,10 @@ export function getVenueDebugInfo(venue, date) {
             continue;
         }
 
-        const schedDay = sched.day.toLowerCase();
-        if (schedDay !== dayName) continue;
-
+        // No day-name pre-filter here: scheduleMatchesDate() already checks the
+        // weekday, and doing it again first meant this loop disagreed with the
+        // real matcher about what counts as a match. It also read `sched.day`
+        // unguarded, which throws on a recurring entry missing a day (#160).
         const matches = scheduleMatchesDate(sched, date);
         if (matches) {
             matchingSchedules.push({

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -180,7 +180,7 @@ export function renderHostSection(host, classPrefix, options = {}) {
                 ${host.name ? `<p class="${classPrefix}__host-name">${escapeHtml(host.name)}</p>` : ''}
                 ${host.affiliation ? `<p class="${classPrefix}__host-affiliation">${escapeHtml(host.affiliation)}</p>` : ''}
                 ${host.website ? `
-                    <a href="${escapeHtml(host.website)}" target="_blank" rel="noopener noreferrer" class="${classPrefix}__host-website">
+                    <a href="${escapeHtml(sanitizeUrl(host.website) || '')}" target="_blank" rel="noopener noreferrer" class="${classPrefix}__host-website">
                         <i class="fa-solid fa-globe"></i> Website
                     </a>
                 ` : ''}
@@ -371,7 +371,7 @@ export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize =
         ${venue.phone ? `
             <section class="${classPrefix}__section">
                 <h3><i class="fa-solid fa-phone"></i> Contact</h3>
-                <a href="tel:${venue.phone}" class="${classPrefix}__phone">${escapeHtml(venue.phone)}</a>
+                <a href="tel:${escapeHtml(venue.phone)}" class="${classPrefix}__phone">${escapeHtml(venue.phone)}</a>
             </section>
         ` : ''}
     `;

--- a/js/utils/tags.js
+++ b/js/utils/tags.js
@@ -4,6 +4,8 @@
  * Configuration is loaded from js/data.json at runtime
  */
 
+import { html } from './string.js';
+
 // Tag configuration - initialized from js/data.json
 let tagConfig = {};
 
@@ -30,11 +32,14 @@ export function renderTags(tags, options = {}) {
 
     if (allTags.length === 0) return '';
 
+    // The `html` tag escapes every interpolation, including the colours and the
+    // label — all three come from data.json's tagDefinitions, which the curator
+    // writes, and the colours land inside a style attribute (#160).
     const badges = allTags.map(tag => {
         const config = tagConfig[tag];
         if (!config) return '';
 
-        return `<span class="venue-tag" style="background-color: ${config.color}; color: ${config.textColor};">${config.label}</span>`;
+        return String(html`<span class="venue-tag" style="background-color: ${config.color}; color: ${config.textColor};">${config.label}</span>`);
     }).filter(Boolean).join('');
 
     return badges ? `<div class="venue-tags">${badges}</div>` : '';

--- a/js/utils/url.js
+++ b/js/utils/url.js
@@ -3,6 +3,7 @@
  */
 
 import { venueShareUrl } from '../core/router.js';
+import { escapeHtml } from './string.js';
 
 // Social media platform configurations
 // Note: 'icon' should be full class including prefix (fa-brands or fa-solid)
@@ -138,21 +139,28 @@ export function createSocialLinks(socials, options = {}) {
 }
 
 /**
- * Format full address as string
+ * Format a full address as an HTML fragment.
+ *
+ * Returns **markup, not text** — with `multiline` the separator is a literal
+ * `<br>` — so it escapes each field itself. A caller cannot escape the result
+ * without destroying that `<br>`, which is why the escaping has to live here.
+ * `renderVenueDetailSections` interpolated the result raw (#160).
+ *
  * @param {Object} address - Address object
  * @param {boolean} [multiline=false] - Use line breaks
- * @returns {string} Formatted address
+ * @returns {string} Formatted address, HTML-escaped field by field
  */
 export function formatAddress(address, multiline = false) {
     if (!address) return '';
 
     const { street, city, state, zip } = address;
     const separator = multiline ? '<br>' : ', ';
+    const esc = (v) => escapeHtml(v || '');
 
-    const cityStateZip = [city, state].filter(Boolean).join(', ') +
-        (zip ? ` ${zip}` : '');
+    const cityStateZip = [city, state].filter(Boolean).map(esc).join(', ') +
+        (zip ? ` ${esc(zip)}` : '');
 
-    return [street, cityStateZip].filter(Boolean).join(separator);
+    return [street ? esc(street) : '', cityStateZip].filter(Boolean).join(separator);
 }
 
 /*

--- a/test/url.test.mjs
+++ b/test/url.test.mjs
@@ -1,0 +1,106 @@
+/**
+ * Unit tests for js/utils/url.js — the escaping and scheme-blocking helpers.
+ *
+ * These are the app's two defences against hostile venue data, and both had
+ * gaps that #160 closed. They load in Node because url.js touches `window` only
+ * inside function bodies (venueShareUrl), same as the router.
+ *
+ * The venue data is curator-maintained, not user-submitted, so nothing here was
+ * a live exploit. It is defence in depth: submit.html emits venue partials that
+ * a curator reconciles, so hostile text has a path toward data.json.
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { formatAddress, sanitizeUrl, buildMapUrl } from '../js/utils/url.js';
+
+describe('formatAddress — escaping', () => {
+    it('leaves an ordinary address alone', () => {
+        assert.equal(
+            formatAddress({ street: '1120 S Lamar Blvd', city: 'Austin', state: 'TX', zip: '78704' }),
+            '1120 S Lamar Blvd, Austin, TX 78704'
+        );
+    });
+
+    it('escapes markup in the street', () => {
+        // renderVenueDetailSections interpolates this straight into an <address>
+        // element, so an unescaped tag here executes.
+        const out = formatAddress({ street: '<img src=x onerror=alert(1)>', city: 'Austin' });
+        assert.equal(out.includes('<img'), false);
+        assert.match(out, /&lt;img/);
+    });
+
+    it('escapes quotes, which would otherwise break out of an attribute', () => {
+        const out = formatAddress({ street: 'a" onmouseover="evil()', city: 'Austin' });
+        assert.equal(out.includes('"'), false);
+        assert.match(out, /&quot;/);
+    });
+
+    it('escapes every field, not just the street', () => {
+        for (const field of ['street', 'city', 'state', 'zip']) {
+            const out = formatAddress({ [field]: '<b>x</b>' });
+            assert.equal(out.includes('<b>'), false, `${field} was not escaped`);
+        }
+    });
+
+    it('keeps its own <br> separator intact in multiline mode', () => {
+        // This is why the escaping lives inside formatAddress: a caller wrapping
+        // the result in escapeHtml would turn this separator into &lt;br&gt;.
+        const out = formatAddress({ street: '1 A St', city: 'Austin', state: 'TX' }, true);
+        assert.equal(out, '1 A St<br>Austin, TX');
+    });
+
+    it('handles missing pieces without emitting stray separators', () => {
+        assert.equal(formatAddress({ city: 'Austin', state: 'TX' }), 'Austin, TX');
+        assert.equal(formatAddress({ street: '1 A St' }), '1 A St');
+        assert.equal(formatAddress(null), '');
+        assert.equal(formatAddress({}), '');
+    });
+});
+
+describe('sanitizeUrl — scheme blocking', () => {
+    it('rejects javascript: and data:, case-insensitively', () => {
+        for (const bad of [
+            'javascript:alert(1)',
+            'JavaScript:alert(1)',
+            '  javascript:alert(1)',
+            'data:text/html,<script>alert(1)</script>',
+            'DATA:text/html,x',
+        ]) {
+            assert.equal(sanitizeUrl(bad), null, bad);
+        }
+    });
+
+    it('upgrades a bare host to https', () => {
+        assert.equal(sanitizeUrl('example.com'), 'https://example.com');
+    });
+
+    it('passes through http and https unchanged', () => {
+        assert.equal(sanitizeUrl('https://example.com/x'), 'https://example.com/x');
+        assert.equal(sanitizeUrl('http://example.com/x'), 'http://example.com/x');
+    });
+
+    it('returns null for empty or non-string input', () => {
+        for (const v of ['', '   ', null, undefined, 42, {}]) {
+            assert.equal(sanitizeUrl(v), null, String(v));
+        }
+    });
+
+    it('escapeHtml alone would NOT have stopped these — hence sanitizeUrl', () => {
+        // The gap #160 closed: host.website went through escapeHtml only, which
+        // leaves `javascript:alert(1)` a perfectly valid href.
+        const hostile = 'javascript:alert(1)';
+        assert.equal(hostile.includes('<'), false, 'nothing for escapeHtml to escape');
+        assert.equal(sanitizeUrl(hostile), null);
+    });
+});
+
+describe('buildMapUrl', () => {
+    it('encodes the address into the query rather than interpolating it raw', () => {
+        const url = buildMapUrl({ street: '1 A St & Co', city: 'Austin', state: 'TX' }, 'Bar "X"');
+        assert.equal(url.startsWith('https://'), true);
+        assert.equal(url.includes(' '), false);
+        assert.equal(url.includes('"'), false);
+    });
+});


### PR DESCRIPTION
Closes #160. First of Wave 3.

Two unrelated defects in the same area — one latent, one live.

## The latent one: `getScheduleForDate()`

It picked a schedule entry **by weekday alone, with no frequency check** — a "first Monday" show would be selected for any Monday — and fell back to `schedule[0]` when nothing matched, rendering an unrelated entry's time.

It was genuinely unreachable. The only compact caller is `DayCard`, and `getVenueEventsForDate()` emits one `{venue, schedule}` pair per *matched* entry, so `scheduleProp ||` always short-circuited. Deleted rather than repaired — selection belongs to the service layer now. `schedule` is a required prop of compact mode, with a warning if absent.

## The live one: three unescaped values

I planted hostile values on a venue and rendered the detail pane, on this branch and with `url.js`/`render.js` reverted.

**Before:**

```
addressImgInjected : true
flags.addr         : 1        ← the onerror actually fired
phoneAttrs         : [href, onfocus, autofocus, x, class]
hostWebsiteHref    : "javascript:window.__PWNED_HOST=1"
```

**After:**

```
addressImgInjected : false
flags.addr         : 0
phoneAttrs         : [href, class]
hostWebsiteHref    : ""
```

The phone payload wasn't just cosmetic — it broke out of the `href` and the parser created real `onfocus`, `autofocus`, and `x` attributes on the anchor.

**`formatAddress()` now escapes its own fields.** It returns *markup* — with `multiline` the separator is a literal `<br>` — so a caller can't escape the result without destroying that separator. That's why it has to happen inside. `renderVenueDetailSections` interpolated the result raw; `VenueCard` escaped it, so VenueCard's now-redundant `escapeHtml` is removed to avoid double-escaping. Both ends had to move together.

**`host.website` goes through `sanitizeUrl()`**, matching how `eventUrl` is handled two functions above. `escapeHtml` alone never helped here — `javascript:alert(1)` contains nothing for it to escape. There's a test asserting exactly that.

**`venue.phone` is escaped inside the `tel:` href**, not only in the link text.

### Scope note

Venue data is curator-maintained, so none of this was reachable from the public site by an outsider. It's defence in depth — `submit.html` emits venue partials that a curator reconciles into `data.json`, so attacker-influenced text has a path toward the file. I'd rather say that plainly than imply the site was popped.

## Also in scope

- **`tags.js`** renders through the `html` tagged template from #147. The tag colours land inside a `style` attribute and the label inside the element — all from `tagDefinitions`.
- **`debug.js`** drops its day-name pre-filter. `scheduleMatchesDate()` already checks the weekday, so the pre-filter only created a second opinion about what counts as a match — and it read `sched.day` unguarded, which throws on a recurring entry with no day.

## Docs

Spec §6's implementation note documented `getScheduleForDate()` as the card's schedule selector *and described behaviour it did not have* ("prioritizes `once` entries over recurring"). Rewritten to describe how selection actually works, with a note on what was removed and why.

## Verification

| Gate | Result |
|---|---|
| `npm run test:unit` | **136 passed** (12 new in `test/url.test.mjs`) |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean |

New unit tests cover `formatAddress` escaping per field, that the `<br>` separator survives, `sanitizeUrl` scheme blocking (including case and leading whitespace), and the motivating case for having both helpers.

In-browser on the full dataset: 269 cards, 415 tags render with correct computed colours, addresses show no stray entities (no double-escaping), times unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
