### PR TITLE
#162: Extract js/chrome.js — one header and footer for five pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -38,12 +38,7 @@
 <body class="page--readable">
     <!-- Note: Not using page--edge-to-edge as this is a content page, not the main app -->
     <!-- page--readable constrains the content column to a comfortable reading measure (see layout.css) -->
-    <header class="site-header">
-        <div class="site-header__content">
-            <h1 class="site-header__title">Greater Austin Karaoke Directory</h1>
-            <p class="site-header__tagline">NOTE HOLIDAY MAY CHANGE AVAILABILITY, CALL VENUE FIRST</p>
-        </div>
-    </header>
+    <div data-site-header></div>
 
     <nav class="navigation-container">
         <div class="navigation">
@@ -55,6 +50,13 @@
     </nav>
 
     <main class="main-content">
+        <!-- A time-sensitive page notice. This text used to sit in the header's
+             brand-tagline slot, where the tagline belongs (#162). -->
+        <p class="notice">
+            <i class="fa-solid fa-triangle-exclamation"></i>
+            Holidays may change availability — call the venue first.
+        </p>
+
         <article class="panel">
             <header class="panel__header">
                 <h2 class="panel__title">About Us</h2>
@@ -153,29 +155,11 @@
         </article>
     </main>
 
-    <footer class="site-footer">
-        <div class="site-footer__social">
-            <h2>Follow Us</h2>
-            <div class="social-links">
-                <a href="https://www.facebook.com/groups/2494105004273043"
-                   target="_blank" rel="noopener noreferrer" title="Facebook">
-                    <i class="fa-brands fa-facebook fa-lg"></i>
-                </a>
-                <a href="https://www.instagram.com/karaokedirectory/"
-                   target="_blank" rel="noopener noreferrer" title="Instagram">
-                    <i class="fa-brands fa-instagram fa-lg"></i>
-                </a>
-            </div>
-        </div>
-        <div class="site-footer__links">
-            <a href="about.html">About Us</a>
-            <a href="submit.html">Submit Venue</a>
-            <a href="docs/index.html">Documentation</a>
-        </div>
-        <p class="site-footer__copyright">
-            &copy; 2025 Austin Karaoke Directory
-        </p>
-    </footer>
+    <div data-site-footer></div>
     <script src="js/analytics.js" defer></script>
+    <script type="module">
+        import { renderSiteChrome } from './js/chrome.js';
+        renderSiteChrome();
+    </script>
 </body>
 </html>

--- a/bday.html
+++ b/bday.html
@@ -485,14 +485,7 @@
 <body>
     <div class="bday-confetti" id="bday-confetti" aria-hidden="true"></div>
 
-    <header class="site-header site-header--compact">
-        <div class="site-header__content">
-            <h1 class="site-header__title">
-                <i class="fa-solid fa-cake-candles"></i> You're Invited
-            </h1>
-            <p class="site-header__tagline">A karaoke directory birthday special</p>
-        </div>
-    </header>
+    <div data-site-header></div>
 
     <nav class="navigation-container">
         <div class="navigation">
@@ -630,28 +623,7 @@
         </section>
     </main>
 
-    <footer class="site-footer">
-        <div class="site-footer__social">
-            <h2>Follow Us</h2>
-            <div class="social-links">
-                <a href="https://www.facebook.com/groups/2494105004273043"
-                   target="_blank" rel="noopener noreferrer" title="Facebook">
-                    <i class="fa-brands fa-facebook fa-lg"></i>
-                </a>
-                <a href="https://www.instagram.com/karaokedirectory/"
-                   target="_blank" rel="noopener noreferrer" title="Instagram">
-                    <i class="fa-brands fa-instagram fa-lg"></i>
-                </a>
-            </div>
-        </div>
-        <div class="site-footer__links">
-            <a href="about.html">About Us</a>
-            <a href="submit.html">Submit Venue</a>
-        </div>
-        <p class="site-footer__copyright">
-            &copy; 2026 Austin Karaoke Directory
-        </p>
-    </footer>
+    <div data-site-footer></div>
 
     <script>
         // Subtle confetti ribbon across the top of the page.
@@ -670,5 +642,9 @@
         });
     </script>
     <script src="js/analytics.js" defer></script>
