### PR TITLE
#166: Extract .panel, .tag and .input; delete the orphan CSS

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@
 
 ### 2. Mobile-First Responsive Design
 - Base styles target mobile devices
-- Media queries enhance for larger screens (560px, 768px, 1024px, 1400px breakpoints); 560px splits phone vs phablet nav, 769px+ enables multi-column venue grids (see spec §19)
+- Media queries enhance for larger screens. The scale is **480 / 560 / 768 / 1400**, plus one `min-width: 1024px` rule for the map's docked venue card: 480px stacks schedule tables, 560px splits phone vs phablet nav, 769px+ enables multi-column venue grids, 1400px+ shows the desktop detail pane (see spec §19). `bingo.html` keeps its own game-specific scale.
 - Modal for venue details on mobile, side pane on desktop (1400px+)
 
 ### 3. Separation of Concerns

--- a/about.html
+++ b/about.html
@@ -55,22 +55,22 @@
     </nav>
 
     <main class="main-content">
-        <article class="day-card">
-            <header class="day-card__header">
-                <h2 class="day-card__day">About Us</h2>
+        <article class="panel">
+            <header class="panel__header">
+                <h2 class="panel__title">About Us</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p>Welcome to the shortest path between you and karaoke!</p>
                 <p>We offer a no nonsense and mobile friendly guide to finding a local karaoke spot in and around Austin Texas.</p>
                 <p>Venues and times are based on our best and latest info, however always contact the venue you are attending to make sure karaoke is still on that night!</p>
             </div>
         </article>
 
-        <article class="day-card">
-            <header class="day-card__header">
-                <h2 class="day-card__day">What You Can Do</h2>
+        <article class="panel">
+            <header class="panel__header">
+                <h2 class="panel__title">What You Can Do</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p><i class="fa-solid fa-calendar-days"></i> <strong>Weekly Calendar</strong> &mdash; See which venues have karaoke each night with a 7-day schedule and week navigation</p>
                 <p><i class="fa-solid fa-arrow-down-a-z"></i> <strong>A-Z Listing</strong> &mdash; Browse all venues alphabetically with a quick-jump letter index</p>
                 <p><i class="fa-solid fa-map"></i> <strong>Interactive Map</strong> &mdash; Find nearby venues on a full-screen immersive map with floating venue cards</p>
@@ -81,11 +81,11 @@
             </div>
         </article>
 
-        <article class="day-card">
-            <header class="day-card__header">
-                <h2 class="day-card__day">Submit a Venue</h2>
+        <article class="panel">
+            <header class="panel__header">
+                <h2 class="panel__title">Submit a Venue</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p>Know of a karaoke night we're missing? Submit a new venue!</p>
                 <a href="submit.html" class="btn btn--primary">
                     <i class="fa-solid fa-plus"></i>
@@ -94,11 +94,11 @@
             </div>
         </article>
 
-        <article class="day-card">
-            <header class="day-card__header">
-                <h2 class="day-card__day">Submit Feedback</h2>
+        <article class="panel">
+            <header class="panel__header">
+                <h2 class="panel__title">Submit Feedback</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p>Click here if you wish to suggest corrections or submit feedback!</p>
                 <a href="https://forms.gle/EiRbnMf1uwcp1Ak16" class="btn btn--primary" target="_blank" rel="noopener noreferrer">
                     <i class="fa-solid fa-comment"></i>
@@ -107,22 +107,22 @@
             </div>
         </article>
 
-        <article class="day-card" id="privacy">
-            <header class="day-card__header">
-                <h2 class="day-card__day">Privacy</h2>
+        <article class="panel" id="privacy">
+            <header class="panel__header">
+                <h2 class="panel__title">Privacy</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p>This site uses <a href="https://clarity.microsoft.com" target="_blank" rel="noopener noreferrer">Microsoft Clarity</a> to understand how visitors use the directory &mdash; what pages get viewed, where people click, how they scroll. The data is anonymous and aggregated; no personal information is collected.</p>
                 <p>The first time you visit, a banner asks for your consent. Clarity does not run until you click Accept. To revisit your choice, clear this site's data in your browser settings and reload.</p>
                 <p>No accounts, no email addresses, no profile tracking. Just karaoke.</p>
             </div>
         </article>
 
-        <article class="day-card">
-            <header class="day-card__header">
-                <h2 class="day-card__day">For Developers</h2>
+        <article class="panel">
+            <header class="panel__header">
+                <h2 class="panel__title">For Developers</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p>Interested in how this site works? Check out our documentation!</p>
                 <p>
                     <a href="docs/index.html" class="btn btn--secondary">
