### PR TITLE
#161: Consolidate the venue detail surface onto one .venue-detail block

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -391,9 +391,6 @@
     font-size: var(--font-size-lg);
 }
 
-.venue-card__address {
-    margin-bottom: var(--spacing-md);
-}
 
 .venue-card__map-link {
     display: inline-flex;
@@ -411,26 +408,9 @@
     color: var(--color-primary-light);
 }
 
-.venue-card__host {
-    margin-top: var(--spacing-md);
-}
 
-.venue-card__host-name {
-    font-weight: 500;
-}
 
-.venue-card__host-affiliation {
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
-}
 
-.venue-card__socials {
-    display: flex;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-md);
-    padding-top: var(--spacing-md);
-    border-top: 1px solid var(--border-color);
-}
 
 /* Social links */
 .social-link {
@@ -528,13 +508,33 @@
     margin: 0;
 }
 
-.venue-modal__section,
-.detail-pane__section {
+/* ===================================================================
+   Venue detail block — .venue-detail
+   ===================================================================
+   ONE block for the sections renderVenueDetailSections() emits. Four
+   surfaces show it, and each puts .venue-detail (plus an optional
+   modifier) on its own wrapper:
+
+     VenueModal        .venue-modal__content venue-detail
+     VenueDetailPane   .detail-pane venue-detail
+     MapView card      .map-venue-card__detail-content venue-detail venue-detail--compact
+     A-Z full card     .venue-card--full venue-detail venue-detail--inline
+
+   Before #161 the renderer took a classPrefix and emitted the same
+   markup under four different names, so these rules existed four times
+   over — a hand-maintained matrix that had already drifted
+   (.venue-card__phone was emitted and styled nowhere).
+
+   The base below IS the modal/pane treatment. Their wrappers, headers,
+   titles and close buttons stay per-surface: those genuinely differ and
+   are not this renderer's markup.
+   =================================================================== */
+
+.venue-detail__section {
     margin-bottom: var(--spacing-lg);
 }
 
-.venue-modal__section h3,
-.detail-pane__section h3 {
+.venue-detail__section h3 {
     display: flex;
     align-items: center;
     gap: var(--spacing-sm);
@@ -543,114 +543,88 @@
     margin-bottom: var(--spacing-sm);
 }
 
-.venue-modal__section h3 i,
-.detail-pane__section h3 i {
+.venue-detail__section h3 i {
     color: var(--color-primary-light);
 }
 
-.venue-modal__address,
-.detail-pane__address {
+.venue-detail__address {
     font-style: normal;
     color: var(--text-primary);
 }
 
-.venue-modal__map-links {
+.venue-detail__map-links {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-sm);
     margin-top: var(--spacing-md);
 }
 
-.venue-modal__schedule-table,
-.detail-pane__schedule-table,
-.map-venue-card__schedule-table {
+.venue-detail__schedule-table {
     width: 100%;
     border-collapse: collapse;
 }
 
-.venue-modal__schedule-table th,
-.venue-modal__schedule-table td,
-.detail-pane__schedule-table th,
-.detail-pane__schedule-table td,
-.map-venue-card__schedule-table th,
-.map-venue-card__schedule-table td {
+.venue-detail__schedule-table th,
+.venue-detail__schedule-table td {
     text-align: left;
     border-bottom: 1px solid var(--border-color);
-}
-
-.venue-modal__schedule-table th,
-.venue-modal__schedule-table td,
-.detail-pane__schedule-table th,
-.detail-pane__schedule-table td {
     padding: var(--spacing-sm);
 }
 
-.venue-modal__schedule-table th,
-.detail-pane__schedule-table th {
+.venue-detail__schedule-table th {
     color: var(--text-muted);
     font-weight: 500;
     font-size: var(--font-size-sm);
 }
 
-.venue-modal__active-period,
-.detail-pane__active-period {
+.venue-detail__active-period {
     color: var(--color-warning);
     font-size: var(--font-size-sm);
     margin-top: var(--spacing-sm);
 }
 
-.venue-modal__host-name,
-.detail-pane__host-name {
+.venue-detail__host-name {
     font-weight: 500;
     margin-bottom: var(--spacing-xs);
 }
 
-.venue-modal__host-affiliation,
-.detail-pane__host-affiliation {
+.venue-detail__host-affiliation {
     color: var(--text-secondary);
     margin-bottom: var(--spacing-xs);
 }
 
-.venue-modal__host-website,
-.detail-pane__host-website {
+.venue-detail__host-website {
     display: inline-flex;
     align-items: center;
     gap: var(--spacing-xs);
 }
 
-.venue-modal__socials-label,
-.detail-pane__socials-label {
+.venue-detail__socials-label {
     font-size: var(--font-size-sm);
     color: var(--text-muted);
     margin-top: var(--spacing-md);
     margin-bottom: var(--spacing-xs);
 }
 
-.venue-modal__host-socials,
-.detail-pane__host-socials {
+.venue-detail__host-socials {
     display: flex;
     gap: var(--spacing-sm);
 }
 
-.venue-modal__socials,
-.detail-pane__socials {
+.venue-detail__socials {
     display: flex;
     flex-wrap: wrap;
     gap: var(--spacing-sm);
 }
 
-.venue-modal__phone,
-.detail-pane__phone {
+.venue-detail__phone {
     font-size: var(--font-size-lg);
 }
 
-/* Exclusion (closure) notices — shared across the three detail surfaces
-   (modal, desktop pane, map expanded card). The "Closed today" banner mirrors
-   the weekly-view .venue-card__exclusion-banner; the upcoming-closures line
+/* Exclusion (closure) notices. The "Closed today" banner mirrors the
+   weekly-view .venue-card__exclusion-banner; the upcoming-closures line
    lists exclusion dates within the next 60 days. */
-.venue-modal__exclusion-banner,
-.detail-pane__exclusion-banner,
-.map-venue-card__exclusion-banner {
+.venue-detail__exclusion-banner {
     display: flex;
     align-items: center;
     gap: var(--spacing-xs);
@@ -663,15 +637,11 @@
     border-radius: var(--border-radius-sm);
 }
 
-.venue-modal__exclusion-banner i,
-.detail-pane__exclusion-banner i,
-.map-venue-card__exclusion-banner i {
+.venue-detail__exclusion-banner i {
     font-size: var(--font-size-xs);
 }
 
-.venue-modal__upcoming-closures,
-.detail-pane__upcoming-closures,
-.map-venue-card__upcoming-closures {
+.venue-detail__upcoming-closures {
     display: flex;
     align-items: baseline;
     gap: var(--spacing-xs);
@@ -680,11 +650,143 @@
     font-size: var(--font-size-sm);
 }
 
-.venue-modal__upcoming-closures i,
-.detail-pane__upcoming-closures i,
-.map-venue-card__upcoming-closures i {
+.venue-detail__upcoming-closures i {
     color: var(--color-warning);
 }
+
+/* --- .venue-detail--compact : MapView's floating card ---------------
+   A card that floats over the map has far less room than a modal or a
+   sidebar, so it runs a tighter, smaller treatment throughout. This is
+   the one surface that genuinely differs on most properties rather than
+   a handful. */
+
+.venue-detail--compact .venue-detail__section {
+    margin-bottom: 0;
+    border-top: 1px solid var(--border-color);
+    padding-top: var(--spacing-sm);
+}
+
+.venue-detail--compact .venue-detail__section h3 {
+    display: block;
+    /* gap/align-items do nothing on a block box, but resetting them keeps a
+       computed-style parity diff against this surface clean. */
+    gap: normal;
+    align-items: normal;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: 600;
+    margin: 0 0 var(--spacing-xs);
+}
+
+.venue-detail--compact .venue-detail__section h3 i {
+    color: var(--color-primary);
+    margin-right: var(--spacing-xs);
+}
+
+.venue-detail--compact .venue-detail__address {
+    font-size: var(--font-size-sm);
+    margin-bottom: var(--spacing-xs);
+}
+
+.venue-detail--compact .venue-detail__map-links {
+    margin-top: var(--spacing-xs);
+}
+
+.venue-detail--compact .venue-detail__schedule-table {
+    font-size: var(--font-size-sm);
+}
+
+/* Tighter rows than the base — the card floats over the map and every
+   pixel of height pushes it further over the pins. */
+.venue-detail--compact .venue-detail__schedule-table th,
+.venue-detail--compact .venue-detail__schedule-table td {
+    padding: var(--spacing-xs) var(--spacing-sm);
+}
+
+.venue-detail--compact .venue-detail__schedule-table th {
+    color: var(--text-secondary);
+    font-size: var(--font-size-xs);
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+}
+
+.venue-detail--compact .venue-detail__schedule-table td {
+    color: var(--text-primary);
+}
+
+.venue-detail--compact .venue-detail__active-period {
+    color: var(--text-secondary);
+    margin: var(--spacing-xs) 0 0;
+}
+
+.venue-detail--compact .venue-detail__host {
+    font-size: var(--font-size-sm);
+}
+
+.venue-detail--compact .venue-detail__host-name {
+    font-weight: 600;
+    margin: 0 0 var(--spacing-2xs);
+}
+
+.venue-detail--compact .venue-detail__host-affiliation {
+    margin: 0 0 var(--spacing-xs);
+}
+
+.venue-detail--compact .venue-detail__host-website {
+    color: var(--color-primary);
+    font-size: var(--font-size-sm);
+    margin-bottom: var(--spacing-xs);
+}
+
+.venue-detail--compact .venue-detail__socials-label {
+    font-size: var(--font-size-xs);
+    margin: var(--spacing-xs) 0 2px;
+}
+
+.venue-detail--compact .venue-detail__phone {
+    color: var(--color-primary);
+    font-size: var(--font-size-sm);
+}
+
+/* --- .venue-detail--pane : the desktop sidebar ----------------------
+   One difference only: the sidebar is narrow, so the action buttons
+   stack instead of sitting in a row. */
+
+.venue-detail--pane .venue-detail__map-links {
+    flex-direction: column;
+    flex-wrap: nowrap;
+}
+
+/* --- .venue-detail--inline : the A-Z full card ----------------------
+   Sits inside a list item rather than its own panel, so the exclusion
+   banner bleeds to the card edge and the socials row gets a rule above
+   it to separate it from the card body. */
+
+.venue-detail--inline .venue-detail__address {
+    margin-bottom: var(--spacing-md);
+}
+
+.venue-detail--inline .venue-detail__host {
+    margin-top: var(--spacing-md);
+}
+
+.venue-detail--inline .venue-detail__host-affiliation {
+    font-size: var(--font-size-sm);
+}
+
+.venue-detail--inline .venue-detail__socials {
+    margin-top: var(--spacing-md);
+    padding-top: var(--spacing-md);
+    border-top: 1px solid var(--border-color);
+}
+
+.venue-detail--inline .venue-detail__exclusion-banner {
+    margin: calc(var(--spacing-md) * -1) calc(var(--spacing-md) * -1) var(--spacing-sm);
+    padding: var(--spacing-xs) var(--spacing-md);
+    border-radius: var(--border-radius) var(--border-radius) 0 0;
+}
+
 
 /* Responsive modal */
 @media (max-width: 480px) {
@@ -696,29 +798,30 @@
         padding: var(--spacing-md);
     }
 
-    .venue-modal__map-links {
+    /* The floating map card keeps its row layout — it is already compact. */
+    .venue-detail:not(.venue-detail--compact) .venue-detail__map-links {
         flex-direction: column;
     }
 
     /* Stack the schedule table into label/value cards on small phones — a
        3-column table (Day/Time/Host) is too cramped here. data-label
        attributes come from renderScheduleTable() in js/utils/render.js. */
-    .venue-modal__schedule-table,
-    .venue-modal__schedule-table tbody {
+    .venue-detail__schedule-table,
+    .venue-detail__schedule-table tbody {
         display: block;
     }
 
-    .venue-modal__schedule-table thead {
+    .venue-detail__schedule-table thead {
         display: none;
     }
 
-    .venue-modal__schedule-table tr {
+    .venue-detail__schedule-table tr {
         display: block;
         padding: var(--spacing-sm) 0;
         border-bottom: 1px solid var(--border-color);
     }
 
-    .venue-modal__schedule-table td {
+    .venue-detail__schedule-table td {
         display: flex;
         gap: var(--spacing-sm);
         padding: var(--spacing-2xs) 0;
@@ -726,12 +829,12 @@
     }
 
     /* Empty cells (e.g. a show with no host) collapse instead of showing a bare label */
-    .venue-modal__schedule-table td:empty {
+    .venue-detail__schedule-table td:empty {
         display: none;
     }
 
     /* Label column from data-label */
-    .venue-modal__schedule-table td::before {
+    .venue-detail__schedule-table td::before {
         content: attr(data-label);
         flex: 0 0 4.5em;
         color: var(--text-muted);
@@ -740,145 +843,28 @@
     }
 
     /* The day cell is the card's title — bold, no label */
-    .venue-modal__schedule-table td:first-child {
+    .venue-detail__schedule-table td:first-child {
         font-weight: 600;
         font-size: var(--font-size-base);
     }
 
-    .venue-modal__schedule-table td:first-child::before {
+    .venue-detail__schedule-table td:first-child::before {
         content: none;
     }
 }
 
-/* Alphabetical full card reuses the shared detail-section renderer
-   (renderVenueDetailSections, classPrefix 'venue-card', actions omitted).
-   These mirror the .venue-modal__/.detail-pane__ section styles for the classes
-   not already defined above (__address, __host, __host-name, __host-affiliation,
-   __socials, __exclusion-banner are shared with the compact/weekly card). */
-.venue-card__section {
-    margin-bottom: var(--spacing-lg);
-}
 
-.venue-card__section h3 {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-    font-size: var(--font-size-base);
-    color: var(--text-muted);
-    margin-bottom: var(--spacing-sm);
-}
 
-.venue-card__section h3 i {
-    color: var(--color-primary-light);
-}
 
-.venue-card__schedule-table {
-    width: 100%;
-    border-collapse: collapse;
-}
 
-.venue-card__schedule-table th,
-.venue-card__schedule-table td {
-    text-align: left;
-    border-bottom: 1px solid var(--border-color);
-    padding: var(--spacing-sm);
-}
 
-.venue-card__schedule-table th {
-    color: var(--text-muted);
-    font-weight: 500;
-    font-size: var(--font-size-sm);
-}
 
-.venue-card__active-period {
-    color: var(--color-warning);
-    font-size: var(--font-size-sm);
-    margin-top: var(--spacing-sm);
-}
 
-.venue-card__host-website {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-}
 
-.venue-card__socials-label {
-    font-size: var(--font-size-sm);
-    color: var(--text-muted);
-    margin-top: var(--spacing-md);
-    margin-bottom: var(--spacing-xs);
-}
 
-.venue-card__host-socials {
-    display: flex;
-    gap: var(--spacing-sm);
-}
 
-.venue-card__upcoming-closures {
-    display: flex;
-    align-items: baseline;
-    gap: var(--spacing-xs);
-    margin: var(--spacing-sm) 0 0;
-    color: var(--text-secondary);
-    font-size: var(--font-size-sm);
-}
 
-.venue-card__upcoming-closures i {
-    color: var(--color-warning);
-}
 
-/* Stack the inline schedule table into label/value rows on small phones,
-   mirroring the modal (data-label comes from renderScheduleTable). */
-@media (max-width: 480px) {
-    .venue-card__schedule-table,
-    .venue-card__schedule-table tbody {
-        display: block;
-    }
-
-    .venue-card__schedule-table thead {
-        display: none;
-    }
-
-    .venue-card__schedule-table tr {
-        display: block;
-        padding: var(--spacing-sm) 0;
-        border-bottom: 1px solid var(--border-color);
-    }
-
-    .venue-card__schedule-table td {
-        display: flex;
-        gap: var(--spacing-sm);
-        padding: var(--spacing-2xs) 0;
-        border: none;
-    }
-
-    .venue-card__schedule-table td:empty {
-        display: none;
-    }
-
-    .venue-card__schedule-table td::before {
-        content: attr(data-label);
-        flex: 0 0 4.5em;
-        color: var(--text-muted);
-        font-size: var(--font-size-sm);
-        font-weight: 500;
-    }
-
-    .venue-card__schedule-table td:first-child {
-        font-weight: 600;
-        font-size: var(--font-size-base);
-    }
-
-    .venue-card__schedule-table td:first-child::before {
-        content: none;
-    }
-}
-
-/* Special Event card accent */
-.venue-card--special-event {
-    border-left: 4px solid var(--color-accent-special-event);
-    background: linear-gradient(135deg, rgba(233, 30, 99, 0.05), transparent);
-}
 
 /* Excluded card — recurring entry suppressed on this specific date
    (holiday, private event, etc.). Body content is dimmed; the banner stays
@@ -1012,13 +998,6 @@
     color: var(--text-primary);
 }
 
-/* Detail pane specific styles (map links layout differs from modal) */
-.detail-pane__map-links {
-    display: flex;
-    flex-direction: column;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-md);
-}
 
 /* Mobile overflow prevention */
 @media (max-width: 768px) {

--- a/css/views.css
+++ b/css/views.css
@@ -944,113 +944,24 @@ body.view--map .app-layout__detail {
     margin-top: var(--spacing-sm);
 }
 
-.map-venue-card__section {
-    border-top: 1px solid var(--border-color);
-    padding-top: var(--spacing-sm);
-}
 
-.map-venue-card__section h3 {
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-    margin: 0 0 var(--spacing-xs);
-    color: var(--text-secondary);
-}
 
-.map-venue-card__section h3 i {
-    margin-right: var(--spacing-xs);
-    color: var(--color-primary);
-}
 
-.map-venue-card__address {
-    font-style: normal;
-    font-size: var(--font-size-sm);
-    color: var(--text-primary);
-    margin-bottom: var(--spacing-xs);
-}
 
-.map-venue-card__map-links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-xs);
-}
 
-.map-venue-card__schedule-table {
-    font-size: var(--font-size-sm);
-}
 
-.map-venue-card__schedule-table th,
-.map-venue-card__schedule-table td {
-    padding: var(--spacing-xs) var(--spacing-sm);
-}
 
-.map-venue-card__schedule-table th {
-    font-weight: 600;
-    color: var(--text-secondary);
-    font-size: var(--font-size-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-}
 
-.map-venue-card__schedule-table td {
-    color: var(--text-primary);
-}
 
-.map-venue-card__active-period {
-    font-size: var(--font-size-sm);
-    color: var(--text-secondary);
-    margin: var(--spacing-xs) 0 0;
-}
 
-.map-venue-card__active-period i {
-    margin-right: var(--spacing-xs);
-    color: var(--color-primary);
-}
 
-.map-venue-card__host {
-    font-size: var(--font-size-sm);
-}
 
-.map-venue-card__host-name {
-    font-weight: 600;
-    margin: 0 0 var(--spacing-2xs);
-}
 
-.map-venue-card__host-affiliation {
-    color: var(--text-secondary);
-    margin: 0 0 var(--spacing-xs);
-}
 
-.map-venue-card__host-website {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-    color: var(--color-primary);
-    font-size: var(--font-size-sm);
-    margin-bottom: var(--spacing-xs);
-}
 
-.map-venue-card__socials-label {
-    font-size: var(--font-size-xs);
-    color: var(--text-muted);
-    margin: var(--spacing-xs) 0 2px;
-}
 
-.map-venue-card__host-socials {
-    display: flex;
-    gap: var(--spacing-sm);
-}
 
-.map-venue-card__socials {
-    display: flex;
-    gap: var(--spacing-sm);
-    flex-wrap: wrap;
-}
 
-.map-venue-card__phone {
-    color: var(--color-primary);
-    font-size: var(--font-size-sm);
-}
 
 /* Mobile adjustments */
 @media (max-width: 768px) {

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -450,6 +450,17 @@ Visible when window width is **1400px or wider**. Hidden on smaller screens via 
 
 Same sections as the mobile modal (closure banner, Location, Schedule, Host, Social Media, Contact) — both are built by the shared `renderVenueDetailSections()`, so the "Closed Today" banner and "Upcoming closures" list (§7, §11) appear identically here.
 
+> **Implementation note (#161):** `renderVenueDetailSections()` emits one block, `.venue-detail__*`, on all four surfaces that use it — the mobile modal, this pane, the map's expanded card, and the A–Z full card. Each caller adds `.venue-detail` plus an optional surface modifier to its own wrapper:
+>
+> | Surface | Wrapper classes |
+> |---|---|
+> | Mobile modal | `.venue-modal__content venue-detail` |
+> | Desktop pane | `.detail-pane venue-detail venue-detail--pane` |
+> | Map expanded card | `.map-venue-card__detail-content venue-detail venue-detail--compact` |
+> | A–Z full card | `.venue-card--full venue-detail venue-detail--inline` |
+>
+> The renderer previously took a `classPrefix` and the four callers passed four different ones, so the same markup came out under four names and the stylesheet carried a 4×17 matrix to dress them alike. Wrappers, headers, titles and close buttons stay per-surface — those genuinely differ and are not the renderer's markup.
+
 ### Empty State
 
 When no venue is selected, shows a microphone icon and the text: "Select a venue to see details, schedule, and host information."

--- a/e2e/venue-detail.spec.js
+++ b/e2e/venue-detail.spec.js
@@ -50,9 +50,13 @@ test.describe('Venue detail — modal & detail pane', () => {
       await openFirstVenue(page);
       await expect(page.locator(modalContent)).toBeVisible({ timeout: 5000 });
 
-      await expect(page.locator('.venue-modal__address')).toBeVisible();
+      // Scope to the modal. Since #161 every detail surface emits the same
+      // .venue-detail__ block, so an unscoped locator also matches the
+      // (display:none at this width) desktop pane and trips strict mode.
+      const modal = page.locator(modalContent);
+      await expect(modal.locator('.venue-detail__address')).toBeVisible();
       // At least 2 sections: Location and Schedule
-      expect(await page.locator('.venue-modal__section').count()).toBeGreaterThanOrEqual(2);
+      expect(await modal.locator('.venue-detail__section').count()).toBeGreaterThanOrEqual(2);
     });
 
     test('close modal via close button', async ({ page }) => {

--- a/js/components/VenueCard.js
+++ b/js/components/VenueCard.js
@@ -133,7 +133,7 @@ export class VenueCard extends Component {
         // button row to keep the long A–Z list light — full actions live in the
         // detail pane/modal opened on click.
         return `
-            <div class="venue-card venue-card--full" data-venue-id="${escapeHtml(venue.id)}">
+            <div class="venue-card venue-card--full venue-detail venue-detail--inline" data-venue-id="${escapeHtml(venue.id)}">
                 <div class="venue-card__header">
                     <h3 class="venue-card__name">
                         <button class="venue-card__link" type="button">
@@ -142,7 +142,7 @@ export class VenueCard extends Component {
                     </h3>
                     ${renderTags(venue.tags, { dedicated: venue.dedicated })}
                 </div>
-                ${renderVenueDetailSections(venue, { classPrefix: 'venue-card', actions: false })}
+                ${renderVenueDetailSections(venue, { actions: false })}
             </div>
         `;
     }

--- a/js/components/VenueDetailPane.js
+++ b/js/components/VenueDetailPane.js
@@ -30,7 +30,7 @@ export class VenueDetailPane extends Component {
         }
 
         return `
-            <div class="detail-pane">
+            <div class="detail-pane venue-detail venue-detail--pane">
                 <header class="detail-pane__header">
                     <h2 class="detail-pane__title">
                         ${escapeHtml(venue.name)}
@@ -39,7 +39,7 @@ export class VenueDetailPane extends Component {
                     ${renderTags(venue.tags, { dedicated: venue.dedicated })}
                 </header>
 
-                ${renderVenueDetailSections(venue, { classPrefix: 'detail-pane' })}
+                ${renderVenueDetailSections(venue)}
             </div>
         `;
     }
@@ -48,7 +48,7 @@ export class VenueDetailPane extends Component {
         if (!this.state.venue) return;
 
         // Share button
-        this.addEventListener('.detail-pane__share', 'click', (e) => {
+        this.addEventListener('.venue-detail__share', 'click', (e) => {
             shareVenue(this.state.venue, e.currentTarget);
         });
     }

--- a/js/components/VenueModal.js
+++ b/js/components/VenueModal.js
@@ -34,7 +34,7 @@ export class VenueModal extends Component {
         return `
             <div class="venue-modal venue-modal--open" role="dialog" aria-modal="true" aria-labelledby="venue-modal-title">
                 <div class="venue-modal__backdrop"></div>
-                <div class="venue-modal__content">
+                <div class="venue-modal__content venue-detail">
                     <button class="venue-modal__close" type="button" aria-label="Close">
                         <i class="fa-solid fa-xmark"></i>
                     </button>
@@ -47,7 +47,7 @@ export class VenueModal extends Component {
                         ${renderTags(venue.tags, { dedicated: venue.dedicated })}
                     </header>
 
-                    ${renderVenueDetailSections(venue, { classPrefix: 'venue-modal' })}
+                    ${renderVenueDetailSections(venue)}
                 </div>
             </div>
         `;
@@ -63,7 +63,7 @@ export class VenueModal extends Component {
         this.addEventListener('.venue-modal__backdrop', 'click', () => this.close());
 
         // Share button
-        this.addEventListener('.venue-modal__share', 'click', (e) => {
+        this.addEventListener('.venue-detail__share', 'click', (e) => {
             shareVenue(this.state.venue, e.currentTarget);
         });
 

--- a/js/utils/render.js
+++ b/js/utils/render.js
@@ -54,10 +54,9 @@ function hasPerShowHosts(venue) {
  * a Host column is added. Otherwise the column is omitted and host info lives
  * in the venue-level "Presented By" section as before.
  * @param {Object} venue - Full venue object (needs .schedule and optionally .host)
- * @param {string} classPrefix - CSS class prefix (e.g., 'venue-modal', 'detail-pane')
  * @returns {string} HTML string for schedule table
  */
-export function renderScheduleTable(venue, classPrefix) {
+export function renderScheduleTable(venue) {
     const schedule = venue?.schedule;
     if (!schedule || schedule.length === 0) {
         return '<p>No schedule information available.</p>';
@@ -93,7 +92,7 @@ export function renderScheduleTable(venue, classPrefix) {
     }).join('');
 
     return `
-        <table class="${classPrefix}__schedule-table">
+        <table class="venue-detail__schedule-table">
             <thead>
                 <tr>
                     <th>Day</th>
@@ -128,14 +127,13 @@ export function renderScheduleCompact(schedule) {
 /**
  * Render an active period notice with icon
  * @param {Object} activePeriod - Object with start and/or end date strings
- * @param {string} classPrefix - CSS class prefix
  * @returns {string} HTML string or empty if no active period
  */
-export function renderActivePeriod(activePeriod, classPrefix) {
+export function renderActivePeriod(activePeriod) {
     const text = formatActivePeriodText(activePeriod);
     if (!text) return '';
 
-    return `<p class="${classPrefix}__active-period"><i class="fa-solid fa-calendar-check"></i> ${text}</p>`;
+    return `<p class="venue-detail__active-period"><i class="fa-solid fa-calendar-check"></i> ${text}</p>`;
 }
 
 /**
@@ -143,10 +141,9 @@ export function renderActivePeriod(activePeriod, classPrefix) {
  * the next 60 days (e.g. "Dec 25 (Christmas), Dec 26 (Repairs)"). Returns an
  * empty string when there are none.
  * @param {Object} venue - Venue object (needs .schedule)
- * @param {string} classPrefix - CSS class prefix
  * @returns {string} HTML string or empty
  */
-export function renderUpcomingClosures(venue, classPrefix) {
+export function renderUpcomingClosures(venue) {
     const upcoming = getUpcomingExclusions(venue, 60);
     if (!upcoming.length) return '';
 
@@ -155,17 +152,16 @@ export function renderUpcomingClosures(venue, classPrefix) {
         return ex.reason ? `${escapeHtml(label)} (${escapeHtml(ex.reason)})` : escapeHtml(label);
     }).join(', ');
 
-    return `<p class="${classPrefix}__upcoming-closures"><i class="fa-solid fa-ban"></i> Upcoming closures: ${list}</p>`;
+    return `<p class="venue-detail__upcoming-closures"><i class="fa-solid fa-ban"></i> Upcoming closures: ${list}</p>`;
 }
 
 /**
  * Render the host/KJ section for venue details
  * @param {Object} host - Host object with name, affiliation, website, socials
- * @param {string} classPrefix - CSS class prefix
  * @param {Object} options - Options for social links
  * @returns {string} HTML string or empty if no host
  */
-export function renderHostSection(host, classPrefix, options = {}) {
+export function renderHostSection(host, options = {}) {
     if (!host) return '';
 
     const { socialSize = 'fa-lg' } = options;
@@ -174,19 +170,19 @@ export function renderHostSection(host, classPrefix, options = {}) {
         : '';
 
     return `
-        <section class="${classPrefix}__section">
+        <section class="venue-detail__section">
             <h3>Presented By</h3>
-            <div class="${classPrefix}__host">
-                ${host.name ? `<p class="${classPrefix}__host-name">${escapeHtml(host.name)}</p>` : ''}
-                ${host.affiliation ? `<p class="${classPrefix}__host-affiliation">${escapeHtml(host.affiliation)}</p>` : ''}
+            <div class="venue-detail__host">
+                ${host.name ? `<p class="venue-detail__host-name">${escapeHtml(host.name)}</p>` : ''}
+                ${host.affiliation ? `<p class="venue-detail__host-affiliation">${escapeHtml(host.affiliation)}</p>` : ''}
                 ${host.website ? `
-                    <a href="${escapeHtml(sanitizeUrl(host.website) || '')}" target="_blank" rel="noopener noreferrer" class="${classPrefix}__host-website">
+                    <a href="${escapeHtml(sanitizeUrl(host.website) || '')}" target="_blank" rel="noopener noreferrer" class="venue-detail__host-website">
                         <i class="fa-solid fa-globe"></i> Website
                     </a>
                 ` : ''}
                 ${hostSocialsHtml ? `
-                    <p class="${classPrefix}__socials-label">KJ Social Media</p>
-                    <div class="${classPrefix}__host-socials">${hostSocialsHtml}</div>
+                    <p class="venue-detail__socials-label">KJ Social Media</p>
+                    <div class="venue-detail__host-socials">${hostSocialsHtml}</div>
                 ` : ''}
             </div>
         </section>
@@ -311,18 +307,33 @@ export function getScheduleContext(venue, schedule, currentDate = null) {
 
 /**
  * Render the full venue-detail sections (location, schedule, host, socials, contact)
- * shared by VenueModal, VenueDetailPane, and MapView's expanded detail card.
+ * shared by VenueModal, VenueDetailPane, MapView's expanded card, and the A–Z
+ * full card.
  *
- * Caller wraps these sections in their own outer container + header — the surfaces
- * differ in their wrappers (modal backdrop vs sticky pane vs floating map card).
+ * Emits ONE block: `.venue-detail__*`. It used to take a `classPrefix` and the
+ * four callers passed four different ones, so the same markup came out under
+ * four names and the stylesheet carried a hand-maintained 4x17 matrix to dress
+ * them identically. It had already drifted — `.venue-card__phone` was emitted
+ * and styled nowhere (#161).
+ *
+ * Callers put a surface modifier on their OWN wrapper and style the differences
+ * through it:
+ *
+ *   (none)                    modal and desktop pane — the reference treatment
+ *   .venue-detail--compact    MapView's floating card: tighter, smaller type
+ *   .venue-detail--inline     A–Z full card: sits inside a list item
+ *
+ * Their own wrappers, headers, titles and close buttons stay per-surface — those
+ * genuinely differ (modal backdrop vs sticky pane vs floating card) and are not
+ * this function's markup.
  *
  * @param {Object} venue - Venue data object
- * @param {Object} options
- * @param {string} options.classPrefix - BEM prefix (e.g. 'venue-modal', 'detail-pane', 'map-venue-card')
+ * @param {Object} [options]
  * @param {string} [options.hostSocialSize='fa-lg'] - Font Awesome size class for host socials ('' for compact)
+ * @param {boolean} [options.actions=true] - Render the View Map / Directions / Share row
  * @returns {string} HTML string of <section> elements
  */
-export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize = 'fa-lg', actions = true }) {
+export function renderVenueDetailSections(venue, { hostSocialSize = 'fa-lg', actions = true } = {}) {
     const addressHtml = formatAddress(venue.address);
     const mapUrl = buildMapUrl(venue.address, venue.name);
     const directionsUrl = buildDirectionsUrl(venue.address, venue.name);
@@ -331,47 +342,47 @@ export function renderVenueDetailSections(venue, { classPrefix, hostSocialSize =
     // "Closed today" banner when a recurring show is excluded on the current date
     const todayExclusion = getVenueExclusionForDate(venue, new Date());
     const exclusionBanner = todayExclusion
-        ? `<div class="${classPrefix}__exclusion-banner"><i class="fa-solid fa-ban"></i> Closed Today${todayExclusion.reason ? `: ${escapeHtml(todayExclusion.reason)}` : ''}</div>`
+        ? `<div class="venue-detail__exclusion-banner"><i class="fa-solid fa-ban"></i> Closed Today${todayExclusion.reason ? `: ${escapeHtml(todayExclusion.reason)}` : ''}</div>`
         : '';
 
     return `
         ${exclusionBanner}
-        <section class="${classPrefix}__section">
+        <section class="venue-detail__section">
             <h3><i class="fa-solid fa-location-dot"></i> Location</h3>
-            <address class="${classPrefix}__address">${addressHtml}</address>
-            ${actions ? `<div class="${classPrefix}__map-links">
+            <address class="venue-detail__address">${addressHtml}</address>
+            ${actions ? `<div class="venue-detail__map-links">
                 <a href="${mapUrl}" target="_blank" rel="noopener noreferrer" class="btn btn--secondary">
                     <i class="fa-solid fa-map"></i> View Map
                 </a>
                 <a href="${directionsUrl}" target="_blank" rel="noopener noreferrer" class="btn btn--secondary">
                     <i class="fa-solid fa-diamond-turn-right"></i> Directions
                 </a>
-                <button class="btn btn--secondary ${classPrefix}__share" type="button">
+                <button class="btn btn--secondary venue-detail__share" type="button">
                     <i class="fa-solid fa-share-from-square"></i> Share
                 </button>
             </div>` : ''}
         </section>
 
-        <section class="${classPrefix}__section">
+        <section class="venue-detail__section">
             <h3><i class="fa-regular fa-calendar"></i> Schedule</h3>
-            ${renderScheduleTable(venue, classPrefix)}
-            ${renderActivePeriod(venue.activePeriod, classPrefix)}
-            ${renderUpcomingClosures(venue, classPrefix)}
+            ${renderScheduleTable(venue)}
+            ${renderActivePeriod(venue.activePeriod)}
+            ${renderUpcomingClosures(venue)}
         </section>
 
-        ${renderHostSection(venue.host, classPrefix, { socialSize: hostSocialSize })}
+        ${renderHostSection(venue.host, { socialSize: hostSocialSize })}
 
         ${socialLinksHtml ? `
-            <section class="${classPrefix}__section">
+            <section class="venue-detail__section">
                 <h3><i class="fa-solid fa-share-nodes"></i> Venue Social Media</h3>
-                <div class="${classPrefix}__socials">${socialLinksHtml}</div>
+                <div class="venue-detail__socials">${socialLinksHtml}</div>
             </section>
         ` : ''}
 
         ${venue.phone ? `
-            <section class="${classPrefix}__section">
+            <section class="venue-detail__section">
                 <h3><i class="fa-solid fa-phone"></i> Contact</h3>
-                <a href="tel:${escapeHtml(venue.phone)}" class="${classPrefix}__phone">${escapeHtml(venue.phone)}</a>
+                <a href="tel:${escapeHtml(venue.phone)}" class="venue-detail__phone">${escapeHtml(venue.phone)}</a>
             </section>
         ` : ''}
     `;

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -466,15 +466,15 @@ export class MapView extends Component {
                 <h3 class="map-venue-card__title">${escapeHtml(venue.name)}</h3>
             </div>
             ${tagsHtml}
-            <div class="map-venue-card__detail-content">
-                ${renderVenueDetailSections(venueForDisplay, { classPrefix: 'map-venue-card', hostSocialSize: '' })}
+            <div class="map-venue-card__detail-content venue-detail venue-detail--compact">
+                ${renderVenueDetailSections(venueForDisplay, { hostSocialSize: '' })}
             </div>
         `;
 
         cardEl.classList.add('map-venue-card--expanded');
 
         // Bind share button
-        const shareBtn = cardEl.querySelector('.map-venue-card__share');
+        const shareBtn = cardEl.querySelector('.venue-detail__share');
         if (shareBtn) {
             shareBtn.addEventListener('click', () => shareVenue(venue, shareBtn));
         }


### PR DESCRIPTION
Closes #161. Targets `main` (#160 has landed).

## What the matrix actually looked like

Before changing anything I enumerated all 64 prefix × element combinations:

```
element             venue-modal  detail-pane  venue-card  map-venue-card
section             YES          YES          YES         YES
address             YES          YES          YES         YES
phone               YES          YES          .           YES     ← drift
host                .            .            YES         YES
...
styled: 56   emitted-but-unstyled: 8
```

`.venue-card__phone` is the drift the ticket names — #116 routed the A–Z card through the shared renderer without adding its rules. (Of the other 7 "unstyled", 4 are `__share` JS hooks that get their look from `.btn`, 2 are bare wrapper divs, and `venue-card__map-links` is never emitted because that caller passes `actions: false`. Only the phone was a real visual orphan.)

Then I diffed the declarations behind each shape. The result was decisive: **`venue-modal`, `detail-pane` and `venue-card` were near-identical on almost every rule, and `map-venue-card` was the consistent outlier.**

## The shape that fell out

Base = the modal/pane treatment. Three modifiers, set by callers on their own wrapper:

| Modifier | Rules | What genuinely differs |
|---|---|---|
| *(none)* | — | modal |
| `--pane` | 1 | narrow sidebar: action buttons stack |
| `--inline` | 5 | A–Z card: full-bleed closure banner, rule above socials |
| `--compact` | 17 | map card: tighter and smaller throughout |

### On the "≤6 modifier overrides" AC

I didn't meet it, deliberately. The map card genuinely differs on ~15 properties — font sizes, paddings, colours, uppercase table headers. Holding it to six rules would have meant *changing how it looks*, which contradicts the screenshot-parity AC in the same ticket. I chose parity and am flagging the trade rather than quietly satisfying the smaller number.

## Verification — computed-style parity

Screenshots can't prove this: the class names are exactly what changed, so I captured **computed styles for every element of every surface by structural position**, before and after, at both widths. Pinned to one venue (`canary-roost`, 7 schedule entries) with a phone injected, since **no venue in the dataset has a phone** — which is precisely how the `.venue-card__phone` orphan survived unnoticed.

| Surface | Width | Elements | Property diffs |
|---|---|---|---|
| Modal | 375 | 56/56 | **0** |
| Desktop pane | 1440 | 55/55 | **0** |
| Map card | 1440 | 49/49 | **0** |
| Map card | 375 | 49/49 | 91 — all table stacking (below) |
| A–Z full card | 375 | 52/52 | 4 (below) |

**The 91 map@375 diffs are AC2 landing.** `display: table→block`, `thead→none`, `td→flex` — the map card's schedule table now stacks on small phones. It was visible at that width and didn't stack before, because the stacking rule existed twice, keyed to `.venue-modal__` and `.venue-card__`, and neither covered it. Those two byte-equivalent blocks are now one.

**The 4 A–Z diffs are the drift closing, not regressions:**

```
<address> font-style   italic → normal   UA default; modal/pane set normal
host-affiliation margin 16px  → 4px      UA <p> margin; modal/pane use --spacing-xs
socials flex-wrap      nowrap → wrap     matches the other three surfaces
phone font-size        16px   → 18px     the .venue-card__phone orphan, fixed
```

Each is the A–Z card converging on the treatment the other three already had. That's the point of the ticket, but it *is* a visual change and I'd rather name it than claim pixel-perfection.

### Two rounds were needed

The first pass regressed the map card: table cells went from `4px 8px` to `8px` padding, and its `<h3>` carried inert `gap`/`align-items`. The parity harness caught both; both are fixed in `--compact`. I'm mentioning it because "the refactor is visually neutral" was not true until the second pass — the measurement is what made it true.

## Other changes

- Three per-surface Share selectors (`.venue-modal__share`, `.detail-pane__share`, `.map-venue-card__share`) collapse to one `.venue-detail__share`.
- `css/views.css` −89 lines; `components.css` nets −21.
- Spec §8 gains an implementation note with the wrapper-class table.

**One e2e assertion had to be scoped.** `.venue-detail__address` now matches the modal *and* the hidden desktop pane, tripping Playwright strict mode. That's a genuine cost of a shared class — worth knowing before adding more assertions against this block. The scoped version asserts something more precise anyway.

| Gate | Result |
|---|---|
| `npm run test:unit` | **136 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

*Supersedes #194, which GitHub auto-closed when its base branch (`160-card-schedule-and-sanitize`) was deleted on merge of #193. Same branch, same commit — retargeted to `main`.*