+    <script type="module">
+        import { renderSiteChrome } from './js/chrome.js';
+        renderSiteChrome({ title: "You're Invited", tagline: 'A karaoke directory birthday special', compact: true, icon: 'fa-solid fa-cake-candles' });
+    </script>
 </body>
 </html>

--- a/bingo.html
+++ b/bingo.html
@@ -38,12 +38,7 @@
     <link rel="stylesheet" href="css/bingo.css">
 </head>
 <body>
-    <header class="site-header site-header--compact">
-        <div class="site-header__content">
-            <h1 class="site-header__title"><i class="fa-solid fa-dice"></i> Karaoke Bingo</h1>
-            <p class="site-header__tagline">Mark off what you see at karaoke night!</p>
-        </div>
-    </header>
+    <div data-site-header></div>
 
     <nav class="navigation-container">
         <div class="navigation">
@@ -65,30 +60,13 @@
         </div>
     </main>
 
-    <footer class="site-footer">
-        <div class="site-footer__social">
-            <h2>Follow Us</h2>
-            <div class="social-links">
-                <a href="https://www.facebook.com/groups/2494105004273043"
-                   target="_blank" rel="noopener noreferrer" title="Facebook">
-                    <i class="fa-brands fa-facebook fa-lg"></i>
-                </a>
-                <a href="https://www.instagram.com/karaokedirectory/"
-                   target="_blank" rel="noopener noreferrer" title="Instagram">
-                    <i class="fa-brands fa-instagram fa-lg"></i>
-                </a>
-            </div>
-        </div>
-        <div class="site-footer__links">
-            <a href="about.html">About Us</a>
-            <a href="submit.html">Submit Venue</a>
-        </div>
-        <p class="site-footer__copyright">
-            &copy; 2025 Austin Karaoke Directory
-        </p>
-    </footer>
+    <div data-site-footer></div>
 
     <script src="js/bingo.js"></script>
     <script src="js/analytics.js" defer></script>
+    <script type="module">
+        import { renderSiteChrome } from './js/chrome.js';
+        renderSiteChrome({ title: 'Karaoke Bingo', tagline: 'Mark off what you see at karaoke night!', compact: true, icon: 'fa-solid fa-dice' });
+    </script>
 </body>
 </html>

--- a/css/bingo.css
+++ b/css/bingo.css
@@ -20,10 +20,8 @@
     -webkit-tap-highlight-color: transparent;
 }
 
-/* Compact header for bingo page */
-.site-header--compact {
-    padding: var(--spacing-md);
-}
+/* .site-header--compact moved to layout.css in #162 — bday.html uses it too
+   and never loads this file, so it was styled on one of its two consumers. */
 
 /* Main bingo area */
 .bingo-main {

--- a/css/layout.css
+++ b/css/layout.css
@@ -23,6 +23,31 @@
     margin: 0;
 }
 
+/* Compact header — bingo and bday. Lived in bingo.css, which bday.html does
+   not load, so one of its two consumers went unstyled (#162). */
+.site-header--compact {
+    padding: var(--spacing-md);
+}
+
+/* Page-level notice. about.html used to put this text in the header's
+   brand-tagline slot; a notice is content, not branding (#162). */
+.notice {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: var(--bg-card);
+    border-left: 4px solid var(--color-warning);
+    border-radius: 0;
+    color: var(--text-primary);
+    font-size: var(--font-size-sm);
+}
+
+.notice i {
+    color: var(--color-warning);
+}
+
 /* Karaoke Video Background */
 .karaoke-video-bg {
     position: absolute;

--- a/index.html
+++ b/index.html
@@ -132,31 +132,7 @@
                  overflow the body and create a second outer scrollbar. Below
                  1400px the list is plain block flow, so the footer still sits at
                  the bottom of the page exactly as before. -->
-            <footer class="site-footer">
-                <div class="site-footer__social">
-                    <h2>Follow Us</h2>
-                    <div class="social-links">
-                        <a href="https://www.facebook.com/groups/2494105004273043"
-                           target="_blank" rel="noopener noreferrer" title="Facebook">
-                            <i class="fa-brands fa-facebook fa-lg"></i>
-                        </a>
-                        <a href="https://www.instagram.com/karaokedirectory/"
-                           target="_blank" rel="noopener noreferrer" title="Instagram">
-                            <i class="fa-brands fa-instagram fa-lg"></i>
-                        </a>
-                    </div>
-                </div>
-
-                <div class="site-footer__links">
-                    <a href="about.html">About Us</a>
-                    <a href="submit.html">Submit Venue</a>
-                    <a href="docs/index.html">Documentation</a>
-                </div>
-
-                <p class="site-footer__copyright">
-                    &copy; 2025 Austin Karaoke Directory
-                </p>
-            </footer>
+            <div data-site-footer></div>
         </div>
 
         <!-- Desktop venue detail pane (>=1400px). Hidden on mobile; replaced by venue-modal. -->
@@ -252,5 +228,11 @@
         })();
     </script>
     <script src="js/analytics.js" defer></script>