@@ -133,11 +133,11 @@
             </div>
         </article>
 
-        <article class="day-card">
-            <header class="day-card__header">
-                <h2 class="day-card__day">Contact Us</h2>
+        <article class="panel">
+            <header class="panel__header">
+                <h2 class="panel__title">Contact Us</h2>
             </header>
-            <div class="day-card__content">
+            <div class="panel__body">
                 <p>Follow us on Social Media!</p>
                 <div class="venue-card__socials">
                     <a href="https://www.facebook.com/groups/2494105004273043"

--- a/css/base.css
+++ b/css/base.css
@@ -24,14 +24,11 @@
     --color-primary-pale: #d8c4ff;
 
     --color-secondary: #ec4899;
-    --color-secondary-dark: #db2777;
 
     --color-success: #10b981;
     --color-warning: #f59e0b;
     --color-error: #ef4444;
 
-    --color-gray-50: #f9fafb;
-    --color-gray-100: #f3f4f6;
     --color-gray-200: #e5e7eb;
     --color-gray-300: #d1d5db;
     --color-gray-400: #9ca3af;

--- a/css/bingo.css
+++ b/css/bingo.css
@@ -335,18 +335,13 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    animation: fireworkExplode 1s ease-out forwards;
 }
 
-@keyframes fireworkExplode {
-    0% {
-        transform: translate(0, 0) scale(1);
-        opacity: 1;
-    }
-    100% {
-        opacity: 0;
-    }
-}
+/* @keyframes fireworkExplode lived here. js/bingo.js assigned it and then
+   immediately replaced it with a Web Animations API call on the same element —
+   its own comment said "Override the animation with inline keyframes" — so the
+   keyframe never rendered a frame. Removed in #166 along with the assignment
+   and the --end-x/--end-y properties nothing read. */
 
 /* Star burst */
 .star {

--- a/css/components.css
+++ b/css/components.css
@@ -224,28 +224,58 @@
     pointer-events: none;
 }
 
