### PR TITLE
#208: Deduplicate tags so a derived one cannot render twice

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -358,9 +358,11 @@ Available tags:
 | `games` | Games | Arcade, bowling, entertainment center |
 | `craft-cocktails` | Craft Cocktails | Upscale craft cocktail bar |
 | `neighborhood` | Neighborhood Bar | Casual neighborhood bar |
-| `special-event` | Special Event | One-time special karaoke events |
+| `special-event` | Special Event | One-time special karaoke events (auto-added on cards for `frequency: "once"` entries) |
 
-Tags are rendered as color-coded badges in VenueCard, VenueModal, and VenueDetailPane components using the `renderTags()` function from `js/utils/tags.js`.
+Tags are rendered as color-coded badges in VenueCard, VenueModal, VenueDetailPane and MapView using the `renderTags()` function from `js/utils/tags.js`.
+
+**`dedicated` and `special-event` are derived, not stored.** `renderTags()` prepends the first when `venue.dedicated` is true; `VenueCard` prepends the second when the entry it is rendering is `frequency: "once"`. `renderTags()` deduplicates the result, so listing either in a venue's `tags` no longer renders the badge twice (#208) — but it is still redundant, and `validate-data.js` warns about it.
 
 ## Key Technical Patterns
 

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -830,9 +830,21 @@ Tags are defined in the `tagDefinitions` object in `js/data.json`. Each tag has:
 ### Rendering
 
 Tags render as color-coded inline badges using `renderTags(tags, options)` from `js/utils/tags.js`.