+    <script type="module">
+        // index.html keeps its own video-background header; only the footer
+        // is shared (#162).
+        import { renderSiteFooter } from './js/chrome.js';
+        renderSiteFooter();
+    </script>
 </body>
 </html>

--- a/js/chrome.js
+++ b/js/chrome.js
@@ -1,0 +1,126 @@
+/**
+ * Site chrome — one header and one footer for every page.
+ *
+ * The header and footer were hand-copied into five HTML files, and had drifted
+ * four separate ways by the time #162 collected them:
+ *
+ *   - the Documentation footer link existed on two pages of five
+ *   - the copyright read 2025 on four pages and 2026 on the fifth
+ *   - about.html had a shouty holiday warning sitting in the brand-tagline slot,
+ *     where the tagline belongs
+ *   - index.html mounted its nav from JS while the other four hand-wrote the
+ *     same anchor markup
+ *
+ * None of that is a bug a test would catch; it is what copied markup does. The
+ * renderers below write into `[data-site-header]` and `[data-site-footer]`, so
+ * a page declares the mount point and its own title, and everything shared
+ * comes from here.
+ *
+ * The year is `getFullYear()`. A hardcoded year is wrong on 1 January and stays
+ * wrong until somebody notices — which is exactly what happened.
+ */
+
+import { escapeHtml } from './utils/string.js';
+
+/** Footer link set. One list, so a new link cannot land on some pages only. */
+const FOOTER_LINKS = [
+    { href: 'about.html', label: 'About Us' },
+    { href: 'submit.html', label: 'Submit Venue' },
+    { href: 'docs/index.html', label: 'Documentation' },
+];
+
+const SOCIAL_LINKS = [
+    {
+        href: 'https://www.facebook.com/groups/2494105004273043',
+        title: 'Facebook',
+        icon: 'fa-brands fa-facebook fa-lg',
+    },
+    {
+        href: 'https://www.instagram.com/karaokedirectory/',
+        title: 'Instagram',
+        icon: 'fa-brands fa-instagram fa-lg',
+    },
+];
+
+const SITE_NAME = 'Austin Karaoke Directory';
+
+/**
+ * Render the site header into `[data-site-header]`.
+ *
+ * index.html does NOT use this — it has a video-background header of its own.
+ * It shares the footer renderer, which is where the drift actually was.
+ *
+ * @param {Object} [options]
+ * @param {string} [options.title] - Brand line
+ * @param {string} [options.tagline] - The line under it. A page-level notice is
+ *   NOT a tagline; put that in a `.notice` in <main> (see about.html).
+ * @param {boolean} [options.compact=false] - Tighter padding (bingo, bday)
+ * @param {string} [options.icon] - Font Awesome classes for a leading icon
+ * @returns {HTMLElement|null} the mount, or null when the page has none
+ */
+export function renderSiteHeader({
+    title = 'Greater Austin Karaoke Directory',
+    tagline = '',
+    compact = false,
+    icon = '',
+} = {}) {
+    const mount = document.querySelector('[data-site-header]');
+    if (!mount) return null;
+
+    const iconHtml = icon ? `<i class="${escapeHtml(icon)}"></i> ` : '';
+
+    mount.innerHTML = `
+        <header class="site-header${compact ? ' site-header--compact' : ''}">
+            <div class="site-header__content">
+                <h1 class="site-header__title">${iconHtml}${escapeHtml(title)}</h1>
+                ${tagline ? `<p class="site-header__tagline">${escapeHtml(tagline)}</p>` : ''}
+            </div>
+        </header>
+    `;
+    return mount;
+}
+
+/**
+ * Render the site footer into `[data-site-footer]`.
+ * @returns {HTMLElement|null} the mount, or null when the page has none
+ */
+export function renderSiteFooter() {
+    const mount = document.querySelector('[data-site-footer]');
+    if (!mount) return null;
+
+    const socials = SOCIAL_LINKS.map(s => `
+                        <a href="${s.href}" target="_blank" rel="noopener noreferrer" title="${s.title}">
+                            <i class="${s.icon}"></i>
+                        </a>`).join('');
+
+    const links = FOOTER_LINKS.map(l =>
+        `<a href="${l.href}">${escapeHtml(l.label)}</a>`).join('\n                    ');
+
+    mount.innerHTML = `
+        <footer class="site-footer">
+            <div class="site-footer__social">
+                <h2>Follow Us</h2>
+                <div class="social-links">${socials}
+                </div>
+            </div>
+
+            <div class="site-footer__links">
+                    ${links}
+            </div>
+
+            <p class="site-footer__copyright">
+                &copy; ${new Date().getFullYear()} ${escapeHtml(SITE_NAME)}
+            </p>
+        </footer>
+    `;
+    return mount;
+}
+
+/**
+ * Render both, for the pages that want the standard header.
+ * @param {Object} [headerOptions] - Passed to renderSiteHeader
+ */
+export function renderSiteChrome(headerOptions) {
+    renderSiteHeader(headerOptions);
+    renderSiteFooter();
+}