-.search-input__field {
+/* .input — the one text-field surface.
+ *
+ * There were four text fields with four focus treatments, one of them keyed to
+ * a violet (rgba(139,92,246,.2)) that exists in no token. They all compose this
+ * now and share the global :focus-visible ring from base.css (#166).
+ *
+ * 16px is deliberate, not arbitrary: iOS auto-zooms the page when a focused
+ * input is smaller. The submit form already used it for that reason; the search
+ * field did not, and now does.
+ *
+ * The consumers are named in the selector list rather than each carrying a
+ * `class="input"`, because submit.html's schedule rows are generated in JS and
+ * would need the class threaded through there too. The point of the AC — one
+ * definition of the field surface — holds either way. #168 converts that file
+ * to a module and can add the class then.
+ */
+.input,
+.search-input__field,
+.form-group input,
+.form-group select,
+.form-group textarea {
     width: 100%;
     padding: var(--spacing-sm) var(--spacing-md);
-    padding-left: calc(var(--spacing-sm) + 1.25em + var(--spacing-xs));
-    padding-right: calc(var(--spacing-sm) + 1.25em + var(--spacing-xs));
     border: 1px solid var(--border-color);
     border-radius: var(--border-radius);
     background: var(--bg-card);
     color: var(--text-primary);
-    font-size: var(--font-size-sm);
-    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+    font-size: 16px;
+    min-height: var(--size-icon-lg);
+    box-sizing: border-box;
+    transition: border-color var(--transition-fast);
+}
+
+.input:focus,
+.search-input__field:focus,
+.form-group :is(input, select, textarea):focus {
+    border-color: var(--color-primary);
+}
+
+/* Composes .input; adds room for the magnifier and clear button. */
+.search-input__field {
+    padding-left: calc(var(--spacing-sm) + 1.25em + var(--spacing-xs));
+    padding-right: calc(var(--spacing-sm) + 1.25em + var(--spacing-xs));
 }
 
 .search-input__field::placeholder {
     color: var(--text-muted);
 }
 
-.search-input__field:focus {
-    outline: none;
-    border-color: var(--color-primary);
-    box-shadow: 0 0 0 2px rgba(139, 92, 246, 0.2);
-}
+/* The `outline: none` + violet box-shadow that lived here is gone — it removed
+   the focus ring and replaced it with a colour from no token (#166). The
+   global :focus-visible ring in base.css applies instead. */
 
 .search-input__clear {
     position: absolute;
@@ -373,13 +403,37 @@
     margin-bottom: var(--spacing-sm);
 }
 
-.venue-tag {
+/* .tag — the one chip for tag data.
+ *
+ * The same tags used to render as two components with two radii and two
+ * inline-style call sites: `.venue-tag` in the directory and `.tag-badge` on
+ * the submit form. Both are this now (#166).
+ *
+ * Colours come from data.json's tagDefinitions, so they cannot be written here.
+ * initTagConfig() in js/utils/tags.js injects one stylesheet keyed on
+ * `[data-tag]` at load, which is what replaced the inline `style=` on both
+ * sites. A tag with no definition simply falls back to the neutral surface
+ * below rather than rendering unstyled.
+ */
+.tag {
     display: inline-block;
     padding: var(--spacing-2xs) var(--spacing-sm);
     border-radius: var(--border-radius-sm);
     font-size: var(--font-size-xs);
     font-weight: 500;
     white-space: nowrap;
+    background: var(--color-gray-700);
+    color: var(--text-primary);
+    text-decoration: none;
+}
+
+/* Hover/focus land on every tag, anchor or not, so wiring a destination later
+   (a future `?tag=` link — ADR-011) needs no new component. Nothing is linked
+   today; renderTagBadge() only emits an <a> when given an href. */
+a.tag:hover,
+a.tag:focus-visible {
+    filter: brightness(1.15);
+    text-decoration: none;
 }
 
 /* Full venue card */
@@ -506,6 +560,67 @@
     color: var(--color-primary-light);
     font-style: italic;
     margin: 0;
+}
+
+/* ===================================================================
+   .panel — a titled content surface
+   ===================================================================
+   A card with a header, a title and a body. The weekly view's day cards
+   and the A-Z view's letter cards are consumers; so is the About page.
+
+   Before #166 there was no such thing, so about.html built seven of its
+   prose sections out of `.day-card` — inheriting sticky positioning, the
+   uppercase calendar display face, and a z-index, none of which a prose
+   page wants. Seven sticky headers stacked up while scrolling it, and
+   restyling the calendar silently restyled About.
+
+   The base is deliberately quiet: a surface, a header, a plain title.
+   Stickiness and the display face belong to the calendar consumers,
+   which add them below.
+   =================================================================== */
+
+.panel {
+    background: var(--bg-card);
+    border-radius: var(--border-radius);
+    display: flex;
+    flex-direction: column;
+}
+
+.panel__header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md) var(--spacing-lg);
+    background: var(--color-gray-800);
+    border-bottom: 1px solid var(--border-color);
+    border-radius: var(--border-radius) var(--border-radius) var(--border-radius-swoop) 0;
+}
+
+.panel__title {
+    margin: 0;
+}
+
+.panel__body {
+    flex: 1;
+    padding: var(--spacing-md);
+}
+
+/* --- Sticky variant: the calendar and A-Z section headers ----------- */
+
+.panel__header--sticky {
+    position: -webkit-sticky;
+    position: sticky;
+    z-index: var(--z-sticky-header);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}
+
+/* --- Display face: the oversized uppercase calendar title ----------- */
+
+.panel__title--display {
+    font-size: 1.8rem;
+    font-weight: 800;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
 }
 
 /* ===================================================================

--- a/css/layout.css
+++ b/css/layout.css
@@ -400,19 +400,12 @@ body.view--map .fab-group {
     display: none;
 }
 
-/* Responsive grid utilities */
-.grid {
-    display: grid;
-    gap: var(--spacing-md);
-}
 
-.grid-cols-1 { grid-template-columns: 1fr; }
-.grid-cols-2 { grid-template-columns: repeat(2, 1fr); }
-.grid-cols-3 { grid-template-columns: repeat(3, 1fr); }
-.grid-cols-4 { grid-template-columns: repeat(4, 1fr); }
 
-/* Responsive breakpoints */
-@media (max-width: 1200px) {
+/* Responsive breakpoints.
+   768px, not the 1200px this used to say: it tightens the main-content gutter,
+   which is a tablet-and-below concern, and 1200 is not on the scale (#166). */
+@media (max-width: 768px) {
     .main-content {
         padding: var(--spacing-md);
     }

--- a/css/submit.css
+++ b/css/submit.css
@@ -129,18 +129,13 @@
     color: var(--color-error);
 }
 
+/* Composes .input from components.css — only the form's own surface treatment
+   remains here (#166). */
 .form-group input,
 .form-group select,
 .form-group textarea {
-    padding: var(--spacing-sm) var(--spacing-md);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius-sm);
     background: var(--bg-secondary);
-    color: var(--text-primary);
-    transition: border-color var(--transition-fast);
-    font-size: 16px;             /* Prevents iOS auto-zoom on focus */
-    min-height: var(--size-icon-lg);            /* Touch target */
-    box-sizing: border-box;
+    border-radius: var(--border-radius-sm);
 }
 
 .form-group textarea {
@@ -149,13 +144,8 @@
     font-family: inherit;
 }
 