-- CSS classes: `.venue-tags` (container), `.venue-tag` (individual badge)
-- The `dedicated` tag is auto-prepended when `venue.dedicated === true`, even if not in the `tags` array
-- The `special-event` tag is injected in compact venue cards for `frequency: "once"` events
+- CSS classes: `.venue-tags` (container), `.tag` (individual badge, carrying `data-tag="<id>"`). *(This line read `.venue-tag` until #208; that class was replaced during #166 and exists only in a comment.)*
+- Colours come from `tagDefinitions` in `js/data.json` and are painted into one generated stylesheet keyed on `[data-tag]`, not inline styles
+
+#### Derived tags
+
+Two tags are **derived at render time** rather than stored, each prepended by whichever module knows the condition:
+
+| Tag | Prepended by | When |
+|---|---|---|
+| `dedicated` | `renderTags()` | `venue.dedicated === true` |
+| `special-event` | `VenueCard` (compact card) | the entry being rendered is `frequency: "once"` |
+
+**`renderTags()` deduplicates the final list**, first occurrence winning, so a derived tag keeps its leading position. Neither prepend can see whether the venue *also* lists that id in its own `tags`, and one did: `austin-deaf-club` stored `special-event` while its only show is a `once` entry, so its card rendered `Special Event · LGBTQ+ · Special Event` (#208). The equivalent `dedicated` collision was latent — no venue sets the flag and lists the tag, but nothing prevented it.
+
+Storing a derived tag is redundant rather than harmful now. `validate-data.js` **warns** (does not fail) when a venue does, since whether "hosts one-time events" also belongs on the venue is an editorial call and `js/data.json` is curator-owned.
 
 ### Searchability
 
@@ -1515,6 +1527,7 @@ Two buttons, **Decline** and **Accept**, handled by one delegated listener readi
 | 2026-08 | 1.0.28 | #154: Documented the analytics consent banner as new **Section 23**; Known Discrepancies and Change Log renumbered 23→24 and 24→25. Header version/date corrected — it had read "1.0 / February 2026" since creation while this log ran to 1.0.27. Section 20 corrected: `escapeHtml()` no longer uses the DOM `textContent` technique (#147 — it did not escape quotes) and venue data is a JSON file, not a JS file. Drift-prone prose venue counts removed from Sections 1 and 11. | Claude Code |
 | 2026-08 | 1.0.29 | #164: Every show on a generated entity page is now a `MusicEvent` in the page's JSON-LD `@graph` — 132 events, shared by `@id` across venue/KJ/company pages. Recurring shows use `eventSchedule` rather than materialised dates so they cannot rot between deploys; times carry real DST-aware offsets. New "Event markup" subsection in Section 22. #163: page background re-encoded to WebP at viewport width (810 KB → 105 KB) and moved to `assets/images/`; `bday.html` deleted with a 301, taking the public page count from 5 to 4; `og:image:alt` on generated pages stopped advertising the neighborhood field #170 removed. | Claude Code |
 | 2026-08 | 1.0.30 | #206: An extended section now renders exactly the venues its header counts. The deduplicated list was computed, used to write the badge and the "plus N already shown above" notice, then discarded — `renderDayCard(date)` re-derived the full day — so "Later in August: 1 venue / plus 67 above" rendered 17 venues, 16 of them from that 67. `DayCard` gains an optional `venueIds` prop. Display Principle #5 now takes effect. Updated Section 2. #23 closed as wontfix in the same pass. | Claude Code |
+| 2026-08 | 1.0.31 | #208: `renderTags()` deduplicates, so a tag renders at most once per card. `dedicated` and `special-event` are derived at render time and prepended by different modules; neither could see a stored copy, and `austin-deaf-club` had one — its card read "Special Event · LGBTQ+ · Special Event". The `dedicated` equivalent was latent. `validate-data.js` now warns when a venue stores a derived tag. Section 12 gains a "Derived tags" subsection; its badge class corrected from `.venue-tag` to `.tag`. | Claude Code |
 
 ---
 

--- a/js/utils/tags.js
+++ b/js/utils/tags.js
@@ -87,7 +87,22 @@ export function renderTagBadge(tagId, { href } = {}) {
 }
 
 /**
- * Render tags as HTML badges
+ * Render tags as HTML badges.
+ *
+ * Two tags are **derived** rather than stored, and are prepended by whoever
+ * knows the condition: `dedicated` here, and `special-event` by VenueCard when
+ * the entry it is rendering is a one-time show. Neither prepend can know
+ * whether the venue also lists that tag in its own `tags`, so the list is
+ * deduplicated here — the one funnel every surface renders through.
+ *
+ * Without it, `austin-deaf-club` — which stores `special-event` and whose only
+ * show is a `once` entry — rendered `Special Event · LGBTQ+ · Special Event`
+ * (#208). The equivalent `dedicated` collision was latent: no venue sets
+ * `dedicated: true` *and* lists `dedicated`, but nothing prevented it.
+ *
+ * Order is preserved, first occurrence wins, so a derived tag keeps the
+ * leading position it already rendered in.
+ *
  * @param {string[]} tags - Array of tag IDs
  * @param {Object} options - Render options
  * @param {boolean} options.dedicated - Whether to include the dedicated tag
@@ -97,7 +112,7 @@ export function renderTags(tags, options = {}) {
     const { dedicated = false } = options;
 
     // Build the full tag list, prepending 'dedicated' if applicable
-    const allTags = dedicated ? ['dedicated', ...(tags || [])] : (tags || []);
+    const allTags = [...new Set(dedicated ? ['dedicated', ...(tags || [])] : (tags || []))];
 
     if (allTags.length === 0) return '';
 

--- a/scripts/validate-data.js
+++ b/scripts/validate-data.js
@@ -346,6 +346,32 @@ for (const venue of data.listings) {
     }
 }
 
+// ---- Derived tags stored on the venue ----
+//
+// `dedicated` and `special-event` are DERIVED at render time — the first from
+// the `dedicated` flag, the second from a schedule entry being `frequency:
+// "once"`. Storing either in `tags` is redundant, and it used to render the
+// badge twice (#208). renderTags now deduplicates, so this is a tidiness
+// warning rather than a correctness one.
+//
+// Warned, not failed: whether "hosts one-time events" belongs on the venue as
+// well as the event is an editorial call, and js/data.json is curator-owned.
+const DERIVED_TAGS = {
+    'special-event': 'derived from a schedule entry with frequency "once"',
+    dedicated: 'derived from the venue\'s `dedicated` flag',
+};
+
+for (const venue of data.listings) {
+    for (const tag of venue.tags || []) {
+        if (!DERIVED_TAGS[tag]) continue;
+        if (tag === 'dedicated' && !venue.dedicated) continue;   // stored but not derived: not a duplicate
+        warnings.push(
+            `${venue.name} (${venue.id}) stores the derived tag "${tag}" — ${DERIVED_TAGS[tag]}, ` +
+            `so the venue does not need to list it`
+        );
+    }
+}
+
 // ---- Output ----
 console.log('=== Summary ===');
 console.log('Total venues:', data.listings.length);

--- a/test/tags.test.mjs
+++ b/test/tags.test.mjs
@@ -1,0 +1,132 @@
+/**
+ * Unit tests for js/utils/tags.js.
+ *
+ * The interesting property is deduplication. Two tags are DERIVED rather than
+ * stored — `dedicated` from the venue flag, `special-event` from a schedule
+ * entry being `frequency: "once"` — and each is prepended by whichever module
+ * knows the condition. Neither prepend can see whether the venue also lists
+ * that tag, so `renderTags` is where the two sources have to reconcile (#208).
+ *
+ * `initTagConfig` no-ops its stylesheet work when `document` is undefined,
+ * which is what lets this run under `node --test` with no DOM.
+ */
+
+import { describe, it, before } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { renderTags, renderTagBadge, initTagConfig, getTagConfig, buildTagStyles } from '../js/utils/tags.js';
+
+const DEFS = {
+    dedicated: { label: 'Dedicated', color: '#7c3aed', textColor: '#ffffff' },
+    'special-event': { label: 'Special Event', color: '#ec4899', textColor: '#ffffff' },
+    lgbtq: { label: 'LGBTQ+', color: '#d946ef', textColor: '#ffffff' },
+    dive: { label: 'Dive Bar', color: '#a16207', textColor: '#ffffff' },
+};
+
+/** Tag ids in render order, read back out of the emitted markup. */
+function renderedTags(htmlString) {
+    return [...String(htmlString).matchAll(/data-tag="([^"]+)"/g)].map((m) => m[1]);
+}
+
+before(() => initTagConfig(DEFS));
+
+describe('renderTags — a tag renders at most once', () => {
+    it('drops a stored copy of the injected `dedicated` tag', () => {
+        // Latent before #208: no venue set both, but nothing prevented it.
+        const out = renderTags(['dedicated', 'dive'], { dedicated: true });
+        assert.deepEqual(renderedTags(out), ['dedicated', 'dive']);
+    });
+
+    it('drops a stored copy of `special-event`, which VenueCard prepends', () => {
+        // The live case: austin-deaf-club stores special-event and its only
+        // show is a `once` entry, so VenueCard hands over ['special-event',
+        // 'lgbtq', 'special-event'] and the badge rendered twice.
+        const out = renderTags(['special-event', 'lgbtq', 'special-event']);
+        assert.deepEqual(renderedTags(out), ['special-event', 'lgbtq']);
+    });
+
+    it('collapses any repeat, not just the two derived ids', () => {
+        assert.deepEqual(renderedTags(renderTags(['dive', 'lgbtq', 'dive'])), ['dive', 'lgbtq']);
+    });
+
+    it('keeps the derived tag first and the rest in order', () => {
+        const out = renderTags(['lgbtq', 'dive'], { dedicated: true });
+        assert.deepEqual(renderedTags(out), ['dedicated', 'lgbtq', 'dive']);
+    });
+});
+
+describe('renderTags — unchanged behaviour', () => {
+    it('renders an ordinary list once each', () => {
+        assert.deepEqual(renderedTags(renderTags(['lgbtq', 'dive'])), ['lgbtq', 'dive']);
+    });
+
+    it('prepends dedicated when the venue is dedicated and does not store it', () => {
+        assert.deepEqual(renderedTags(renderTags(['dive'], { dedicated: true })), ['dedicated', 'dive']);
+    });
+
+    it('returns empty string for no tags, rather than an empty wrapper', () => {
+        assert.equal(renderTags([]), '');
+        assert.equal(renderTags(null), '');
+        assert.equal(renderTags(undefined), '');
+    });
+
+    it('skips ids with no definition, and emits nothing if none survive', () => {
+        assert.deepEqual(renderedTags(renderTags(['lgbtq', 'no-such-tag'])), ['lgbtq']);
+        assert.equal(renderTags(['no-such-tag']), '');
+    });
+
+    it('wraps the badges in .venue-tags', () => {
+        assert.match(renderTags(['lgbtq']), /^<div class="venue-tags">.*<\/div>$/s);
+    });
+});
+
+describe('renderTagBadge', () => {
+    it('renders a span by default and an anchor when given an href', () => {
+        assert.match(renderTagBadge('lgbtq'), /^<span class="tag" data-tag="lgbtq">LGBTQ\+<\/span>$/);
+        assert.match(renderTagBadge('lgbtq', { href: '?tag=lgbtq' }),
+            /^<a class="tag" data-tag="lgbtq" href="\?tag=lgbtq">LGBTQ\+<\/a>$/);
+    });
+
+    it('returns empty for an unknown id', () => {
+        assert.equal(renderTagBadge('nope'), '');
+    });
+
+    it('escapes a hostile label rather than emitting it raw', () => {
+        initTagConfig({ ...DEFS, evil: { label: '<img src=x onerror=alert(1)>', color: '#000', textColor: '#fff' } });
+        const out = renderTagBadge('evil');
+        assert.equal(out.includes('<img'), false, 'raw markup survived');
+        assert.match(out, /&lt;img/);
+        initTagConfig(DEFS);
+    });
+});
+
+describe('buildTagStyles — colours come from curator data, so they are validated', () => {
+    it('emits one rule per tag', () => {
+        const css = buildTagStyles({ lgbtq: { color: '#d946ef', textColor: '#fff' } });
+        assert.equal(css, '.tag[data-tag="lgbtq"]{background:#d946ef;color:#fff}');
+    });
+
+    it('skips a colour that could break out of the rule', () => {
+        // A stylesheet has no escaping: a stray `}` would end the rule and
+        // start a new one, so bad values are dropped rather than emitted.
+        const css = buildTagStyles({ bad: { color: 'red}.x{display:none', textColor: '#fff' } });
+        assert.equal(css, '');
+    });
+
+    it('skips an id an attribute selector could not carry', () => {
+        assert.equal(buildTagStyles({ 'a"]{x': { color: '#fff', textColor: '#000' } }), '');
+    });
+
+    it('accepts the colour forms the data actually uses', () => {
+        for (const c of ['#fff', '#ffffff', 'rebeccapurple', 'rgb(1, 2, 3)', 'hsl(1, 2%, 3%)']) {
+            assert.notEqual(buildTagStyles({ t: { color: c, textColor: '#000' } }), '', c);
+        }
+    });
+});
+
+describe('getTagConfig', () => {
+    it('returns the definition, or null for an unknown id', () => {
+        assert.equal(getTagConfig('lgbtq').label, 'LGBTQ+');
+        assert.equal(getTagConfig('nope'), null);
+    });
+});


### PR DESCRIPTION
Closes #208.

## The card

> **Austin Deaf Club** — ⭐ Rainbow Party: Colors of Love
> `Special Event` `LGBTQ+` `Special Event`

## Why, and why it is bigger than one venue

Two tags are **derived at render time** rather than stored, each prepended by whichever module knows the condition — and neither prepend can see whether the venue also lists that id itself:

| Tag | Prepended by | When |
|---|---|---|
| `dedicated` | `renderTags()` | `venue.dedicated === true` |
| `special-event` | `VenueCard` (compact card) | the rendered entry is `frequency: "once"` |

`austin-deaf-club` stores `special-event` in its `tags` and its only show is a `once` entry, so `renderTags` received `['special-event','lgbtq','special-event']`.

**The `dedicated` collision was latent, not live.** No venue today sets `dedicated: true` *and* lists `"dedicated"` — but nothing prevented it, and that one would have doubled on all six render paths rather than one. Worth naming, because a fix aimed only at `special-event` would have left it.

## The fix, and where it goes

One `[...new Set(...)]` in **`renderTags()`** — the single funnel all six call sites go through. That covers the live case, the latent one, and any tag derived in future. Order preserved, first occurrence wins, so a derived tag keeps the leading position it already rendered in.

Fixing it in `VenueCard` instead would have handled only the compact card and left `dedicated` exposed everywhere.

### Verified across the whole page, not just the one card

```
cards scanned            : 239
cards with duplicate tags: 0
Austin Deaf Club         : ["Special Event", "LGBTQ+"]
```

## `js/data.json` is deliberately untouched

Removing `special-event` from that venue would also strip the badge from the modal, detail pane and both map cards — five of the six call sites pass `venue.tags` with no injection, so only the calendar card would keep it.

Whether "hosts one-time events" is a property of the *venue* or only of the *event* is an editorial question, and that file is curator-owned. So instead `validate-data.js` gains a **warning** (non-fatal, exits 0):

```
- Austin Deaf Club (austin-deaf-club) stores the derived tag "special-event" —
  derived from a schedule entry with frequency "once", so the venue does not need to list it
```

It also covers `dedicated` in `tags` alongside `dedicated: true`, and skips a stored `dedicated` on a non-dedicated venue, which is a real tag rather than a duplicate.

## Tests

`js/utils/tags.js` is a pure module — `initTagConfig` already no-ops its stylesheet work when `document` is undefined — so this is unit coverage, not e2e, per the repo's split. **New file, `test/tags.test.mjs`: 17 cases**, the first for this module.

They cover the dedup (both derived tags plus an arbitrary repeat), the unchanged behaviour around it, and two things that were untested and worth pinning while I was in here: `renderTagBadge` escaping a hostile label, and `buildTagStyles` rejecting a colour that could break out of its CSS rule (`red}.x{display:none`) — a stylesheet has no equivalent of HTML escaping, so that validation is load-bearing.

**Confirmed against the planted original bug** — removing the `new Set(...)` fails 3 of them:

```
tests 206   pass 203   fail 3
```

## Docs

- Spec §12 gains a **"Derived tags"** subsection stating the invariant and why it exists.
- Its badge class corrected: the spec said `.venue-tag`, which #166 replaced. The real class is `.tag` with `data-tag="<id>"`; `.venue-tag` now survives only in a CSS comment about what it replaced.
- CLAUDE.md's tag table and rendering note updated, and MapView added to the list of renderers (it was missing).

| Gate | Result |
|---|---|
| `npm run test:unit` | **206 passed** (+17) |
| `npm test` (e2e, `--workers=1`) | **77 passed** |
| `npm run validate:all` | clean — 11 warnings, the new one plus the known #135 venues |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