--- a/scripts/check-css-load-order.js
+++ b/scripts/check-css-load-order.js
@@ -67,23 +67,139 @@ function checkPage(file) {
     return { file, order, errors };
 }
 
+/* -------------------------------------------------------- reachability ----
+ *
+ * Loading the right files in the right order is not enough: a page can use a
+ * class that is only defined in a stylesheet it never loads, and nothing goes
+ * red. `.site-header--compact` did exactly that — it lived in bingo.css, and
+ * bday.html used it without loading that file, so one of its two consumers
+ * was unstyled (#162).
+ */
+
+/** Every class selector a stylesheet defines. */
+function classesDefinedIn(cssFile) {
+    const css = fs.readFileSync(path.join(ROOT, 'css', cssFile), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '');          // strip comments
+    const defined = new Set();
+    // selector text is everything before each `{` that is not an at-rule body
+    for (const m of css.matchAll(/([^{}]+)\{/g)) {
+        const sel = m[1].trim();
+        if (sel.startsWith('@')) continue;
+        for (const c of sel.matchAll(/\.([A-Za-z0-9_-]+)/g)) defined.add(c[1]);
+    }
+    return defined;
+}
+
+/**
+ * Every class a page's markup uses, from static `class="..."` attributes.
+ *
+ * Comments are stripped first, same as extractCssOrder does — index.html keeps
+ * the seasonal snowfall markup commented out alongside its commented-out
+ * <link>, and counting it would report a stylesheet the page deliberately
+ * does not load.
+ */
+function classesUsedIn(html) {
+    const used = new Set();
+    const stripped = html.replace(/<!--[\s\S]*?-->/g, '');
+    for (const m of stripped.matchAll(/\sclass="([^"]*)"/g)) {
+        for (const c of m[1].split(/\s+/)) {
+            if (!c || c.includes('${')) continue;    // skip template placeholders
+            used.add(c);
+        }
+    }
+    return used;
+}
+
+const ALL_CSS = fs.readdirSync(path.join(ROOT, 'css')).filter(f => f.endsWith('.css'));
+const DEFINED = new Map(ALL_CSS.map(f => [f, classesDefinedIn(f)]));
+
+/**
+ * Class names emitted by the first-party modules a page imports, one level deep.
+ *
+ * Static markup alone is not enough any more, and #162 is why: it moved the
+ * header and footer out of five HTML files and into js/chrome.js, so the very
+ * classes that motivated this check (`.site-header--compact`) stopped appearing
+ * in any `class="..."` attribute. A check that could not see them would have
+ * passed the exact bug it was written for.
+ *
+ * One level, first-party only. Classes rendered deeper in the module graph —
+ * most of index.html — are out of scope; this is a drift guard for page
+ * chrome, not a whole-app reachability prover.
+ */
+function classesFromImportedModules(html) {
+    const used = new Set();
+    const specs = new Set();
+
+    for (const m of html.matchAll(/<script[^>]*type="module"[^>]*>([\s\S]*?)<\/script>/g)) {
+        for (const im of m[1].matchAll(/from\s+['"]\.?\/?(js\/[^'"]+)['"]/g)) specs.add(im[1]);
+    }
+    for (const m of html.matchAll(/<script[^>]*\ssrc="(js\/[^"]+)"/g)) specs.add(m[1]);
+
+    for (const spec of specs) {
+        const p = path.join(ROOT, spec);
+        if (!fs.existsSync(p)) continue;
+        const src = fs.readFileSync(p, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '');
+
+        // Over-collect: every whitespace-separated token that could be a class
+        // name, from anywhere in the file. A class attribute in a template
+        // literal is routinely interpolated —
+        //   class="site-header${compact ? ' site-header--compact' : ''}"
+        // — so the name that matters sits inside the expression, not in the
+        // literal part of the attribute. Matching the attribute alone misses it.
+        //
+        // Restricted to hyphenated tokens. Collecting every identifier turned up
+        // `hidden`, `error` and `back` from app.js — ordinary words that happen
+        // to be class names in a stylesheet index.html does not load. A hyphen
+        // is what separates a BEM class from English, and every chrome class
+        // this guards has one.
+        for (const m of src.matchAll(/[A-Za-z][A-Za-z0-9_]*(?:-{1,2}[A-Za-z0-9_]+)+/g)) {
+            used.add(m[0]);
+        }
+    }
+    return used;
+}
+
+function checkReachability(file, order) {
+    const html = fs.readFileSync(path.join(ROOT, file), 'utf8');
+    const used = new Set([...classesUsedIn(html), ...classesFromImportedModules(html)]);
+    const loaded = new Set(order);
+
+    const reachable = new Set();
+    for (const f of order) for (const c of DEFINED.get(f) || []) reachable.add(c);
+
+    const errors = [];
+    for (const cls of used) {
+        if (reachable.has(cls)) continue;
+        // Where else is it defined? Only report if some stylesheet has it —
+        // otherwise it is a utility/JS-only hook, not a load-order problem.
+        const elsewhere = ALL_CSS.filter(f => !loaded.has(f) && DEFINED.get(f).has(cls));
+        if (elsewhere.length) {
+            errors.push(`uses .${cls}, defined only in ${elsewhere.join(', ')} which it does not load`);
+        }
+    }
+    return errors;
+}
+
 const pages = fs.readdirSync(ROOT)
     .filter(f => f.endsWith('.html') && !f.startsWith('_'));
 
 let failed = false;
 for (const page of pages) {
     const { order, errors } = checkPage(page);
-    if (errors.length > 0) {
+    const reachErrors = checkReachability(page, order);
+    const all = [...errors, ...reachErrors];
+    if (all.length > 0) {
         failed = true;
         console.log(`FAIL ${page}`);
         console.log(`     loaded: ${order.join(' -> ')}`);
-        for (const err of errors) console.log(`     - ${err}`);
+        for (const err of all) console.log(`     - ${err}`);
     } else {
         console.log(`OK   ${page}  (${order.join(' -> ')})`);
     }
 }
 
 if (failed) {
-    console.log('\nSome pages violate the canonical CSS load order. See CLAUDE.md "CSS Loading Order".');
+    console.log('\nSome pages violate the canonical CSS load order or use unreachable classes.');
+    console.log('See CLAUDE.md "CSS Loading Order".');
     process.exit(1);
 }

--- a/submit.html
+++ b/submit.html
@@ -37,12 +37,7 @@
     <link rel="stylesheet" href="css/submit.css">
 </head>
 <body>
-    <header class="site-header">
-        <div class="site-header__content">
-            <h1 class="site-header__title">Greater Austin Karaoke Directory</h1>
-            <p class="site-header__tagline">Submit a New Venue</p>
-        </div>
-    </header>
+    <div data-site-header></div>
 
     <nav class="navigation-container">
         <div class="navigation">
@@ -358,28 +353,7 @@
         </div>
     </main>
 
-    <footer class="site-footer">
-        <div class="site-footer__social">
-            <h2>Follow Us</h2>
-            <div class="social-links">
-                <a href="https://www.facebook.com/groups/2494105004273043"
-                   target="_blank" rel="noopener noreferrer" title="Facebook">
-                    <i class="fa-brands fa-facebook fa-lg"></i>
-                </a>
-                <a href="https://www.instagram.com/karaokedirectory/"
-                   target="_blank" rel="noopener noreferrer" title="Instagram">
-                    <i class="fa-brands fa-instagram fa-lg"></i>
-                </a>
-            </div>
-        </div>
-        <div class="site-footer__links">
-            <a href="about.html">About Us</a>
-            <a href="submit.html">Submit Venue</a>
-        </div>
-        <p class="site-footer__copyright">
-            &copy; 2025 Austin Karaoke Directory
-        </p>
-    </footer>
+    <div data-site-footer></div>
 
     <script>
         // Tag ids that are *not* user-selectable as checkboxes:
@@ -1188,5 +1162,9 @@
         });
     </script>
     <script src="js/analytics.js" defer></script>
