### PR TITLE
#167: Extract a disclosure primitive and make the calendar keyboard-operable

### DIFF
--- a/css/views.css
+++ b/css/views.css
@@ -64,6 +64,30 @@
     border-radius: var(--border-radius);
 }
 
+/* The past-day expand control. A transparent overlay across the whole sticky
+   header, so the entire header stays clickable while the interaction is a real
+   <button> with aria-expanded — keyboard and screen readers included (#167).
+   It cannot wrap the header's content: a <button> may only contain phrasing
+   content, and the header holds an <h2>.
+
+   No `position: relative` on the header — it is already `position: sticky` from
+   .panel__header--sticky, which is a positioned element and so already the
+   containing block. Adding relative here would override the sticky and drop
+   every calendar header out of its stuck position. */
+.day-card__toggle {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+.day-card__toggle:focus-visible {
+    outline: 2px solid var(--color-primary);
+    outline-offset: -4px;
+}
+
 /* Chevron indicator for collapsed past days */
 .day-card__expand-indicator {
     display: none;

--- a/index.html
+++ b/index.html
@@ -117,7 +117,11 @@
 
     <div class="app-layout">
         <div class="app-layout__list">
-            <nav id="navigation" class="navigation-container"></nav>
+            <!-- A div, not a nav: the Navigation component renders its own <nav>
+                 inside this mount, and two nested nav landmarks are one too
+                 many (#167). The other four pages hand-write their nav and
+                 keep the element. -->
+            <div id="navigation" class="navigation-container"></div>
 
             <main id="main-content" class="main-content">
                 <div class="loading">

--- a/js/components/DayCard.js
+++ b/js/components/DayCard.js
@@ -16,6 +16,7 @@ import { Component } from './Component.js';
 import { renderVenueCard } from './VenueCard.js';
 import { formatDateShort, isToday, getDayDisplayName, getDayName, getScheduleExclusion } from '../utils/date.js';
 import { getVenueEventsForDate } from '../services/venues.js';
+import { renderDisclosureButton } from '../utils/disclosure.js';
 import { getState } from '../core/state.js';
 
 /**
@@ -59,18 +60,42 @@ export class DayCard extends Component {
         const pastClass = isPast(date) ? 'day-card--past' : '';
         const emptyClass = events.length === 0 ? 'day-card--empty' : '';
 
+        // Past days collapse and expand on click. That interaction is spec'd
+        // (§2) but was mouse-only: the header carried a delegated click and no
+        // button, tabindex, role or aria-expanded (#167).
+        //
+        // The button does NOT wrap the header's content, though the ticket words
+        // it that way — a <button> may only contain phrasing content, and this
+        // header holds an <h2>. Instead it is a transparent overlay stretched
+        // across the header (see .day-card__toggle in views.css): the whole
+        // header stays clickable, the heading stays a heading, and keyboard and
+        // screen-reader users get a real control with a real state.
+        const isPastDay = isPast(date);
+        const contentId = `day-content-${date.toISOString().slice(0, 10)}`;
+        const toggle = isPastDay
+            ? renderDisclosureButton({
+                controls: contentId,
+                expanded: false,
+                // dateStr already leads with the weekday abbreviation, so
+                // pairing it with dayName read "Sunday, Sun 8/2".
+                label: `Show venues for ${dayName} ${dateStr.replace(/^\S+\s/, '')}`,
+                className: 'day-card__toggle',
+            })
+            : '';
+
         return `
             <article class="panel day-card day-card--${dayOfWeek} ${todayClass} ${pastClass} ${emptyClass}">
                 <header class="panel__header panel__header--sticky day-card__header">
                     <h2 class="panel__title panel__title--display day-card__day">${dayName}</h2>
                     <span class="day-card__date">${dateStr}</span>
                     ${isToday(date) ? '<span class="day-card__today-badge">Today</span>' : ''}
-                    <span class="day-card__expand-indicator">
+                    <span class="day-card__expand-indicator" aria-hidden="true">
                         <i class="fa-solid fa-chevron-down"></i>
                     </span>
+                    ${toggle}
                 </header>
 
-                <div class="panel__body day-card__content">
+                <div class="panel__body day-card__content" id="${contentId}">
                     ${events.length > 0
                         ? this.renderEvents(events, date)
                         : '<p class="day-card__empty">No karaoke scheduled</p>'

--- a/js/components/ExtendedSection.js
+++ b/js/components/ExtendedSection.js
@@ -11,6 +11,7 @@
  */
 
 import { renderDayCard } from './DayCard.js';
+import { renderDisclosureButton } from '../utils/disclosure.js';
 import { getDateRange } from '../utils/date.js';
 import { getVenuesForDate } from '../services/venues.js';
 import { getState } from '../core/state.js';
@@ -148,6 +149,8 @@ export function renderExtendedSection({ title, startDate, endDate, seenVenues, d
     const collapsed = isCollapsed(title);
     const collapsedClass = collapsed ? 'extended-section--collapsed' : '';
     const chevronClass = collapsed ? '' : 'extended-section__toggle--expanded';
+    // Stable per-section id so aria-controls points somewhere real.
+    const contentId = `extended-section-${title.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`;
 
     // Add venues to seenVenues set
     venuesByDate.forEach(({ venues }) => {
@@ -176,11 +179,15 @@ export function renderExtendedSection({ title, startDate, endDate, seenVenues, d
             <header class="extended-section__header">
                 <h3 class="extended-section__title">${title}</h3>
                 <span class="extended-section__count">${count} venue${count !== 1 ? 's' : ''}</span>
-                <button class="extended-section__toggle ${chevronClass}" aria-label="Toggle section">
-                    <i class="fa-solid fa-chevron-down"></i>
-                </button>
+                ${renderDisclosureButton({
+                    controls: contentId,
+                    expanded: !collapsed,
+                    label: `${collapsed ? 'Show' : 'Hide'} ${title}`,
+                    className: `extended-section__toggle ${chevronClass}`.trim(),
+                    icon: 'fa-solid fa-chevron-down',
+                })}
             </header>
-            <div class="extended-section__content">
+            <div class="extended-section__content" id="${contentId}">
                 ${dayCardsHtml ? `<div class="weekly-view__grid">${dayCardsHtml}</div>` : ''}
                 ${dedupNotice}
             </div>
@@ -196,13 +203,22 @@ export function attachExtendedSectionListeners(container) {
     container.querySelectorAll('.extended-section__toggle').forEach(button => {
         button.addEventListener('click', (e) => {
             const section = e.target.closest('.extended-section');
-            if (section) {
-                const title = section.dataset.sectionTitle;
-                // Toggle the DOM first; its result is the authoritative new state
-                const nowCollapsed = section.classList.toggle('extended-section--collapsed');
-                button.classList.toggle('extended-section__toggle--expanded', !nowCollapsed);
-                setCollapsed(title, nowCollapsed);
-            }
+            if (!section) return;
+
+            const title = section.dataset.sectionTitle;
+            // Toggle the DOM first; its result is the authoritative new state
+            const nowCollapsed = section.classList.toggle('extended-section--collapsed');
+            button.classList.toggle('extended-section__toggle--expanded', !nowCollapsed);
+
+            // The button announces its own state, and says what it will do next
+            // rather than what it just did (#167). It used to carry a static
+            // aria-label="Toggle section" and no aria-expanded at all, so a
+            // screen reader could not tell open from closed.
+            button.setAttribute('aria-expanded', String(!nowCollapsed));
+            const label = button.querySelector('.sr-only');
+            if (label) label.textContent = `${nowCollapsed ? 'Show' : 'Hide'} ${title}`;
+
+            setCollapsed(title, nowCollapsed);
         });
     });
 }

--- a/js/components/Navigation.js
+++ b/js/components/Navigation.js
@@ -18,7 +18,7 @@ import { Component } from './Component.js';
 import { getState, setState, subscribe, navigateWeek, goToCurrentWeek } from '../core/state.js';
 import { formatWeekRange, getWeekStart, isCurrentWeek } from '../utils/date.js';
 import { resolveView, isKJView } from '../core/router.js';
-import { html } from '../utils/string.js';
+import { html, raw } from '../utils/string.js';
 
 export class Navigation extends Component {
     init() {
@@ -170,21 +170,28 @@ export class Navigation extends Component {
             hostFilter: getState('hostFilter'),
         }));
         const cls = (active) => `nav-btn nav-btn--labeled${active ? ' nav-btn--active' : ''}`;
+        // The active view was signalled by class alone, which is invisible to a
+        // screen reader. aria-current="page" says it out loud (#167).
+        //
+        // raw() because the `html` tag escapes every interpolation by design —
+        // without it the attribute renders as visible text instead of an
+        // attribute, which is exactly what happened on the first attempt.
+        const cur = (active) => raw(active ? ' aria-current="page"' : '');
         return html`
             <div class="navigation__views">
-                <button class="${cls(!inKJMode && view === 'weekly')}" data-view="weekly" type="button">
+                <button class="${cls(!inKJMode && view === 'weekly')}"${cur(!inKJMode && view === 'weekly')} data-view="weekly" type="button">
                     <i class="fa-regular fa-calendar"></i>
                     <span class="nav-btn__label">CAL</span>
                 </button>
-                <button class="${cls(!inKJMode && view === 'alphabetical')}" data-view="alphabetical" type="button">
+                <button class="${cls(!inKJMode && view === 'alphabetical')}"${cur(!inKJMode && view === 'alphabetical')} data-view="alphabetical" type="button">
                     <i class="fa-solid fa-list"></i>
                     <span class="nav-btn__label">A-Z</span>
                 </button>
-                <button class="${cls(!inKJMode && view === 'map')}" data-view="map" type="button">
+                <button class="${cls(!inKJMode && view === 'map')}"${cur(!inKJMode && view === 'map')} data-view="map" type="button">
                     <i class="fa-solid fa-map-location-dot"></i>
                     <span class="nav-btn__label">MAP</span>
                 </button>
-                <a class="${cls(kjIndexActive)}" href="?kj=all">
+                <a class="${cls(kjIndexActive)}"${cur(kjIndexActive)} href="?kj=all">
                     <i class="fa-solid fa-microphone-lines"></i>
                     <span class="nav-btn__label">KJs</span>
                 </a>

--- a/js/components/VenueModal.js
+++ b/js/components/VenueModal.js
@@ -32,6 +32,29 @@ export class VenueModal extends Component {
         this.addEventListener(document, 'keydown', (e) => {
             if (e.key === 'Escape' && this.state.isOpen) this.close();
         });
+
+        // Tab cycle. Bound here, not in trapFocus(), because trapFocus runs from
+        // afterRender on every render and this.addEventListener does not
+        // de-duplicate — binding it there would stack one handler per render
+        // (#158). init() runs once per instance.
+        this.addEventListener(document, 'keydown', (e) => {
+            if (e.key !== 'Tab' || !this.state.isOpen) return;
+
+            const items = this.focusableElements();
+            if (!items.length) return;
+
+            const first = items[0];
+            const last = items[items.length - 1];
+            const active = document.activeElement;
+
+            if (e.shiftKey && (active === first || !items.includes(active))) {
+                e.preventDefault();
+                last.focus();
+            } else if (!e.shiftKey && active === last) {
+                e.preventDefault();
+                first.focus();
+            }
+        });
     }
 
     template() {
@@ -92,6 +115,12 @@ export class VenueModal extends Component {
             return;
         }
 
+        // Remember what had focus so close() can hand it back. Without this the
+        // modal dropped focus to the top of the document on close, so a keyboard
+        // user tabbing through the calendar landed back at the page start every
+        // time they looked at a venue (#167).
+        this._returnFocusTo = document.activeElement;
+
         this.setState({ venue, isOpen: true });
         document.body.style.overflow = 'hidden';
     }
@@ -100,19 +129,34 @@ export class VenueModal extends Component {
         document.body.style.overflow = '';
         this.setState({ isOpen: false });
         emit(Events.VENUE_CLOSED, this.state.venue);
+
+        // Back to the card that opened it, if it is still in the document.
+        const target = this._returnFocusTo;
+        this._returnFocusTo = null;
+        if (target && document.contains(target) && typeof target.focus === 'function') {
+            target.focus();
+        }
     }
 
-    trapFocus() {
+    /** Everything inside the modal a user can tab to, in DOM order. */
+    focusableElements() {
         const modal = this.$('.venue-modal__content');
-        if (!modal) return;
-
-        const focusable = modal.querySelectorAll(
+        if (!modal) return [];
+        return [...modal.querySelectorAll(
             'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-        );
+        )].filter(el => !el.hasAttribute('disabled') && el.offsetParent !== null);
+    }
 
-        if (focusable.length) {
-            focusable[0].focus();
-        }
+    /**
+     * Move focus into the modal and keep it there.
+     *
+     * The old version only focused the first element and called that a trap —
+     * Tab walked straight out into the page behind, which is still scrolled
+     * and inert. This wraps at both ends (#167).
+     */
+    trapFocus() {
+        const focusable = this.focusableElements();
+        if (focusable.length) focusable[0].focus();
     }
 
     onDestroy() {

--- a/js/utils/disclosure.js
+++ b/js/utils/disclosure.js
@@ -1,0 +1,92 @@
+/**
+ * Disclosure primitive — one way to build "click this to show that".
+ *
+ * The app had two, built to different standards (#167):
+ *
+ *   ExtendedSection  a real <button>, keyboard-operable, but with only an
+ *                    aria-label — it never announced whether it was open
+ *   DayCard          a <header> with a delegated click and no button, no
+ *                    tabindex, no role and no aria-expanded, so the past-day
+ *                    expand documented in spec §2 was mouse-only
+ *
+ * Both use this now. The contract is the ARIA disclosure pattern: a button that
+ * owns `aria-expanded`, points at what it controls with `aria-controls`, and
+ * carries a label that says what will happen.
+ *
+ * The visual state stays in CSS via a class on the container — this module only
+ * owns the button and the ARIA. Callers decide what "expanded" looks like.
+ */
+
+import { escapeHtml } from './string.js';
+
+/**
+ * Render a disclosure button.
+ *
+ * @param {Object} options
+ * @param {string} options.controls - id of the element this shows/hides
+ * @param {boolean} options.expanded - current state
+ * @param {string} options.label - what the button does, e.g. "Show venues for Sunday"
+ * @param {string} [options.className=''] - extra classes for the caller's styling
+ * @param {boolean} [options.labelVisible=false] - when false the label is
+ *   screen-reader-only, for buttons whose meaning is carried by adjacent visuals
+ * @param {string} [options.icon=''] - Font Awesome classes for a visible icon
+ * @returns {string} HTML string
+ */
+export function renderDisclosureButton({
+    controls,
+    expanded = false,
+    label,
+    className = '',
+    labelVisible = false,
+    icon = '',
+}) {
+    const iconHtml = icon ? `<i class="${escapeHtml(icon)}" aria-hidden="true"></i>` : '';
+    const labelHtml = labelVisible
+        ? escapeHtml(label)
+        : `<span class="sr-only">${escapeHtml(label)}</span>`;
+    const classes = `disclosure ${className}`.trim();
+
+    return `<button type="button" class="${escapeHtml(classes)}" `
+        + `aria-expanded="${expanded}" aria-controls="${escapeHtml(controls)}">`
+        + `${iconHtml}${labelHtml}</button>`;
+}
+
+/**
+ * Wire every disclosure button inside `root`.
+ *
+ * Delegated from `root`, so it survives re-renders of the content inside it and
+ * does not need re-binding per button.
+ *
+ * @param {HTMLElement} root - container to listen on
+ * @param {Object} [options]
+ * @param {(button: HTMLElement, expanded: boolean) => void} [options.onToggle]
+ *   Called after the state flips, for callers that persist it or update classes.
+ * @returns {() => void} unbind
+ */
+export function bindDisclosure(root, { onToggle } = {}) {
+    if (!root) return () => {};
+
+    const handler = (e) => {
+        const button = e.target.closest('.disclosure');
+        if (!button || !root.contains(button)) return;
+
+        const expanded = button.getAttribute('aria-expanded') === 'true';
+        const next = !expanded;
+        button.setAttribute('aria-expanded', String(next));
+
+        if (onToggle) onToggle(button, next);
+    };
+
+    root.addEventListener('click', handler);
+    return () => root.removeEventListener('click', handler);
+}
+
+/**
+ * The element a disclosure button controls.
+ * @param {HTMLElement} button
+ * @returns {HTMLElement|null}
+ */
+export function disclosureTarget(button) {
+    const id = button?.getAttribute('aria-controls');
+    return id ? document.getElementById(id) : null;
+}

--- a/js/views/WeeklyView.js
+++ b/js/views/WeeklyView.js
@@ -12,6 +12,7 @@ import { attachVenueSelectionListener } from '../components/venue-selection.js';
 import { getState, subscribe } from '../core/state.js';
 import { getWeekDates, getWeekStart, getNextWeekRange, getThisMonthRange, getNextMonthRange, getMonthName } from '../utils/date.js';
 import { getVenuesForDate } from '../services/venues.js';
+import { bindDisclosure } from '../utils/disclosure.js';
 
 export class WeeklyView extends Component {
     init() {
@@ -109,13 +110,20 @@ export class WeeklyView extends Component {
     }
 
     afterRender() {
-        // Event delegation for past day card header clicks to toggle expansion
-        this.delegate('click', '.day-card--past .day-card__header', (_e, target) => {
-            const dayCard = target.closest('.day-card--past');
-            if (dayCard) {
-                dayCard.classList.toggle('day-card--expanded');
-            }
+        // Past-day expand. The button owns aria-expanded; this only mirrors it
+        // onto the card so CSS can react (#167).
+        //
+        // afterRender runs on every render, so the previous binding is released
+        // first — stacking them would fire the toggle N times per click and
+        // leave the state flipping back to where it started (#158's lesson).
+        if (this._unbindDisclosure) this._unbindDisclosure();
+        this._unbindDisclosure = bindDisclosure(this.container, {
+            onToggle: (button, expanded) => {
+                button.closest('.day-card--past')
+                    ?.classList.toggle('day-card--expanded', expanded);
+            },
         });
+        this.subscribe(() => this._unbindDisclosure?.());
 
         attachVenueSelectionListener(this);
 


### PR DESCRIPTION
Closes #167.

## Two disclosures, two standards

| | Before |
|---|---|
| `ExtendedSection` | real `<button>`, keyboard-operable — but only `aria-label="Toggle section"`, so it never announced open vs closed |
| `DayCard` past day | a `<header>` with a delegated click. No button, no tabindex, no role, no `aria-expanded` — the expand that spec §2 documents was **mouse-only** |

`js/utils/disclosure.js` is now the one way: `renderDisclosureButton()` emits a button that owns `aria-expanded`, points at what it controls, and says what it will do *next*; `bindDisclosure()` flips the state and hands the caller the result. Both components use it.

## Where I deviated from the AC, and why

**The past-day button does not wrap the header's content.** A `<button>` may only contain phrasing content, and the header holds an `<h2>` — wrapping would be invalid markup and would cost the heading semantics.

It's a transparent overlay stretched across the header instead. The whole header stays clickable, the heading stays a heading, and keyboard/AT users get a real control with real state.

One trap worth recording: I nearly added `position: relative` to the header to make the overlay's containing block. That would have **overridden the `position: sticky`** it inherits from `.panel__header--sticky` and dropped every calendar header out of its stuck position. Sticky is itself a positioned element, so it's already the containing block — no extra rule needed.

## `aria-current="page"`

The active view was signalled by class alone. It now carries `aria-current="page"`.

This needed `raw()` — the `html` tag escapes every interpolation by design, so my first attempt rendered the attribute as **visible text** rather than an attribute. Caught by checking the DOM rather than assuming.

Verified across all five destinations: exactly one match per view, and correctly **zero** in dossier mode, where no nav button represents a single KJ.

```
weekly       → CAL   aria-current=page
map          → MAP   aria-current=page
alphabetical → A-Z   aria-current=page
?kj=all      → KJs   aria-current=page
?kj=armando  → (none)
```

## Nested landmark

`index.html`'s outer `<nav>` is now a `<div>` — the Navigation component renders its own `<nav>` inside that mount, so there were two nested landmarks. The other four pages hand-write their nav and keep the element.

## Modal focus

`VenueModal` stashes `document.activeElement` on open and restores it on close, so a keyboard user returns to the card they opened instead of the top of the document.

Its "focus trap" only focused the first element — **Tab walked straight out** into the page behind, which is scrolled and inert. It now wraps at both ends.

## Two rebinding hazards avoided

Both are #158's lesson, and both would have been silent:

- `WeeklyView` releases the previous `bindDisclosure` before rebinding — `afterRender` runs on every render, so stacking would fire the toggle N times per click and leave the state flipping back to where it started.
- The modal's Tab handler is bound in `init()`, not `trapFocus()` — `trapFocus` is called from `afterRender`, and `this.addEventListener` doesn't de-duplicate.

## Verification

In-browser, on the real page:

```
past-day toggle   BUTTON, focusable, overlays full header, header still sticky
aria-controls     day-content-2026-08-02 → resolves to the content it shows
aria-expanded     false → true → false across activations
label             "Show venues for Sunday 8/2"
modal Tab         last → first wraps ✓   Shift+Tab first → last wraps ✓
modal close       focus returns to the opening card — close button ✓ and Escape ✓
```

One measurement error worth noting: my first focus test reported restoration broken. The bug was the test — it grabbed the first `.venue-card__link`, which sits inside a *collapsed past day* (`display: none`) and therefore can't take focus. Re-run against a visible card, it passes.

| Gate | Result |
|---|---|
| `npm run test:unit` | **136 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** — including the existing past-day expand spec, unchanged, against the new button |
| `npm run validate:all` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
