### PR TITLE
#206: Render the venues an extended section counts, not the ones it hid

### DIFF
--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -104,7 +104,7 @@ It also **excludes one-time events whose date has passed**, for the same reason 
 
 When viewing the current week, the page scrolls to today's day card after render using `scrollIntoView({ behavior: 'instant', block: 'start' })`.
 
-> **Implementation note:** WeeklyView creates day cards via `renderDayCard()` — a template helper that instantiates a temporary DayCard, calls `template()`, and returns an HTML string (no persistent component instance). Extended sections use `renderExtendedSection()` with a shared `seenVenues` Set passed across all three sections for deduplication. Auto-scroll to today runs in `afterRender()`. See [Architecture: Component Hierarchy](architecture.md#2-component-hierarchy) for the template helper pattern.
+> **Implementation note:** WeeklyView creates day cards via `renderDayCard(date, venueIds?)` — a template helper that instantiates a temporary DayCard, calls `template()`, and returns an HTML string (no persistent component instance). The optional second argument narrows the card to a given set of venue ids; the primary week omits it. Extended sections use `renderExtendedSection()` with a shared `seenVenues` Set passed across all three sections for deduplication, and hand the resulting ids to each card so the rendered venues match the section's own count (#206). Auto-scroll to today runs in `afterRender()`. See [Architecture: Component Hierarchy](architecture.md#2-component-hierarchy) for the template helper pattern.
 
 ### Filtering
 
@@ -144,11 +144,34 @@ Below the current 7-day week, three additional collapsible sections display venu
 
 This prevents the same weekly-recurring venue from appearing multiple times across sections.
 
+> **A section renders exactly the venues it counts.** The header badge, the
+> dedup notice and the cards are three statements about one set, and they must
+> agree. `ExtendedSection` passes the deduplicated venue ids into
+> `renderDayCard(date, venueIds)`; `DayCard` narrows its events to that set.
+>
+> This is stated because it did not hold (#206). The dedup was computed, used
+> to write the badge and the notice, and then discarded — `renderDayCard(date)`
+> took only the date and re-derived the full day. On 2026-08-05 the "Later in
+> August" section read **"1 venue"** above a notice reading **"Plus 67
+> recurring venues already shown above"** above a card listing **17 venues**,
+> 16 of them from the 67 it had just placed elsewhere. Display Principle #5
+> ("Balance Visibility, Don't Overwhelm") had no effect at all: the
+> less-frequent shows the section exists to surface stayed buried under the
+> nightly regulars.
+>
+> Passing the id set is unconditional, including for "Next Week" where
+> `deduplicate: false` makes it every venue that day. A no-op filter is
+> cheaper than a branch, and the invariant then holds without exception.
+
 #### Implementation
 
 - Component: `ExtendedSection` (`js/components/ExtendedSection.js`)
 - CSS classes: `.extended-section`, `.extended-section__header`, `.extended-section__content`, `.extended-section--collapsed`, `.extended-section__dedup-notice`
 - WeeklyView method: `renderExtendedSections()`
+- `DayCard` accepts an optional `props.venueIds` (`Set<string>`); when absent it
+  renders every venue scheduled that day, which is what the primary week wants
+- Pinned by e2e: a section's badge equals its unique rendered venues, and a
+  deduplicating section repeats nothing shown above it
 
 ---
 
@@ -1491,6 +1514,7 @@ Two buttons, **Decline** and **Accept**, handled by one delegated listener readi
 | 2026-07 | 1.0.27 | #124 Phase 3: submit form's host fields suggest known KJs/companies from the registries and emit a `{kjId, companyId}` ref when both sides match, falling back to the inline shape otherwise. Email body gains a HOST section saying which it was. Updated Section 15. | Claude Code |
 | 2026-08 | 1.0.28 | #154: Documented the analytics consent banner as new **Section 23**; Known Discrepancies and Change Log renumbered 23→24 and 24→25. Header version/date corrected — it had read "1.0 / February 2026" since creation while this log ran to 1.0.27. Section 20 corrected: `escapeHtml()` no longer uses the DOM `textContent` technique (#147 — it did not escape quotes) and venue data is a JSON file, not a JS file. Drift-prone prose venue counts removed from Sections 1 and 11. | Claude Code |
 | 2026-08 | 1.0.29 | #164: Every show on a generated entity page is now a `MusicEvent` in the page's JSON-LD `@graph` — 132 events, shared by `@id` across venue/KJ/company pages. Recurring shows use `eventSchedule` rather than materialised dates so they cannot rot between deploys; times carry real DST-aware offsets. New "Event markup" subsection in Section 22. #163: page background re-encoded to WebP at viewport width (810 KB → 105 KB) and moved to `assets/images/`; `bday.html` deleted with a 301, taking the public page count from 5 to 4; `og:image:alt` on generated pages stopped advertising the neighborhood field #170 removed. | Claude Code |
+| 2026-08 | 1.0.30 | #206: An extended section now renders exactly the venues its header counts. The deduplicated list was computed, used to write the badge and the "plus N already shown above" notice, then discarded — `renderDayCard(date)` re-derived the full day — so "Later in August: 1 venue / plus 67 above" rendered 17 venues, 16 of them from that 67. `DayCard` gains an optional `venueIds` prop. Display Principle #5 now takes effect. Updated Section 2. #23 closed as wontfix in the same pass. | Claude Code |
 
 ---
 

--- a/e2e/weekly-view.spec.js
+++ b/e2e/weekly-view.spec.js
@@ -100,4 +100,72 @@ test.describe('Weekly view — calendar behavior', () => {
     await expect(section).not.toHaveClass(/extended-section--collapsed/);
   });
 
+  /*
+   * #206. An extended section's header count, its "plus N already shown above"
+   * notice, and the venues in its cards are three statements about one thing,
+   * and they used to disagree: the dedup was computed, used to write the first
+   * two, then discarded because renderDayCard(date) re-derived the full day.
+   * A section reading "1 venue / plus 67 already shown above" rendered 17.
+   *
+   * These assert the agreement rather than any particular number, so they hold
+   * as the dataset changes.
+   */
+  test('every extended section renders exactly the venue count it advertises', async ({ page }) => {
+    const sections = page.locator('.extended-section');
+    const n = await sections.count();
+    expect(n).toBeGreaterThan(0);
+
+    for (let i = 0; i < n; i++) {
+      const section = sections.nth(i);
+      const title = (await section.locator('.extended-section__title').textContent())?.trim();
+      const advertised = parseInt(
+        (await section.locator('.extended-section__count').textContent()) || '', 10);
+
+      const names = await section.locator('.venue-card__link').allTextContents();
+      const rendered = new Set(names.map((s) => s.trim()));
+
+      expect(rendered.size, `${title}: header says ${advertised}`).toBe(advertised);
+    }
+  });
+
+  test('a deduplicating section never repeats a venue shown above it', async ({ page }) => {
+    // "Next Week" is exempt by design — WeeklyView passes deduplicate:false so
+    // it shows the whole week. The dedup notice is what marks the others.
+    const seen = new Set(
+      (await page.locator('.weekly-view > .weekly-view__grid .venue-card__link').allTextContents())
+        .map((s) => s.trim()));
+
+    const sections = page.locator('.extended-section');
+    for (let i = 0; i < await sections.count(); i++) {
+      const section = sections.nth(i);
+      const title = (await section.locator('.extended-section__title').textContent())?.trim();
+      const names = (await section.locator('.venue-card__link').allTextContents()).map((s) => s.trim());
+      const dedupes = await section.locator('.extended-section__dedup-notice').count() > 0;
+
+      if (dedupes) {
+        const repeats = [...new Set(names)].filter((v) => seen.has(v));
+        expect(repeats, `${title} repeats venues its notice says are above`).toEqual([]);
+      }
+      names.forEach((v) => seen.add(v));
+    }
+  });
+
+  test('the day-card footer count matches the cards the day actually shows', async ({ page }) => {
+    // The footer counts unique OPEN venues, so a card whose only event is
+    // excluded that day is deliberately not counted. Assert footer <= unique
+    // rendered, and equal whenever nothing is closed.
+    const cards = page.locator('.extended-section .day-card');
+    for (let i = 0; i < await cards.count(); i++) {
+      const card = cards.nth(i);
+      const footer = await card.locator('.day-card__count').textContent();
+      if (!footer) continue;
+      const stated = parseInt(footer, 10);
+      const names = (await card.locator('.venue-card__link').allTextContents()).map((s) => s.trim());
+      const closed = await card.locator('.venue-card--excluded').count();
+      const unique = new Set(names).size;
+      expect(stated).toBeLessThanOrEqual(unique);
+      if (closed === 0) expect(stated).toBe(unique);
+    }
+  });
+
 });