+    <script type="module">
+        import { renderSiteChrome } from './js/chrome.js';
+        renderSiteChrome({ tagline: 'Submit a New Venue' });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
Closes #162.

## The drift, confirmed before touching anything

| Claim | Measured |
|---|---|
| Documentation footer link on two pages | ✔ index + about only, of five |
| Copyright year says 2025 on four, 2026 on one | ✔ bday is the odd one |
| about.html puts a holiday warning in the tagline slot | ✔ `NOTE HOLIDAY MAY CHANGE AVAILABILITY, CALL VENUE FIRST` |
| index mounts nav from JS, others hand-write it | ✔ |

## The extraction

`js/chrome.js` renders into `[data-site-header]` / `[data-site-footer]`, with one `FOOTER_LINKS` list and the year from `getFullYear()`.

**Every page now reads 2026.** That's the point of the change, not a side effect: a hardcoded year is wrong from 1 January and stays wrong until someone notices — which is exactly what happened here.

`index.html` keeps its video-background header and takes only the footer, which is where the drift actually was.

`about.html`'s warning becomes a `.notice` in `<main>`. `.site-header--compact` moves from `bingo.css` to `layout.css` — `bday.html` uses it and never loads `bingo.css`, so one of its two consumers was unstyled.

## The new reachability check took three passes

