### PR TITLE
#212: Teach the submit form the cities registry, and offer 'fifth'

### DIFF
--- a/js/submit.js
+++ b/js/submit.js
@@ -37,6 +37,7 @@ const TAG_GRID_EXCLUDE = new Set([
 let tagDefinitions = {};
 let knownKjs = {};        // id → { name, ... }  (ADR-007 registries)
 let knownCompanies = {};
+let knownCities = {};     // id → { name }       (#170 city vocabulary)
 
 function getUserSelectableTagIds() {
     return Object.keys(tagDefinitions).filter(id => !TAG_GRID_EXCLUDE.has(id));
@@ -55,9 +56,18 @@ function matchRegistryId(registry, typed) {
     return hit ? hit[0] : null;
 }
 
-/** Fill a <datalist> with the registry's names, so typing suggests known hosts. */
-function populateHostSuggestions() {
-    for (const [listId, registry] of [['known-kjs', knownKjs], ['known-companies', knownCompanies]]) {
+/** Fill a <datalist> with a registry's names, so typing suggests known values. */
+function populateSuggestions() {
+    const lists = [
+        ['known-kjs', knownKjs],
+        ['known-companies', knownCompanies],
+        // #170 made address.city a closed vocabulary that validate-data.js
+        // hard-fails on. Free text is what produced 19 distinct strings for 17
+        // real cities, and this form could still emit "Hutto/Round Rock"
+        // verbatim (#212).
+        ['known-cities', knownCities],
+    ];
+    for (const [listId, registry] of lists) {
         const list = document.getElementById(listId);
         if (!list) continue;
         list.innerHTML = Object.values(registry)
@@ -83,7 +93,8 @@ function populateHostSuggestions() {
         tagDefinitions = data.tagDefinitions || {};
         knownKjs = data.kjs || {};
         knownCompanies = data.companies || {};
-        populateHostSuggestions();
+        knownCities = data.cities || {};
+        populateSuggestions();
     } catch (error) {
         console.error('Could not load tag definitions from js/data.json:', error);
         grid.innerHTML = '<p class="validation-error">Could not load the tag list. Everything else on this form still works.</p>';
@@ -292,6 +303,7 @@ function addScheduleEntry() {
                 <option value="second">Second</option>
                 <option value="third">Third</option>
                 <option value="fourth">Fourth</option>
+                <option value="fifth">Fifth</option>
                 <option value="last">Last</option>
                 <option value="once">One-Time Event</option>
             </select>
@@ -549,13 +561,25 @@ function collectFormData() {
         if (other) contactMethods.push({ type: 'other', value: other });
     }
 
+    // `address.city` is a closed vocabulary (#170) that validate-data.js hard-
+    // fails on, but a venue in a suburb the registry doesn't list yet is still
+    // a real submission. So the value passes through and the email flags it,
+    // the same reconciliation route an unrecognised host takes — rejecting the
+    // report would lose the venue to save the curator one lookup.
+    const cityNote = matchRegistryId(knownCities, venue.address.city)
+        ? ''
+        : `"${venue.address.city}" is not in the cities registry. Add it to `
+          + `data.json's "cities" map, or correct the spelling — validate-data.js `
+          + `fails the venue otherwise.`;
+
     return {
         venue,
         notes,
         submitterName,
         submitterType,
         contactMethods,
-        hostNote
+        hostNote,
+        cityNote
     };
 }
 
@@ -594,6 +618,10 @@ function formatEmailBody(data) {
     // the ref shape can't hold.
     if (data.hostNote) {
         body += 'HOST:\n' + data.hostNote + '\n\n';
+    }
+
+    if (data.cityNote) {
+        body += 'CITY:\n' + data.cityNote + '\n\n';
     }
 
     body += 'VENUE JSON (copy/paste ready):\n';

--- a/submit.html
+++ b/submit.html
@@ -86,7 +86,12 @@
                         <div class="form-row form-row--address">
                             <div class="form-group">
                                 <label for="city">City <span class="required">*</span></label>
-                                <input type="text" id="city" name="city" required autocomplete="address-level2" value="Austin">
+                                <!-- Suggestions come from data.json's city registry (#170/#212).
+                                     Not a <select>: a venue in a suburb we haven't listed yet is a
+                                     valid submission, and the email flags an unknown city for the
+                                     curator rather than rejecting the report. -->
+                                <input type="text" id="city" name="city" required autocomplete="address-level2" value="Austin" list="known-cities">
+                                <datalist id="known-cities"></datalist>
                             </div>
                             <div class="form-group">
                                 <label for="state">State</label>
@@ -111,6 +116,7 @@
                                         <option value="second">Second</option>
                                         <option value="third">Third</option>
                                         <option value="fourth">Fourth</option>
+                                        <option value="fifth">Fifth</option>
                                         <option value="last">Last</option>
                                         <option value="once">One-Time Event</option>
                                     </select>


### PR DESCRIPTION
Closes #212.

## The gap, measured rather than read

#170 made `address.city` a **closed vocabulary** — `js/data.json` carries a `cities` registry and `validate-data.js` **hard-fails** any venue outside it. The submit form never learned that.

I drove the real form and captured what it emits:

```json
"address": { "street": "123 Main St", "city": "Hutto/Round Rock", "state": "TX", "zip": "78701" }
```

`"Hutto/Round Rock"` is the **exact string #170 had to fold in**. Free text is what produced 19 distinct strings for 17 real cities, and the form could still reproduce one verbatim — a bare `<input>` with no `list`, no `pattern`, no validation.

Everything else it emits was already correct: no `neighborhood`, proper schedule shape, tags array, no derived tags, host refs per #124 Phase 3.

## The fix

The City input now offers the registry's names via a `<datalist>`, loaded from `data.json` alongside `tagDefinitions` / `kjs` / `companies`. **No parallel hardcoded list** — adding a city to the registry surfaces it here automatically, the same rule the tag grid follows.

**Deliberately not a `<select>`, and an unknown city is not blocked.** A venue in a suburb the registry doesn't list yet is a real submission, and rejecting it loses the venue to save the curator one lookup. It passes through and the email gains a `CITY:` section naming the problem — the same reconciliation route an unrecognised host already takes.

```
CITY:
"Hutto/Round Rock" is not in the cities registry. Add it to data.json's
"cities" map, or correct the spelling — validate-data.js fails the venue otherwise.
```

## Second gap: `fifth`

The frequency dropdown offered `every, first, second, third, fourth, last, once`. The schema's enum also allows **`fifth`**, so a fifth-of-the-month show could not be submitted at all. Added to both the static first entry and the generated ones — they had drifted from each other only in that both were missing it.

## Verified through the real form

| | |
|---|---|
| datalist | 17 cities, matching the registry exactly |
| frequency options | `…fourth, fifth, last, once` |
| `fifth` round-trip | emitted as `"frequency": "fifth"` |
| unknown city | still submits, email carries the CITY note |
| known city (`Round Rock`) | submits with **no** CITY note |

| Gate | Result |
|---|---|
| `npm run test:unit` | **206 passed** |
| `npm test` (e2e, `--workers=1`) | **77 passed** |
| `npm run validate:all` | clean |

---

*Found while auditing both data consumers against the current shape. The curator has the same city gap plus two export-breaking bugs — reported separately; it lives outside this repo.*