--- a/js/components/DayCard.js
+++ b/js/components/DayCard.js
@@ -35,15 +35,26 @@ export class DayCard extends Component {
      * @param {HTMLElement|string} container
      * @param {Object} props
      * @param {Date} props.date - Date for this day
+     * @param {Set<string>} [props.venueIds] - Render only these venue ids.
+     *   Extended sections pass the deduplicated set they counted, so the card
+     *   shows exactly what its header claims. Omit for the primary week, which
+     *   shows everything (#206).
      */
 
     template() {
-        const { date } = this.props;
+        const { date, venueIds = null } = this.props;
         const showDedicated = getState('showDedicated');
         const searchQuery = getState('searchQuery');
         // One entry per matching schedule entry, so a venue with two events
         // on the same day renders two cards (each with its own event title/time).
-        const events = getVenueEventsForDate(date, { includeDedicated: showDedicated, searchQuery });
+        //
+        // The venueIds narrowing exists because this component used to be the
+        // only thing deciding what a day contains. ExtendedSection computed a
+        // deduplicated list, wrote its header and notice from it, then called
+        // renderDayCard(date) — which re-derived the full list here and rendered
+        // that instead, so header, notice and body all disagreed (#206).
+        const allEvents = getVenueEventsForDate(date, { includeDedicated: showDedicated, searchQuery });
+        const events = venueIds ? allEvents.filter(e => venueIds.has(e.venue.id)) : allEvents;
         // Footer count is unique venues that are actually open — exclude
         // venues whose only event today is suppressed by an exclusion.
         const openVenueIds = new Set(
@@ -127,10 +138,12 @@ export class DayCard extends Component {
 /**
  * Render a day card without component instance
  * @param {Date} date - Date to render
+ * @param {Set<string>} [venueIds] - Restrict to these venue ids (see the class
+ *   doc). Omit to render every venue scheduled that day.
  * @returns {string} HTML string
  */
-export function renderDayCard(date) {
+export function renderDayCard(date, venueIds = null) {
     const container = document.createElement('div');
-    const card = new DayCard(container, { date });
+    const card = new DayCard(container, { date, venueIds });
     return card.template();
 }

--- a/js/components/ExtendedSection.js
+++ b/js/components/ExtendedSection.js
@@ -157,11 +157,20 @@ export function renderExtendedSection({ title, startDate, endDate, seenVenues, d
         venues.forEach(v => seenVenues.add(v.id));
     });
 
-    // Render day cards for dates with venues
+    // Render day cards for exactly the venues this section counted.
+    //
+    // The venue list is handed to the card rather than dropped. Passing only
+    // the date let DayCard re-derive the full, undeduplicated day, so a section
+    // headed "1 venue" with a "plus 67 already shown above" notice rendered 17
+    // venues — 16 of them from the 67 it had just said were elsewhere (#206).
+    //
+    // Passed unconditionally, including when deduplicate is false: there the
+    // set is every venue that day, so the filter is a no-op and the invariant
+    // "a section renders what it counted" holds without a branch.
     const dayCardsHtml = Array.from(venuesByDate.values())
-        .map(({ date }) => `
+        .map(({ date, venues }) => `
             <div class="weekly-view__day">
-                ${renderDayCard(date)}
+                ${renderDayCard(date, new Set(venues.map(v => v.id)))}
             </div>
         `)
         .join('');


### PR DESCRIPTION
Closes #206.

## What the page said before

> ### Later in August · **1 venue**
> ⓘ *Plus **67** recurring venues already shown above*
> …card listing **17 venues**, 16 of them from that 67

Three statements about one set, all disagreeing. `ExtendedSection` computed the deduplicated list, used it to write the badge and the notice, then dropped it:

```js
Array.from(venuesByDate.values())
    .map(({ date }) => `…${renderDayCard(date)}…`)
```

It destructured only `date`. `renderDayCard(date)` built a `DayCard` whose `template()` called `getVenueEventsForDate(date, …)` for itself — re-deriving the full, undeduplicated day. **The dedup never reached the DOM.**

So Display Principle #5 ("Balance Visibility, Don't Overwhelm") had no effect whatsoever: the less-frequent shows the section exists to surface were still buried under the nightly regulars, exactly as if the feature had never been written.

## The fix

`DayCard` gains an optional `props.venueIds` (`Set<string>`); `renderDayCard(date, venueIds?)` passes it through. The card narrows its events to that set. The primary week omits the argument and renders everything, as before.

The set is passed **unconditionally**, including for "Next Week" where `deduplicate: false` makes it every venue that day. A no-op filter is cheaper than a branch, and the invariant *"a section renders what it counted"* then holds without exception.

This works because `getVenuesForDate` is derived from `getVenueEventsForDate` (#117) — the two agree by construction, so filtering events by the counted venue ids reproduces the counted set exactly rather than approximating it.

## After

| Section | Badge | Unique rendered | Agrees | Repeated from above |
|---|---|---|---|---|
| Next Week | 63 | 63 | ✅ | 61 — *by design, `deduplicate: false`* |
| Later in August | 1 | 1 | ✅ | **0** |
| September | 2 | 2 | ✅ | **0** |

"Later in August" now shows what it was built to show — one starred one-time event (Austin Deaf Club, "Rainbow Party: Colors of Love") instead of that event buried under 16 nightly regulars. Badge, card, footer count and notice all agree.

Verified under search too, since `ExtendedSection` and `DayCard` read `searchQuery` independently:

```
search="lgbtq"                 3/3, 1/1, 1/1   agree, 0 repeats
search="karaoke underground"   1/1             agree, 0 repeats
no search                      63/63, 1/1, 2/2 agree, 0 repeats
```

## Tests

Three e2e cases, asserting the *agreement* rather than any particular number so they survive dataset churn:

- a section's badge equals its unique rendered venues
- a deduplicating section repeats nothing shown above it
- a day-card footer count matches the cards that day shows (≤ when something is closed, since the footer counts open venues)

**Confirmed against the planted original bug** — reverting the one-line change to `renderDayCard(date)` fails exactly the first two:

```
2 failed
8 passed
```

The third passes either way; it guards a different invariant (the footer is computed from what `DayCard` itself renders, so it was always self-consistent). Keeping it because nothing else covered it, but it is not what catches #206.

## Also

`#23` was closed as `wontfix` in the same pass. It proposed a jump-to-week button partly so users could reach the "full" view of a deep-section day — but those cards were *already* showing everything, which was this bug. Its other premise, that "Next Week" leaves you re-reading the same content, is true and unaffected: `deduplicate: false` is deliberate there.

**Spotted but deliberately not fixed here:** the Austin Deaf Club card renders the "Special Event" badge twice — `js/data.json` stores `special-event` in that venue's `tags` while `VenueCard.js:84` also injects it for `once` entries. It is the only venue in the dataset that does. Out of scope; flagged separately.

| Gate | Result |
|---|---|
| `npm run test:unit` | **189 passed** |
| `npm test` (e2e, `--workers=1`) | **77 passed** (+3) |
| `npm run validate:all` | clean |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