This is the part worth reading. `check-css-load-order.js` now fails when a page uses a class defined only in a stylesheet it doesn't load. Getting there was not clean:

**Pass 1 — static markup only.** Reported `.snowflakes` on index.html. False positive: that markup is commented out, alongside its commented-out `<link>`. Fixed by stripping HTML comments — which `extractCssOrder` already did, for this exact reason.

**Pass 2 — it passed the planted defect.** I put `.site-header--compact` back in `bingo.css` alone and the suite stayed green. The reason is uncomfortable: *this ticket had just moved the chrome into JS*, so the class no longer appeared in any `class="..."` attribute. The check couldn't see the very bug it was written for. It now also scans the first-party modules a page imports, one level deep.

**Pass 3 — over-collecting.** Scanning those modules for every identifier reported `.hidden`, `.error` and `.back` on index.html — ordinary words in `app.js` that happen to be class names in stylesheets it doesn't load. Narrowed to hyphenated tokens: a hyphen is what separates a BEM class from English, and every chrome class this guards has one.

**Verified both directions.** With `.site-header--compact` in `bingo.css` alone, all four consumer pages fail:

```
FAIL about.html   - uses .site-header--compact, defined only in bingo.css which it does not load
FAIL bday.html    - uses .site-header--compact, defined only in bingo.css which it does not load
FAIL index.html   - uses .site-header--compact, defined only in bingo.css which it does not load
FAIL submit.html  - uses .site-header--compact, defined only in bingo.css which it does not load
```

With it in `layout.css`, all five pass.

### Scope, stated in the script

It's a drift guard for page chrome, not a whole-app reachability prover. Classes rendered deeper in the module graph — most of index.html — are out of scope, and the script header says so rather than implying coverage it doesn't have.

## Verification

| Gate | Result |
|---|---|
| `npm run test:unit` | **136 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean |

In-browser: all five pages render their chrome; about's warning sits in `<main>` with no tagline; bingo keeps its compact header and dice icon with all 25 cells working; index keeps its video header and takes the shared footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
