### PR TITLE
#169 (partial): Delete the exclusions shorthand; warn on spent one-time events

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,7 @@ When adding or modifying venues in `js/data.json`, follow this structure:
       endTime: "01:00",       // Can cross midnight
       eventUrl: "https://...", // Optional: link to event page
       exclusions: [           // Optional: dates this recurring show is skipped (holiday/closure)
-        { date: "2026-12-25", reason: "Holiday" }  // reason optional; "2026-12-25" shorthand also accepted
+        { date: "2026-12-25", reason: "Holiday" }  // objects only — reason optional. A bare date string is NOT accepted (#169)
       ],
       host: {                 // Optional: overrides venue-level host for this show only
         name: "Guest KJ",     // See "Per-show host override" below

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -667,14 +667,21 @@ A **host ref** is the pair `{ kjId?, companyId? }`, with at least one id present
 
 ### Schedule Exclusions
 
-A recurring schedule entry may carry an `exclusions` array listing dates on which that show does **not** happen (holiday closures, private events, one-off cancellations). Each item is either a shorthand date string or an object with an optional reason:
+A recurring schedule entry may carry an `exclusions` array listing dates on which that show does **not** happen (holiday closures, private events, one-off cancellations). **Each item is an object**; `reason` is optional:
 
 ```
 exclusions: [
-  "2026-12-25",                              // shorthand — no reason
-  { date: "2026-12-26", reason: "Repairs" }  // object form with a reason
+  { date: "2026-12-25" },                    // no reason given
+  { date: "2026-12-26", reason: "Repairs" }
 ]
 ```
+
+> A bare `"2026-12-25"` string used to be documented here and in CLAUDE.md as an
+> accepted shorthand, and `getScheduleExclusion` read it — but the schema
+> requires an object with `additionalProperties: false`, so **following the
+> documentation failed CI**. Confirmed live: the validator reports
+> `exclusions/0 — must be object` and exits 1. The shorthand is gone from the
+> code and both documents (#169).
 
 - An exclusion **suppresses** the recurring occurrence on that date, but the schedule still "matches" the date — so the venue renders with a **closure indicator** rather than disappearing (users hunting for it still find it in place).
 - Helpers in `js/utils/date.js`: `getScheduleExclusion(entry, date)` (per-entry), `getVenueExclusionForDate(venue, date)` (venue-level — is it closed on a given date?), and `getUpcomingExclusions(venue, days)` (future closures within a window, today excluded).

--- a/js/utils/date.js
+++ b/js/utils/date.js
@@ -133,7 +133,14 @@ export function isCurrentWeek(weekStart) {
 export function scheduleMatchesDate(schedule, date) {
     const { frequency, day } = schedule;
 
-    // One-time special event: compare exact date string
+    // One-time special event: compare exact date string.
+    //
+    // "One-time" means the date is not on a predictable cadence, not that it
+    // happens only once. A venue or KJ may hold many of these — The Highball's
+    // Xpider nights are the standing example — and each is listed explicitly
+    // because nothing can generate them. They keep the star for the same
+    // reason: an irregular date is genuinely a departure from the recurring
+    // baseline, which is what Display Philosophy §4 marks.
     if (frequency === 'once') {
         const y = date.getFullYear();
         const m = String(date.getMonth() + 1).padStart(2, '0');
@@ -180,8 +187,8 @@ export function scheduleMatchesDate(schedule, date) {
  * indicator); call this alongside `scheduleMatchesDate()` to know whether to
  * dim/banner the card.
  *
- * Accepts both shorthand (`"2026-06-12"`) and object (`{date, reason}`) forms
- * inside `schedule.exclusions`.
+ * `schedule.exclusions` holds objects: `{date, reason?}`. A bare date string is
+ * NOT accepted — the schema forbids it (#169).
  *
  * @param {Object} schedule - Schedule entry, possibly with `exclusions`
  * @param {Date} date - Date to check
@@ -195,10 +202,13 @@ export function getScheduleExclusion(schedule, date) {
     const d = String(date.getDate()).padStart(2, '0');
     const dateStr = `${y}-${m}-${d}`;
 
+    // Objects only. A bare `"2026-12-25"` string used to be accepted here and
+    // was documented in CLAUDE.md as valid — but the schema requires an object
+    // with additionalProperties:false, so following the documentation failed
+    // CI. Reading the shorthand made the code agree with the docs and disagree
+    // with the gate; it is gone from both (#169).
     for (const ex of schedule.exclusions) {
-        if (typeof ex === 'string') {
-            if (ex === dateStr) return { date: ex, reason: null };
-        } else if (ex?.date === dateStr) {
+        if (ex?.date === dateStr) {
             return { date: ex.date, reason: ex.reason || null };
         }
     }
@@ -242,12 +252,12 @@ export function getUpcomingExclusions(venue, days = 60) {
     const upcoming = [];
     for (const entry of venue?.schedule || []) {
         for (const ex of entry.exclusions || []) {
-            const dateStr = typeof ex === 'string' ? ex : ex?.date;
+            const dateStr = ex?.date;
             if (!dateStr || seen.has(dateStr)) continue;
             const d = parseLocalDate(dateStr);
             if (d > today && d <= horizon) {
                 seen.add(dateStr);
-                upcoming.push({ date: dateStr, reason: typeof ex === 'string' ? null : (ex.reason || null) });
+                upcoming.push({ date: dateStr, reason: ex.reason || null });
             }
         }
     }

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -268,6 +268,34 @@ for (const venue of data.listings) {
     );
 }
 
+// ---- Spent one-time events (#169) ----
+// `once` does not mean "happens only once" — it means the date is not on a
+// predictable cadence, so it has to be listed explicitly. A venue or KJ may
+// legitimately carry many, and this check says nothing about how many there are.
+//
+// It reports individual rows whose date has passed: those can never match again
+// and only pad the schedule table with history. Thirty days is the grace period
+// — long enough not to nag about last weekend, short enough that a year-old row
+// gets noticed.
+//
+// Warned, not failed: deleting rows is curation, and only the curator knows
+// whether a past date is finished or about to be rescheduled (#135).
+const STALE_ONCE_DAYS = 30;
+const staleCutoff = new Date(TODAY);
+staleCutoff.setDate(staleCutoff.getDate() - STALE_ONCE_DAYS);
+
+for (const venue of data.listings) {
+    for (const entry of venue.schedule || []) {
+        if (entry.frequency !== 'once' || !entry.date) continue;
+        if (new Date(entry.date + 'T00:00:00') >= staleCutoff) continue;
+        warnings.push(
+            `${venue.name} (${venue.id}) has a spent one-time event on ${entry.date}` +
+            (entry.eventName ? ` ("${entry.eventName}")` : '') +
+            ` — more than ${STALE_ONCE_DAYS} days past and can never match again`
+        );
+    }
+}
+
 // ---- Output ----
 console.log('=== Summary ===');
 console.log('Total venues:', data.listings.length);

--- a/test/date.test.mjs
+++ b/test/date.test.mjs
@@ -130,6 +130,30 @@ describe('scheduleMatchesDate — one-time events', () => {
   });
 });
 
+describe('isPastOnceEvent', () => {
+  // "One-time" means the date is not on a predictable cadence, not that it
+  // happens only once — a venue may hold many. Each is still spent the day
+  // after it happens, which is what this reports (#169).
+  it('retires an entry the day after it happens', () => {
+    const e = { frequency: 'once', date: '2026-01-09' };
+    assert.equal(isPastOnceEvent(e, JAN(10)), true);
+    assert.equal(isPastOnceEvent(e, JAN(9)), false, 'the day itself is not past');
+  });
+
+  it("says nothing about a venue's other one-time entries", () => {
+    // Several `once` rows on one venue is the normal shape for an irregular
+    // night, not a data smell. Each is judged on its own date.
+    const past = { frequency: 'once', date: '2026-01-09' };
+    const future = { frequency: 'once', date: '2026-02-06' };
+    assert.equal(isPastOnceEvent(past, JAN(10)), true);
+    assert.equal(isPastOnceEvent(future, JAN(10)), false);
+  });
+
+  it('never retires a weekday-recurring entry', () => {
+    assert.equal(isPastOnceEvent({ frequency: 'every', day: 'friday' }, JAN(30)), false);
+  });
+});
+
 describe('getScheduleExclusion', () => {
   const base = { frequency: 'every', day: 'Friday' };
 
@@ -148,12 +172,14 @@ describe('getScheduleExclusion', () => {
     assert.deepEqual(getScheduleExclusion(s, JAN(2)), { date: '2026-01-02', reason: null });
   });
 
-  it('accepts the bare-string shorthand', () => {
-    // CLAUDE.md documents this form; the JSON Schema does not accept it.
-    // See #169 — the shorthand is slated for removal. Until then the runtime
-    // takes it, and this test records that.
+  it('ignores the bare-string shorthand — the schema rejects it', () => {
+    // This test used to assert the opposite, recording that the runtime took a
+    // form CLAUDE.md documented and the schema refused. That combination meant
+    // following the documentation failed CI (`exclusions/0 — must be object`).
+    // The shorthand is gone from the code and both documents (#169), so a bare
+    // string now matches nothing rather than quietly working in one layer.
     const s = { ...base, exclusions: ['2026-01-02'] };
-    assert.deepEqual(getScheduleExclusion(s, JAN(2)), { date: '2026-01-02', reason: null });
+    assert.equal(getScheduleExclusion(s, JAN(2)), null);
   });
 
   it('returns null on a non-excluded date', () => {


### PR DESCRIPTION
Relates to #169 — **does not close it.** Most of the ticket's premise turned out to be wrong; see below.

## The premise, corrected

#169 proposed a `frequency: "dates"` for irregular recurring nights, because The Highball's six `once` rows looked like *"a house night permanently occupying the star-and-sort-to-top special event slot, undercutting Display Philosophy §4."*

That misreads what `once` means in this project. Per the owner:

> `once` does not mean "happens only once" — it means **the time and day are not on a predictable cadence**, so the show must be listed explicitly because nothing can generate it. A venue or KJ may legitimately have several. They should keep the star, and should still show in the "also on" list.

Under that model The Highball's rows are correctly `once`, and the star is right: an irregular date genuinely *is* a departure from the recurring baseline, which is exactly what §4 marks.

**Dropped, with `js/data.json` untouched:**

- `frequency: "dates"` (schema, matcher, label, render branches, tests)
- The Highball's four-row collapse
- The past-row deletions
- The `special-event` tag removal

The corrected model is now written into the matcher's comment, so the next reader doesn't re-derive the same wrong conclusion from the same six rows.

## What survives — the half that stands on its own

### The `exclusions` string shorthand is gone

CLAUDE.md and spec §11 both documented this as valid:

```
exclusions: [
  "2026-12-25",                              // shorthand — no reason
  { date: "2026-12-26", reason: "Repairs" }
]
```

`getScheduleExclusion` read it. **The schema does not accept it** — `items` requires an object with `additionalProperties: false`. So following the documentation failed CI. Confirmed by planting the documented form:

```
- Sociedad (sociedad)/schedule/0/exclusions/0 — must be object
Validation FAILED.   exit=1
```

Removed from the code, both documents, and the JSDoc.

**A unit test had locked in the broken behaviour.** It asserted the shorthand worked, with a comment noting the schema disagreed and that #169 would resolve it — so the suite was actively defending the form that breaks the gate. Flipped to assert a bare string now matches nothing.

### `validate-data.js` warns on spent one-time events

Any `once` date more than 30 days past, named with its venue:

```
- The Highball (the-highball) has a spent one-time event on 2026-05-30
  ("Story-Oke: Country @ Highball!") — more than 30 days past and can never match again
```

Advisory, not fatal — deleting rows is curation, and only the curator knows whether a past date is finished or about to be rescheduled (#135).

Its comment states the corrected model up front, so the warning can't be misread as *"you have too many one-time events."* It's about individual spent rows, not how many a venue carries.

## Verification

| Gate | Result |
|---|---|
| `npm run test:unit` | **153 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean (10 advisory warnings, 6 of them the new check) |

After the revert, in-browser: The Highball keeps its star, its `venue-card--special-event` accent, its "Also Aug 22" line, and its Special Event tag.

## What's left on #169

Three ACs are void under the corrected model. Worth editing the ticket rather than leaving them for a future session to re-attempt:

- ~~`frequency: "dates"` added to the schema~~
- ~~The Highball's rows collapsed; past rows deleted~~
- ~~`special-event` tag removed~~
- ✔ validator warns on spent `once` dates
- ✔ `exclusions` shorthand deleted from code and docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
