### PR TITLE
#124 Phase 5: ?kj= carries a registry id, not a name substring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -393,14 +393,14 @@ Tags are rendered as color-coded badges in VenueCard, VenueModal, and VenueDetai
 - `?view=<weekly|alphabetical|map>` — initial view. `VALID_VIEWS` is declared once, in the router
 - `?kj=all` — KJ index (`KJIndexView`)
 - `?kj=none` — venues with no listed host
-- `?kj=<name>` — KJ dossier (`KJDossierView`; `venueMatchesHost()` filters by **substring**, which is why `?kj=Armando` also matches "KJ Armando and Paola" — see #124 Phase 5 and ADR-011)
+- `?kj=<id>` — KJ dossier (`KJDossierView`). Carries a **registry id**, matched exactly, so `?kj=armando` no longer also matches "KJ Armando and Paola". A non-id value still substring-matches names, so links shared before #124 Phase 5 keep working
 - `?debug=1` — debug mode (also `localStorage.debug=1`)
 - `#view=<v>&venue=<id>` — deep link to a selected venue. The hash records the **actual** view; a venue-less hash is cleared rather than left as `#view=weekly`
 - Legacy bare hashes (`#weekly`) are still honoured
 
 `venueShareUrl()` pins `view=weekly` deliberately — a shared venue link should land on the calendar regardless of which view the sharer was in. That is a different question from what the address bar shows while browsing.
 
-`?kj=` and the generated `/kj/<id>/` pages (ADR-012) are still two systems for one concept: the SPA matches on substring, the static pages on registry id. Reconciling them is #124 Phase 5.
+`?kj=` and the generated `/kj/<id>/` pages (ADR-012) now speak the same language: both address a host by registry id (#124 Phase 5). The SPA additionally accepts a name substring, for links that predate the change.
 
 ### Extended Sections
 - `ExtendedSection` component renders collapsible sections: "Next Week", "Later in [Month]", "[Next Month]"

--- a/docs/adr/007-host-registry-normalization.md
+++ b/docs/adr/007-host-registry-normalization.md
@@ -68,3 +68,58 @@ Two top-level registries in `data.json`, with shows referencing them by id:
 - **#124** — implementation ticket (phased: contract/runtime → migration → submit form → curator → cleanup)
 - **ADR-005** — the schema this extends; **ADR-006** — migration edits `data.json`, `data.js` regenerated
 - Tag system (`tagDefinitions` + `validate-data.js` cross-reference) — the in-repo precedent this generalizes
+
+---
+
+## Amendment (2026-08-04, #124 Phase 5)
+
+### The dual-shape `oneOf` is permanent — it is the intake contract, not a transition artifact
+
+The Negative section above calls the inline-host shape a cost of "the transition
+window", and Phase 5 was originally scoped to delete it once the curator and the
+submit form were migrated. Both are migrated. It is staying anyway.
+
+Phase 3 built the submit form to emit a **ref** when a typed KJ or company name
+matches a registry entry, and the **inline** shape when it does not. That
+fallback is not a leftover — it is what carries the most valuable submissions we
+receive, the ones telling us about a host we do not have yet. Removing inline
+support would mean the form has to reject an unknown name, or silently drop the
+attribution.
+
+So the two shapes have different jobs:
+
+| Shape | Where it is legal | Why |
+|---|---|---|
+| `{ kjId?, companyId? }` | `js/data.json` | The committed data is all refs. Identity is exact, and the registries are the single source of truth. |
+| `{ name?, affiliation?, website?, socials? }` | submission intake | A submitter cannot know registry ids. An unrecognised name still has to arrive intact for the curator to reconcile. |
+
+The schema keeps accepting both. `js/data.json` staying all-refs is a separate,
+narrower rule — enforceable by a check on the committed file rather than by
+tightening the shared contract.
+
+### `?kj=` now carries a registry id
+
+The Positive section anticipated this ("the index and dossiers group by id,
+ending substring conflation and enabling stable `?kj=<slug>` URLs later"). Later
+is now.
+
+`KJIndexView` groups by `kjId`/`companyId`, falling back to the lowercased name
+only for inline hosts, and every link it renders carries an id. `venueMatchesHost`
+resolves an id **exactly**; name substring matching is retained solely so links
+shared or indexed before this change keep working.
+
+One subtlety worth recording, because getting it wrong silently re-opens the bug:
+**an id query must not fall through to the substring pass.** `armando` is a valid
+KJ id *and* a substring of "KJ Armando and Paola", so a fallback would still have
+matched a venue hosted only by the duo. The service keeps the set of known
+registry ids and answers an id query by id alone.
+
+### Supabase seed pipeline — deferred, deliberately
+
+Phase 5 also listed updating `supabase/seed-from-data.js` for the registries.
+Supabase was parked by **ADR-009** and its scaffolding moved to
+`_deprecated/supabase/`. Updating a seed script for a runtime that no longer
+exists would be maintaining two data models to no benefit. It stays deferred;
+ADR-009's re-entry trigger (the directory needing a *write* path) is when it gets
+revisited, and at that point the registries are the shape it should target
+anyway.

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -542,12 +542,25 @@ Venues with an `activePeriod` field only appear when the current date falls with
 - **Chip:** Reads "All KJs" (special-cased) instead of the literal "all". × exits to weekly view.
 - **Empty state:** "No KJs found in the directory." (renders when data has zero host fields populated).
 
-### KJ Dossier (`?kj=<name>`)
+### KJ Dossier (`?kj=<id>`)
 
 - **Audience:** KJs auditing their own listings ("what do I have up on karaokedirectory?"). Not a customer-facing filter.
-- **URL-driven:** Append `?kj=<name>` to `index.html` (e.g. `index.html?kj=xpider`). Discoverable via `?kj=all`.
-- **Match scope:** Case-insensitive substring against `venue.host.{name,company}` and per-show `schedule[N].host.{name,company}` only. Does NOT match venue name, city, tags, or event names.
-- **Replaces the normal views:** `KJDossierView` renders in place of weekly/alphabetical/map. Navigation collapses to a minimal bar showing just the `KJ: <name>` chip with a × close button (clearing the chip exits dossier mode and strips `?kj=` from the URL).
+- **URL-driven:** Append `?kj=<id>` to `index.html` (e.g. `index.html?kj=xpider-cantu`). Discoverable via `?kj=all`, whose every link carries an id.
+- **Match scope — id first, exactly.** The value is a `kjs`/`companies` registry id, matched against `host.kjId`/`host.companyId` on the venue and on each schedule entry. A value that is *not* a known id falls back to case-insensitive substring matching on host names, so links shared before #124 Phase 5 keep working. Does NOT match venue name, city, tags, or event names.
+
+> **Why ids.** A substring cannot identify an entity. `?kj=armando` matched both
+> "Armando" and "KJ Armando and Paola" — two different KJs on one dossier — and
+> `?kj=karaoke` matched 23 venues across 13 distinct hosts, because most company
+> names contain the word.
+>
+> An id query is answered **by id alone**, never falling through to the substring
+> pass. That matters more than it looks: `armando` is a valid id *and* a substring
+> of the duo's name, so a fallback would have kept matching a venue hosted only by
+> the duo. See the ADR-007 amendment.
+>
+> The dossier title and the nav chip resolve the id back to a display name, so a
+> visitor sees "KJ: Xpider Cantu", not the slug.
+- **Replaces the normal views:** `KJDossierView` renders in place of weekly/alphabetical/map. Navigation collapses to a minimal bar showing just the `KJ: <name>` chip (the resolved name, not the id) with a × close button (clearing the chip exits dossier mode and strips `?kj=` from the URL).
 - **Layout per venue:**
   - Venue name + address
   - All recurring slots that belong to this KJ (one entry per slot, sorted Sunday → Saturday)

--- a/js/components/Navigation.js
+++ b/js/components/Navigation.js
@@ -18,6 +18,7 @@ import { Component } from './Component.js';
 import { getState, setState, subscribe, navigateWeek, goToCurrentWeek } from '../core/state.js';
 import { formatWeekRange, getWeekStart, isCurrentWeek } from '../utils/date.js';
 import { resolveView, isKJView } from '../core/router.js';
+import { resolveHostLabel } from '../services/venues.js';
 import { html, raw } from '../utils/string.js';
 
 export class Navigation extends Component {
@@ -47,7 +48,8 @@ export class Navigation extends Component {
         if (isKJView(resolved)) {
             const isIndex = resolved === 'kj-index';
             let chipLabel = 'KJ:';
-            let chipValue = hostFilter;
+            // hostFilter carries a registry id now; show the name (#124 Phase 5).
+            let chipValue = resolveHostLabel(hostFilter);
             let chipIcon = 'fa-microphone-lines';
             if (isIndex) {
                 chipLabel = '';

--- a/js/services/venues.js
+++ b/js/services/venues.js
@@ -22,6 +22,9 @@ import { hydrateVenues } from '../utils/hosts.js';
 
 let venues = [];
 
+// Registry ids (kjs + companies), lowercased. Populated by initVenues.
+let registryIds = new Set();
+
 /**
  * Check if a venue is active
  * Venues without an 'active' property are considered active (default true)
@@ -96,6 +99,13 @@ export function initVenues(data) {
     // Resolve any { kjId, companyId } host refs against the kjs/companies
     // registries so everything downstream sees one host shape (ADR-007).
     venues = hydrateVenues(data);
+
+    // The set of ids `?kj=` can name. Kept so venueMatchesHost can tell an id
+    // query from a name query — see hostMatches (#124 Phase 5).
+    registryIds = new Set([
+        ...Object.keys(data.kjs || {}),
+        ...Object.keys(data.companies || {}),
+    ].map(id => id.toLowerCase()));
     const activeCount = getActiveVenues().length;
     const inactiveCount = venues.length - activeCount;
     console.log(`Loaded ${venues.length} venues (${activeCount} active, ${inactiveCount} inactive)`);
@@ -121,23 +131,79 @@ export function getVenueById(id) {
 }
 
 /**
- * Check if a venue is hosted by a KJ matching the given query.
- * Substring + case-insensitive. Matches on venue.host.name, venue.host.affiliation,
- * and per-show schedule[N].host.{name,affiliation} (for multi-host venues like
- * The Highball). Does NOT match venue name, city, tags, or event names — use
+ * Check if a venue is hosted by the KJ or company the query identifies.
+ *
+ * Two modes, in order:
+ *
+ *   1. **Registry id** — an exact match against `host.kjId` or `host.companyId`.
+ *      This is what `?kj=` carries now, and it identifies exactly one entity.
+ *   2. **Name substring** — the old behaviour, kept so links already shared or
+ *      indexed keep working.
+ *
+ * Mode 2 is why this needed fixing (#124 Phase 5). A substring cannot identify
+ * an entity: `?kj=armando` matched both "Armando" and "KJ Armando and Paola" —
+ * two different KJs on one dossier — and `?kj=karaoke` matched 23 venues across
+ * 13 distinct hosts, because most company names contain the word. A dossier is
+ * supposed to be one host's shows.
+ *
+ * Ids are checked first and exactly, so a registry id can never widen into a
+ * substring sweep.
+ *
+ * Does NOT match venue name, city, tags, or event names — use
  * venueMatchesSearch() for that.
  *
+ * `hostMatches` is exported so the dossier can filter individual schedule
+ * entries by the same rule. It used to substring-match them separately, which
+ * would show zero shows for a dossier reached by id.
+ *
  * @param {Object} venue - Venue object
- * @param {string} query - Host name or affiliation substring
- * @returns {boolean} True if any host field substring-matches
+ * @param {string} query - Registry id (preferred) or host-name substring
+ * @returns {boolean} True if the venue is hosted by that entity
  */
+export function hostMatches(host, query) {
+    if (!host) return false;
+    const q = (query || '').toLowerCase().trim();
+    if (!q) return true;
+
+    // An id query is answered by id alone. Falling through to the substring
+    // pass would undo the whole fix: `?kj=armando` is a valid KJ id, but the
+    // string "armando" is also inside "KJ Armando and Paola", so a venue hosted
+    // ONLY by the duo still matched. Verified against Feral Housewife Wine,
+    // whose single host is the duo (#124 Phase 5).
+    if (registryIds.has(q)) {
+        return host.kjId === q || host.companyId === q;
+    }
+
+    // Not an id — a legacy name link. Substring, as before.
+    return containsIgnoreCase(host.name, q) || containsIgnoreCase(host.affiliation, q);
+}
+
 export function venueMatchesHost(venue, query) {
     if (!query?.trim()) return true;
-    const q = query.toLowerCase().trim();
+    return getVenueHosts(venue).some(({ host }) => hostMatches(host, query));
+}
 
-    return getVenueHosts(venue).some(({ host }) =>
-        containsIgnoreCase(host.name, q) || containsIgnoreCase(host.affiliation, q)
-    );
+/**
+ * Resolve a `?kj=` value to a display label.
+ *
+ * A registry id is not a name — `?kj=kj-armando-and-paola` should title the page
+ * "KJ Armando and Paola", not echo the slug. Falls back to the query itself for
+ * legacy name links (#124 Phase 5).
+ *
+ * @param {string} query - Registry id or legacy name
+ * @returns {string} Display label
+ */
+export function resolveHostLabel(query) {
+    const q = (query || '').trim();
+    if (!q) return '';
+
+    for (const venue of getAllVenues()) {
+        for (const { host } of getVenueHosts(venue)) {
+            if (host.kjId === q && host.name) return host.name;
+            if (host.companyId === q && host.affiliation) return host.affiliation;
+        }
+    }
+    return q;
 }
 
 /**

--- a/js/views/KJDossierView.js
+++ b/js/views/KJDossierView.js
@@ -11,8 +11,8 @@
 
 import { Component } from '../components/Component.js';
 import { getState } from '../core/state.js';
-import { getAllVenues, venueMatchesHost } from '../services/venues.js';
-import { escapeHtml, containsIgnoreCase, getSortableName } from '../utils/string.js';
+import { getAllVenues, venueMatchesHost, hostMatches, resolveHostLabel } from '../services/venues.js';
+import { escapeHtml, getSortableName } from '../utils/string.js';
 import {
     formatScheduleEntry,
     parseLocalDate,
@@ -41,12 +41,15 @@ export class KJDossierView extends Component {
 
         const isNone = kjName.toLowerCase() === 'none';
         const matches = isNone ? this.getNoHostMatches() : this.getMatches(kjName);
+        // `?kj=` now carries a registry id, which is a slug, not a name. Resolve
+        // it back for display; legacy name links resolve to themselves (#124 P5).
+        const label = isNone ? '' : resolveHostLabel(kjName);
 
         if (matches.length === 0) {
             return `
                 <div class="kj-dossier">
                     <header class="kj-dossier__header">
-                        <h2 class="kj-dossier__title">${isNone ? 'Venues with no listed host' : `KJ: ${escapeHtml(kjName)}`}</h2>
+                        <h2 class="kj-dossier__title">${isNone ? 'Venues with no listed host' : `KJ: ${escapeHtml(label)}`}</h2>
                         <p class="kj-dossier__stats">No venues currently listed.</p>
                     </header>
                     ${!isNone ? `
@@ -68,7 +71,7 @@ export class KJDossierView extends Component {
 
         const title = isNone
             ? `<i class="fa-solid fa-circle-question"></i> Venues with no listed host`
-            : `<i class="fa-solid fa-microphone-lines"></i> KJ: ${escapeHtml(kjName)}`;
+            : `<i class="fa-solid fa-microphone-lines"></i> KJ: ${escapeHtml(label)}`;
 
         const hint = isNone
             ? 'These venues have no <code>host</code> field on the venue or on any schedule entry. If you host at one of these, contact the directory to get your attribution added.'
@@ -148,14 +151,12 @@ export class KJDossierView extends Component {
         const matches = getAllVenues()
             .filter(v => venueMatchesHost(v, kjName))
             .map(v => {
-                const kjEntries = (v.schedule || []).filter(e => {
-                    const eff = resolveHostFor(v, e);
-                    if (!eff) return false;
-                    return (
-                        containsIgnoreCase(eff.name, kjName) ||
-                        containsIgnoreCase(eff.affiliation, kjName)
-                    );
-                });
+                // Same predicate the venue filter uses. Substring-matching here
+                // separately meant a dossier reached by registry id matched the
+                // venue but none of its shows (#124 Phase 5).
+                const kjEntries = (v.schedule || []).filter(e =>
+                    hostMatches(resolveHostFor(v, e), kjName)
+                );
 
                 const recurring = kjEntries
                     .filter(e => e.frequency !== 'once')

--- a/js/views/KJIndexView.js
+++ b/js/views/KJIndexView.js
@@ -161,48 +161,55 @@ export class KJIndexView extends Component {
         const affiliations = new Map();
         const independents = new Map();
 
-        const addAffiliation = (rawAff, venueId) => {
+        // Group by registry id, falling back to the lowercased name for the
+        // legacy inline hosts the schema still accepts from submissions.
+        //
+        // The name was the key for both before #124 Phase 5, which is how
+        // "Armando" and "KJ Armando and Paola" ended up sharing a dossier: the
+        // link carried a name, and a name is matched by substring. An id is
+        // matched exactly, so the link means one entity.
+        const addAffiliation = (rawAff, companyId, venueId) => {
             const aff = (rawAff || '').trim();
             if (!aff) return null;
-            const key = aff.toLowerCase();
+            const key = companyId || aff.toLowerCase();
             if (!affiliations.has(key)) {
-                affiliations.set(key, { name: aff, venueIds: new Set(), kjs: new Map() });
+                affiliations.set(key, { id: companyId || null, name: aff, venueIds: new Set(), kjs: new Map() });
             }
             const entry = affiliations.get(key);
             entry.venueIds.add(venueId);
             return entry;
         };
 
-        const addKJUnder = (affEntry, rawName, venueId) => {
+        const addKJUnder = (affEntry, rawName, kjId, venueId) => {
             const name = (rawName || '').trim();
             if (!name) return;
-            const key = name.toLowerCase();
+            const key = kjId || name.toLowerCase();
             if (!affEntry.kjs.has(key)) {
-                affEntry.kjs.set(key, { name, venueIds: new Set() });
+                affEntry.kjs.set(key, { id: kjId || null, name, venueIds: new Set() });
             }
             affEntry.kjs.get(key).venueIds.add(venueId);
         };
 
-        const addIndependent = (rawName, venueId) => {
+        const addIndependent = (rawName, kjId, venueId) => {
             const name = (rawName || '').trim();
             if (!name) return;
-            const key = name.toLowerCase();
+            const key = kjId || name.toLowerCase();
             if (!independents.has(key)) {
-                independents.set(key, { name, venueIds: new Set() });
+                independents.set(key, { id: kjId || null, name, venueIds: new Set() });
             }
             independents.get(key).venueIds.add(venueId);
         };
 
         const processHost = (host, venueId) => {
             if (!host) return false;
-            const affEntry = addAffiliation(host.affiliation, venueId);
+            const affEntry = addAffiliation(host.affiliation, host.companyId, venueId);
             if (affEntry) {
-                addKJUnder(affEntry, host.name, venueId);
+                addKJUnder(affEntry, host.name, host.kjId, venueId);
                 return true;
             }
             const nm = (host.name || '').trim();
             if (!nm) return false;
-            addIndependent(host.name, venueId);
+            addIndependent(host.name, host.kjId, venueId);
             return true;
         };
 
@@ -223,23 +230,26 @@ export class KJIndexView extends Component {
 
         const affiliationList = [...affiliations.values()]
             .map(a => ({
+                id: a.id,
                 name: a.name,
                 venueCount: a.venueIds.size,
                 kjs: [...a.kjs.values()]
-                    .map(k => ({ name: k.name, venueCount: k.venueIds.size }))
+                    .map(k => ({ id: k.id, name: k.name, venueCount: k.venueIds.size }))
                     .sort(sortByName),
             }))
             .sort(sortByName);
 
         const independentList = [...independents.values()]
-            .map(k => ({ name: k.name, venueCount: k.venueIds.size }))
+            .map(k => ({ id: k.id, name: k.name, venueCount: k.venueIds.size }))
             .sort(sortByName);
 
         return { affiliations: affiliationList, independents: independentList, noHostCount };
     }
 
-    renderAffiliation({ name, venueCount, kjs }) {
-        const href = `?kj=${encodeURIComponent(name)}`;
+    renderAffiliation({ id, name, venueCount, kjs }) {
+        // Prefer the registry id: it identifies one entity exactly. Falls back
+        // to the name for legacy inline hosts, which have no id (#124 Phase 5).
+        const href = `?kj=${encodeURIComponent(id || name)}`;
         const subList = kjs.length > 0
             ? `
                 <ul class="kj-index__sublist">
@@ -258,8 +268,10 @@ export class KJIndexView extends Component {
         `;
     }
 
-    renderKjUnderAffiliation({ name, venueCount }) {
-        const href = `?kj=${encodeURIComponent(name)}`;
+    renderKjUnderAffiliation({ id, name, venueCount }) {
+        // Prefer the registry id: it identifies one entity exactly. Falls back
+        // to the name for legacy inline hosts, which have no id (#124 Phase 5).
+        const href = `?kj=${encodeURIComponent(id || name)}`;
         return `
             <li class="kj-index__subitem" data-search="${escapeHtml(name.toLowerCase())}">
                 <a class="kj-index__link kj-index__link--kj" href="${href}">
@@ -270,8 +282,10 @@ export class KJIndexView extends Component {
         `;
     }
 
-    renderIndependent({ name, venueCount }) {
-        const href = `?kj=${encodeURIComponent(name)}`;
+    renderIndependent({ id, name, venueCount }) {
+        // Prefer the registry id: it identifies one entity exactly. Falls back
+        // to the name for legacy inline hosts, which have no id (#124 Phase 5).
+        const href = `?kj=${encodeURIComponent(id || name)}`;
         return `
             <li class="kj-index__item" data-search="${escapeHtml(name.toLowerCase())}">
                 <a class="kj-index__link" href="${href}">

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -245,6 +245,28 @@ for (const [id, count] of Object.entries(idCounts)) {
     if (count > 1) issues.push(`Duplicate ID: ${id} (${count} times)`);
 }
 
+// ---- Committed data is refs-only (#124 Phase 5) ----
+// The schema accepts BOTH host shapes on purpose: the inline form is the submit
+// form's intake contract, carrying a KJ or company we don't have a registry
+// entry for yet (ADR-007 amendment). That tolerance is for submissions, not for
+// this file — js/data.json should be all refs, or identity goes back to being a
+// string and `?kj=` goes back to substring matching.
+//
+// A hard failure, because there is no case where a committed inline host is
+// right: the curator creates the registry entry as part of accepting the
+// submission.
+for (const venue of data.listings) {
+    const check = (host, where) => {
+        if (!host) return;
+        if (host.kjId || host.companyId) return;
+        const named = host.name || host.affiliation || '(unnamed)';
+        fail(venue, `${where} is an inline host ("${named}") — js/data.json is ` +
+            'refs-only. Add the KJ/company to the registry and reference it by id.');
+    };
+    check(venue.host, 'host');
+    (venue.schedule || []).forEach((entry, i) => check(entry.host, `schedule[${i}].host`));
+}
+
 // ---- Registry hygiene (warnings — bad smells, not broken data) ----
 // An unreferenced entry is dead weight; two entries with the same name are the
 // duplication ADR-007 exists to remove, creeping back in.

--- a/test/venues.test.mjs
+++ b/test/venues.test.mjs
@@ -11,7 +11,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { venuePasses, venueMatchesSearch, venueMatchesHost, byName } from '../js/services/venues.js';
+import { venuePasses, venueMatchesSearch, venueMatchesHost, byName, initVenues, hostMatches, resolveHostLabel } from '../js/services/venues.js';
 import { hydrateVenues, isHostRef, resolveHostRef } from '../js/utils/hosts.js';
 
 const JAN = (d) => new Date(2026, 0, d);
@@ -118,14 +118,75 @@ describe('venueMatchesHost', () => {
     assert.equal(venueMatchesHost(venue(), ''), true);
   });
 
-  it('matches on SUBSTRING, so distinct KJs collide', () => {
-    // Not an endorsement — this is the live defect behind the ?kj= identity
-    // work (#124 Phase 5, #171). A query of "Joe" matches "Average Joe" and
-    // would equally match any other Joe. When ?kj= moves to registry ids this
-    // test should be replaced by an exact-id assertion.
+  it('still substring-matches a NAME, for links that predate ids', () => {
+    // Legacy behaviour, kept deliberately so shared and indexed ?kj=<name>
+    // links keep working. No link the app renders produces one any more.
     const v = venue({ host: { name: 'Average Joe' } });
     assert.equal(venueMatchesHost(v, 'Joe'), true);
     assert.equal(venueMatchesHost(v, 'ave'), true);
+  });
+});
+
+describe('venueMatchesHost — registry ids (#124 Phase 5)', () => {
+  // The collision this closes: "Armando" is a substring of "KJ Armando and
+  // Paola", so a dossier for one showed venues belonging to the other. Ids are
+  // matched exactly; names are not.
+  const DATA = {
+    kjs: {
+      'armando': { name: 'Armando' },
+      'kj-armando-and-paola': { name: 'KJ Armando and Paola' },
+    },
+    companies: {
+      'starling-karaoke': { name: 'Starling Karaoke' },
+    },
+    listings: [
+      { id: 'solo-bar', name: 'Solo Bar', address: {}, schedule: [],
+        host: { kjId: 'armando' } },
+      { id: 'duo-bar', name: 'Duo Bar', address: {}, schedule: [],
+        host: { kjId: 'kj-armando-and-paola' } },
+      { id: 'company-bar', name: 'Company Bar', address: {}, schedule: [],
+        host: { companyId: 'starling-karaoke' } },
+    ],
+  };
+
+  it('an id matches only its own entity', () => {
+    initVenues(structuredClone(DATA));
+    const solo = { ...DATA.listings[0] };
+    const duo = { ...DATA.listings[1] };
+    assert.equal(venueMatchesHost(solo, 'armando'), true);
+    assert.equal(venueMatchesHost(duo, 'armando'), false,
+      'the duo must NOT appear under the solo KJ');
+    assert.equal(venueMatchesHost(duo, 'kj-armando-and-paola'), true);
+    assert.equal(venueMatchesHost(solo, 'kj-armando-and-paola'), false);
+  });
+
+  it('an id query never falls back to substring matching', () => {
+    // This is the subtle half. "armando" IS a valid id, and it is also a
+    // substring of the duo's name — so a fallback pass would re-open the
+    // collision the id was meant to close.
+    initVenues(structuredClone(DATA));
+    assert.equal(hostMatches({ kjId: 'kj-armando-and-paola', name: 'KJ Armando and Paola' }, 'armando'),
+      false);
+  });
+
+  it('company ids work the same way', () => {
+    initVenues(structuredClone(DATA));
+    assert.equal(hostMatches({ companyId: 'starling-karaoke', affiliation: 'Starling Karaoke' }, 'starling-karaoke'), true);
+    assert.equal(hostMatches({ kjId: 'armando', name: 'Armando' }, 'starling-karaoke'), false);
+  });
+
+  it('a non-id query still substring-matches, so old links survive', () => {
+    initVenues(structuredClone(DATA));
+    // "Paola" is nobody's id, so it behaves as a name query.
+    assert.equal(hostMatches({ kjId: 'kj-armando-and-paola', name: 'KJ Armando and Paola' }, 'Paola'), true);
+  });
+
+  it('resolveHostLabel turns an id back into a display name', () => {
+    initVenues(structuredClone(DATA));
+    assert.equal(resolveHostLabel('kj-armando-and-paola'), 'KJ Armando and Paola');
+    assert.equal(resolveHostLabel('starling-karaoke'), 'Starling Karaoke');
+    // A legacy name link resolves to itself rather than an empty title.
+    assert.equal(resolveHostLabel('Some Old Name'), 'Some Old Name');
   });
 });
 


### PR DESCRIPTION
Closes #124 — Phase 5, the last one. Phases 1–4 shipped in #130 / #141 / #143.

## The bug, measured

A substring cannot identify an entity, and `?kj=` was matching by one:

```
?kj=armando    3 venues,  2 distinct KJs   (Armando AND KJ Armando and Paola)
?kj=karaoke   23 venues, 13 distinct hosts (most company names contain the word)
```

A dossier is supposed to be one host's shows.

## The fix

`KJIndexView` groups by `kjId`/`companyId` — falling back to the lowercased name only for the inline hosts the schema still accepts from submissions — and all **41** of its links now carry an id. `venueMatchesHost` resolves an id exactly.

### The subtle half, and how I caught it

**An id query must not fall through to the substring pass.**

After the first pass everything looked right — until I checked Feral Housewife Wine directly. Its *only* host is `kj-armando-and-paola`, yet it still appeared under `?kj=armando`: the id didn't match, so the code fell through to substring, and "armando" is inside "KJ Armando and Paola". The dossier said 3 venues when 2 were his.

The service now keeps the set of known registry ids and answers an id query **by id alone**:

```
?kj=armando               → 2 venues   (was 3, across 2 KJs)
?kj=kj-armando-and-paola  → 1 venue
?kj=starling-karaoke      → 4 venues, titled "Starling Karaoke"
?kj=Armando  (legacy)     → still resolves
```

Name substring matching is retained for values that *aren't* ids, so links shared or indexed before this keep working. `?kj=karaoke` therefore still sweeps — **by design**, and no link the app renders produces one.

`hostMatches()` is exported and used by the dossier's per-entry filter too. It substring-matched entries separately, which would have made a dossier reached by id match the venue but show none of its shows.

The title and nav chip resolve an id back to a name, so a visitor sees "KJ: Xpider Cantu", not the slug.

## ADR-007 amended: the dual shape is permanent

Phase 5 originally scoped *"drop legacy inline-host support once curator and form are migrated"*. Both are migrated. **It's staying**, and the ADR now says why.

Phase 3 built the submit form to emit a ref when a typed name matches the registry and the inline shape when it doesn't. That fallback carries the most valuable submissions — the ones telling us about a host we don't have. Dropping inline support means rejecting them.

| Shape | Legal where | Why |
|---|---|---|
| `{ kjId?, companyId? }` | `js/data.json` | committed data is all refs; identity is exact |
| `{ name?, affiliation?, … }` | submission intake | a submitter can't know registry ids |

## Two smaller Phase 5 items

**`validate-data.js` now fails on an inline host in `js/data.json`.** The schema tolerance is for intake; the committed file stays refs-only, or identity goes back to being a string. Verified against a planted inline host:

```
- Sociedad (sociedad): host is an inline host ("Some New KJ") — js/data.json is
  refs-only. Add the KJ/company to the registry and reference it by id.
```

**Supabase seed pipeline: deferred, explicitly.** ADR-009 parked Supabase and moved the scaffolding to `_deprecated/`. Updating a seed script for a runtime that doesn't exist maintains two data models for nothing. Recorded in the amendment, with ADR-009's re-entry trigger as the revisit point.

## Tests

A unit test asserted the substring collision as *current behaviour*, with a note that it should become an exact-id assertion when `?kj=` moved to ids. Done — plus new tests for the no-fallback rule (the bug above), company ids, legacy name links, and label resolution.

| Gate | Result |
|---|---|
| `npm run test:unit` | **159 passed** |
| `npm test` (e2e, `--workers=1`) | **74 passed** |
| `npm run validate:all` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