-.form-group input:focus,
-.form-group select:focus,
-.form-group textarea:focus {
-    border-color: var(--color-primary);
-    outline: 2px solid var(--color-primary);
-    outline-offset: -1px;
-}
+/* Focus is the global :focus-visible ring (base.css). This rule used to draw
+   its own inset outline, a third treatment for the same state (#166). */
 
 .form-group input[aria-invalid="true"],
 .form-group select[aria-invalid="true"],
@@ -296,14 +286,9 @@
     flex-shrink: 0;
 }
 
-.tag-badge {
-    display: inline-block;
-    padding: 4px 10px;
-    border-radius: 12px;
-    font-size: var(--font-size-sm);
-    font-weight: 600;
-    white-space: nowrap;
-}
+/* .tag-badge lived here — a second chip for the same tag data, with its own
+   radius, size and weight. Deleted in #166; the grid renders .tag from
+   js/utils/tags.js like everything else. */
 
 /* ---- Contact methods ---- */
 

--- a/css/views.css
+++ b/css/views.css
@@ -18,11 +18,9 @@
    - .day-card--empty: Collapsed, no venues match filters
    - .day-card--expanded: Past day that's been expanded
    ============================================ */
+/* Composes .panel — see components.css. Only what is specific to a calendar
+   day lives here. */
 .day-card {
-    background: var(--bg-card);
-    border-radius: var(--border-radius);
-    display: flex;
-    flex-direction: column;
     scroll-margin-top: var(--nav-height);
 }
 
@@ -102,34 +100,10 @@
     transform: rotate(180deg);
 }
 
-/* Sticky section header shared by day cards (weekly view) and letter cards (alphabetical view) */
-.day-card__header,
-.letter-card__header {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-md);
-    padding: var(--spacing-md) var(--spacing-lg);
-    border-bottom: 1px solid var(--border-color);
-    border-radius: var(--border-radius) var(--border-radius) var(--border-radius-swoop) 0;
-    position: -webkit-sticky;
-    position: sticky;
-    z-index: var(--z-sticky-header);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
+/* Both section headers compose .panel__header .panel__header--sticky; each only
+   needs the offset it sticks at, plus its own background. */
 .day-card__header {
-    background: var(--color-gray-800);
     top: var(--nav-height);
-}
-
-/* Shared title typography */
-.day-card__day,
-.letter-card__letter {
-    font-size: 1.8rem;
-    font-weight: 800;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-    margin: 0;
 }
 
 /* Rainbow colors for each day - ROYGBIV order starting Sunday.
@@ -195,11 +169,6 @@
     padding: var(--spacing-2xs) var(--spacing-sm);
     border-radius: var(--border-radius-sm);
     margin-left: auto;
-}
-
-.day-card__content {
-    flex: 1;
-    padding: var(--spacing-md);
 }
 
 .day-card__empty {
@@ -423,11 +392,8 @@
 }
 
 /* Letter Card - similar structure to Day Card */
+/* Composes .panel — see components.css. */
 .letter-card {
-    background: var(--bg-card);
-    border-radius: var(--border-radius);
-    display: flex;
-    flex-direction: column;
     scroll-margin-top: calc(var(--nav-height) + var(--az-index-height, 50px));
 }
 
@@ -445,11 +411,6 @@
     margin-left: auto;
     color: rgba(255, 255, 255, 0.8);
     font-size: var(--font-size-sm);
-}
-
-.letter-card__content {
-    flex: 1;
-    padding: var(--spacing-md);
 }
 
 .letter-card__venues {
@@ -584,27 +545,9 @@
     margin-top: var(--spacing-xs);
 }
 
-/* Map popup */
-.map-popup {
-    min-width: 200px;
-}
 
-.map-popup__name {
-    font-size: var(--font-size-base);
-    font-weight: 600;
-    margin-bottom: var(--spacing-sm);
-    color: var(--color-gray-900);
-}
 
-.map-popup__schedule {
-    font-size: var(--font-size-sm);
-    color: var(--color-gray-600);
-    margin-bottom: var(--spacing-sm);
-}
 
-.map-popup__details {
-    margin-top: var(--spacing-sm);
-}
 
 /* Custom Map Markers */
 .map-marker {
@@ -1192,7 +1135,9 @@ body.view--map .app-layout__detail {
     padding-left: calc(14ch + var(--spacing-sm));
 }
 
-@media (max-width: 600px) {
+/* 560px, not the 600px this used to say — the scale is 480/560/768/1400 and a
+   lone 600 put a phone/phablet boundary 40px away from the real one (#166). */
+@media (max-width: 560px) {
     .kj-dossier__show-event {
         padding-left: 0;
     }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -546,7 +546,7 @@ Components use Block-Element-Modifier naming:
 .venue-card__header            /* Element */
 .venue-card__name              /* Element */
 .venue-card__more-nights       /* Element */
-.venue-card--compact           /* Modifier */
+.venue-card--full              /* Modifier */
 .venue-card--special-event     /* Modifier */
 .venue-card--selected          /* Modifier */
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -1050,14 +1050,25 @@ The `<body>` carries the `page--readable` class, which constrains `.main-content
 
 ### Breakpoints
 
+The scale is **480 / 560 / 768 / 1400**, plus one `min-width: 1024px` rule for
+the map's docked venue card.
+
 | Width | Behavior |
 |-------|----------|
+| ≤480px | Schedule tables stack into label/value rows; the section header's swoop corner squares off |
 | Phone (≤560px) | Single column, modal for venue details; compact two-row navigation (~102px sticky) with collapsible search; single-row scrollable A–Z index |
-| Phablet (561–768px) | Desktop-style labeled navigation with inline search (~115–130px); single column content |
+| Phablet (561–768px) | Desktop-style labeled navigation with inline search (~115–130px); single column content; tighter main-content gutter below 768px |
 | 769px+ | Venue cards flow into a multi-column grid (`auto-fill, minmax(320px, 1fr)`) inside day/letter cards; labeled nav buttons |
-| 1024px+ | More grid columns as space allows |
-| 1200px+ | Side-by-side layouts where applicable |
+| 1024px+ | The map's expanded venue card docks right at a fixed 350px instead of a bottom sheet |
 | 1400px+ | Desktop venue detail pane visible alongside main content; mobile modal suppressed |
+
+> **Corrected in #166.** This table used to list a `1200px+` row ("side-by-side
+> layouts where applicable") and describe `1024px+` as "more grid columns as
+> space allows" — neither matched the stylesheets. There was one 1200px query,
+> tightening the main-content gutter, which is a tablet concern and now sits at
+> 768px; and one stray 600px query, now 560px. `bingo.html` keeps its own
+> game-specific scale (400/599/600 and a landscape max-height rule), which is
+> deliberate and out of this table.
 
 ### Mobile-Specific Behaviors
 

--- a/docs/patterns.md
+++ b/docs/patterns.md
@@ -693,7 +693,7 @@ socials.threads = document.getElementById('social-threads').value.trim() || unde
 |------|-----------|---------|
 | **Block** | Lowercase, hyphen-separated noun | `.venue-card`, `.day-card` |
 | **Element** | Block + `__` + element name | `.venue-card__header` |
-| **Modifier** | Block + `--` + modifier name | `.venue-card--compact` |
+| **Modifier** | Block + `--` + modifier name | `.venue-card--full` |
 
 ### Gotchas
 

--- a/js/bingo.js
+++ b/js/bingo.js
@@ -393,13 +393,10 @@ function createSingleFirework(x, y) {
         const endX = Math.cos(angle) * velocity;
         const endY = Math.sin(angle) * velocity;
 
-        // Set custom end position via CSS variable
-        particle.style.setProperty('--end-x', `${endX}px`);
-        particle.style.setProperty('--end-y', `${endY}px`);
-        particle.style.animation = `fireworkExplode 1s ease-out forwards`;
-        particle.style.setProperty('transform', `translate(0, 0)`);
-
-        // Override the animation with inline keyframes
+        // The motion is a Web Animations API call, not CSS. A
+        // `fireworkExplode` CSS animation used to be assigned here first, along
+        // with --end-x/--end-y custom properties, and then overridden on the
+        // very next line — the keyframe never rendered (#166).
         particle.animate([
             { transform: 'translate(0, 0) scale(1)', opacity: 1 },
             { transform: `translate(${endX}px, ${endY}px) scale(0.3)`, opacity: 0 }

--- a/js/components/DayCard.js
+++ b/js/components/DayCard.js
@@ -60,9 +60,9 @@ export class DayCard extends Component {
         const emptyClass = events.length === 0 ? 'day-card--empty' : '';
 
         return `
-            <article class="day-card day-card--${dayOfWeek} ${todayClass} ${pastClass} ${emptyClass}">
-                <header class="day-card__header">
-                    <h2 class="day-card__day">${dayName}</h2>
+            <article class="panel day-card day-card--${dayOfWeek} ${todayClass} ${pastClass} ${emptyClass}">
+                <header class="panel__header panel__header--sticky day-card__header">
+                    <h2 class="panel__title panel__title--display day-card__day">${dayName}</h2>
                     <span class="day-card__date">${dateStr}</span>
                     ${isToday(date) ? '<span class="day-card__today-badge">Today</span>' : ''}
                     <span class="day-card__expand-indicator">
@@ -70,7 +70,7 @@ export class DayCard extends Component {
                     </span>
                 </header>
 
-                <div class="day-card__content">
+                <div class="panel__body day-card__content">
                     ${events.length > 0
                         ? this.renderEvents(events, date)
                         : '<p class="day-card__empty">No karaoke scheduled</p>'

--- a/js/components/VenueCard.js
+++ b/js/components/VenueCard.js
@@ -60,7 +60,11 @@ export class VenueCard extends Component {
         const isSpecialEvent = schedule?.frequency === 'once';
         // Excluded: a recurring entry suppressed on this specific date (e.g. holiday, private event)
         const exclusion = (schedule && date) ? getScheduleExclusion(schedule, date) : null;
-        const classes = ['venue-card', 'venue-card--compact'];
+        // No `venue-card--compact` modifier: the compact card IS the base
+        // `.venue-card`, and the modifier carried no rules — it was emitted on
+        // every card in the calendar and styled nothing (#166). `--full` is the
+        // variant that genuinely differs.
+        const classes = ['venue-card'];
         if (isSpecialEvent) classes.push('venue-card--special-event');
         if (exclusion) classes.push('venue-card--excluded');
         const cardClass = classes.join(' ');

--- a/js/utils/tags.js
+++ b/js/utils/tags.js
@@ -9,12 +9,81 @@ import { html } from './string.js';
 // Tag configuration - initialized from js/data.json
 let tagConfig = {};
 
+const STYLE_ELEMENT_ID = 'tag-colors';
+
+/** Only ids a CSS attribute selector can safely carry. */
+const SAFE_TAG_ID = /^[a-zA-Z0-9_+-]+$/;
+/** Colours are curator-written; accept the forms CSS actually takes. */
+const SAFE_COLOR = /^(#[0-9a-fA-F]{3,8}|[a-zA-Z]+|rgba?\([\d\s.,%]+\)|hsla?\([\d\s.,%]+\))$/;
+
 /**
- * Initialize tag configuration from data
+ * Build one stylesheet for every tag colour, keyed on `[data-tag]`.
+ *
+ * Tag colours live in data.json, so they cannot be written into a stylesheet
+ * ahead of time — which is why both call sites used to emit an inline
+ * `style="background:…"`. One generated sheet replaces both (#166), and keeps
+ * the colours out of the markup where a CSP would object to them.
+ *
+ * Values are validated rather than escaped: anything that is not a plain id or
+ * a recognisable colour is skipped, because a stylesheet has no equivalent of
+ * HTML escaping — a stray `}` would end the rule and start a new one.
+ *
+ * @param {Object} definitions
+ * @returns {string} CSS text
+ */
+export function buildTagStyles(definitions) {
+    return Object.entries(definitions || {})
+        .filter(([id, def]) =>
+            SAFE_TAG_ID.test(id) && def && SAFE_COLOR.test(String(def.color || '')) &&
+            SAFE_COLOR.test(String(def.textColor || ''))
+        )
+        .map(([id, def]) =>
+            `.tag[data-tag="${id}"]{background:${def.color};color:${def.textColor}}`
+        )
+        .join('\n');
+}
+
+/**
+ * Initialize tag configuration from data, and paint the tag colours.
  * @param {Object} definitions - Tag definitions from the data file's tagDefinitions
  */
 export function initTagConfig(definitions) {
     tagConfig = definitions || {};
+
+    if (typeof document === 'undefined') return;   // unit tests, build scripts
+    let el = document.getElementById(STYLE_ELEMENT_ID);
+    if (!el) {
+        el = document.createElement('style');
+        el.id = STYLE_ELEMENT_ID;
+        document.head.appendChild(el);
+    }
+    el.textContent = buildTagStyles(tagConfig);
+}
+
+/**
+ * Render one tag chip.
+ *
+ * The single tag renderer, used by the directory and by submit.html — they
+ * previously built the same chip two different ways, under two class names,
+ * each with its own inline style.
+ *
+ * Pass `href` to get an anchor instead of a span. **Nothing links today**;
+ * the parameter exists so that wiring a destination later (a `?tag=` view,
+ * per ADR-011) does not mean introducing a third chip that every call site
+ * would have to be rewritten to use.
+ *
+ * @param {string} tagId
+ * @param {Object} [options]
+ * @param {string} [options.href] - When set, renders `<a class="tag">`
+ * @returns {string} HTML string, or '' when the tag has no definition
+ */
+export function renderTagBadge(tagId, { href } = {}) {
+    const config = tagConfig[tagId];
+    if (!config) return '';
+
+    return href
+        ? String(html`<a class="tag" data-tag="${tagId}" href="${href}">${config.label}</a>`)
+        : String(html`<span class="tag" data-tag="${tagId}">${config.label}</span>`);
 }
 
 /**
@@ -32,15 +101,7 @@ export function renderTags(tags, options = {}) {
 
     if (allTags.length === 0) return '';
 
-    // The `html` tag escapes every interpolation, including the colours and the
-    // label — all three come from data.json's tagDefinitions, which the curator
-    // writes, and the colours land inside a style attribute (#160).
-    const badges = allTags.map(tag => {
-        const config = tagConfig[tag];
-        if (!config) return '';
-
-        return String(html`<span class="venue-tag" style="background-color: ${config.color}; color: ${config.textColor};">${config.label}</span>`);
-    }).filter(Boolean).join('');
+    const badges = allTags.map(tag => renderTagBadge(tag)).filter(Boolean).join('');
 
     return badges ? `<div class="venue-tags">${badges}</div>` : '';
 }

--- a/js/views/AlphabeticalView.js
+++ b/js/views/AlphabeticalView.js
@@ -48,12 +48,12 @@ export class AlphabeticalView extends Component {
 
                 <div class="alphabetical-view__list">
                     ${Object.entries(groups).map(([letter, letterVenues]) => `
-                        <article class="letter-card" id="venues-${letter}">
-                            <header class="letter-card__header">
-                                <h2 class="letter-card__letter">${letter}</h2>
+                        <article class="panel letter-card" id="venues-${letter}">
+                            <header class="panel__header panel__header--sticky letter-card__header">
+                                <h2 class="panel__title panel__title--display letter-card__letter">${letter}</h2>
                                 <span class="letter-card__count">${letterVenues.length} venue${letterVenues.length !== 1 ? 's' : ''}</span>
                             </header>
-                            <div class="letter-card__content">
+                            <div class="panel__body letter-card__content">
                                 <ul class="letter-card__venues">
                                     ${letterVenues.map(venue => `
                                         <li class="letter-card__venue-item">

--- a/submit.html
+++ b/submit.html
@@ -452,17 +452,19 @@
                 return;
             }
 
-            grid.innerHTML = getUserSelectableTagIds().map(id => {
-                const def = tagDefinitions[id];
-                const safeLabel = def.label
-                    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-                return `
+            // Chips come from the directory's own renderer, so this form and the
+            // venue cards cannot drift apart again (#166). A dynamic import works
+            // from this classic script; #168 converts the whole file to a module.
+            // initTagConfig also injects the [data-tag] colour stylesheet, which
+            // is what replaced the inline style= that used to be on each badge.
+            const { initTagConfig, renderTagBadge } = await import('./js/utils/tags.js');
+            initTagConfig(tagDefinitions);
+
+            grid.innerHTML = getUserSelectableTagIds().map(id => `
                     <label class="tag-checkbox-option">
                         <input type="checkbox" name="tag-${id}" value="${id}">
-                        <span class="tag-badge" data-tag="${id}"
-                              style="background:${def.color};color:${def.textColor}">${safeLabel}</span>
-                    </label>`;
-            }).join('');
+                        ${renderTagBadge(id)}
+                    </label>`).join('');
         })();
 
         // Rate limiting configuration


### PR DESCRIPTION
Closes #166. Unblocked by #165.

## `.panel`

There was no generic content panel, so `about.html` built seven prose sections out of `.day-card` — inheriting sticky positioning, a z-index, and the uppercase calendar display face. Seven sticky headers stacked while scrolling a prose page, and editing the weekly calendar silently restyled About.

The base is deliberately quiet — a surface, a header, a plain title. Stickiness (`.panel__header--sticky`) and the display face (`.panel__title--display`) are opt-in, and only the calendar consumers opt in.

| | Before | After |
|---|---|---|
| About: sticky headers | **7** | **0** |
| About: heading | 28.8px uppercase, letter-spaced | ordinary h2, 24px sentence case |
| Weekly / A–Z | — | unchanged: same surface, sticky offset, z-index, 28.8px face |

The About change is real and visible — that's the ticket's intent, not a side effect.

Also removed the duplicate `padding: var(--spacing-md)` from `.day-card__content` and `.letter-card__content`; `.panel__body` owns it at the same value.

## `.tag`

The same tag data rendered as two chips with two radii and two inline `style=` call sites. One `.tag` now, one `renderTagBadge(tagId)` used by both the directory and the submit form.

**Ending the inline styles needed somewhere for data-driven colours to live.** `initTagConfig()` injects one stylesheet keyed on `[data-tag]`. Its values are *validated rather than escaped* — a stylesheet has no equivalent of HTML escaping, and a stray `}` would close the rule and open another, so anything that isn't a plain id or a recognisable colour is skipped.

submit.html reaches the shared renderer through a dynamic `import()`, which works from its classic script. #168 converts that file wholesale; this doesn't pre-empt it.

```
directory:  415 tags, 0 inline styles   (was 415 inline)
submit:      13 tags, 0 inline styles
colours identical on both
```

The form's chips take the directory's 4px radius in place of their old 12px. That *is* the unification, and it's visible.

`renderTagBadge` takes an optional `href` and emits `<a class="tag">` when given one, with hover/focus on `.tag` either way. **Nothing is linked today** — it exists so a future `?tag=` destination ([ADR-011](docs/adr/011-entity-link-contract.md)) is a parameter rather than a third chip.

## `.input`

Four text fields, four focus treatments — one keyed to `rgba(139,92,246,.2)`, a violet in no token, applied *after* `outline: none`. That combination removed the focus ring and replaced it with an off-palette glow.

One `.input` now, sharing the global `:focus-visible` ring from base.css.

Two honest notes:

- The consumers are **named in the selector list** rather than each carrying `class="input"`. submit.html's schedule rows are generated in JS and would need the class threaded through there too; the AC's point — one definition of the field surface — holds either way, and #168 can add the class when it converts that file.
- The shared size is **16px**, which the submit form already used deliberately (iOS auto-zooms a focused input smaller than that). The search field was 14px and now isn't. Small visible change, real benefit.

## Orphans removed — each verified unreferenced first

| Removed | Evidence |
|---|---|
| `.map-popup*` | 4 rules, no markup anywhere |
| `.grid` / `.grid-cols-1..4` | 5 rules, no markup |
| `--color-gray-50`, `--color-gray-100` | defined, never read |
| `--color-secondary-dark` | defined, never read |
| `@keyframes fireworkExplode` | see below |
| `.venue-card--compact` | see below |

**`fireworkExplode` is the interesting one.** `bingo.js` assigned it and then replaced it with a Web Animations call on the very next line — its own comment read *"Override the animation with inline keyframes"*. The CSS keyframe never rendered a frame. The assignment and the write-only `--end-x`/`--end-y` custom properties went with it.

**`.venue-card--compact`** was emitted on every card in the calendar and styled nothing. Dropped rather than given rules: the compact card *is* the base `.venue-card`, and `--full` is the variant that genuinely differs. The two doc examples repoint to `--full`, which exists.

## Breakpoints

Spec §19 listed a `1200px+` row ("side-by-side layouts where applicable") and described `1024px+` as "more grid columns as space allows". Neither matched the stylesheets.

- The one 1200px query tightened the main-content gutter — a tablet concern → **768px**
- A stray 600px query → **560px**
- `1024px` survives as exactly one rule: the map's docked venue card

The scale is **480 / 560 / 768 / 1400**, and §19 and CLAUDE.md now say that. `bingo.html` keeps its own game-specific scale (400/599/600 plus a landscape max-height rule), called out as deliberate rather than quietly folded in.

| Gate | Result |
|---|---|
| `npm run test:unit` | **136 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean, incl. the contrast gate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
