### PR TITLE
#215/#217: Filter the map by date, and only by date

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -381,8 +381,10 @@ Tags are rendered as color-coded badges in VenueCard, VenueModal, VenueDetailPan
 
 ### Immersive Map Mode
 - `app.js` adds `body.view--map` class; CSS hides header/footer/nav, map fills viewport
-- Floating elements: `.map-controls` (left), `.map-view-switcher` (right), `.map-venue-card` (details)
+- Floating elements: `.map-date-filter` + `.map-controls` (left), `.map-view-switcher` (right), `.map-venue-card` (details)
 - Escape key: closes card first, then exits to Calendar view
+- **Date filter** (#215): All / This Week / Today, held in `mapDateFilter` state. "This week" is Sunday–Saturday of the current week, not the next seven days. Composes with search and the dedicated toggle; the predicate is `venueHasShowInRange()` in `js/services/venues.js`. Deliberately not in the URL — the spans are relative to "now"
+- Leaflet loads from a CDN *after* render, so `MapView.destroyed` gates the async `initMap()`. Skip that guard and a destroyed instance claims the live one's container, which leaves a map nothing is subscribed to — see functional spec §4
 
 ### Search Feature
 - Navigation updates `searchQuery` state; the views subscribe to that key. State is the only change channel — never `setState` and then `emit` the same change (#157)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -383,11 +383,12 @@ Tags are rendered as color-coded badges in VenueCard, VenueModal, VenueDetailPan
 - `app.js` adds `body.view--map` class; CSS hides header/footer/nav, map fills viewport
 - Floating elements: `.map-date-filter` + `.map-controls` (left), `.map-view-switcher` (right), `.map-venue-card` (details)
 - Escape key: closes card first, then exits to Calendar view
-- **Date filter** (#215): All / This Week / Today, held in `mapDateFilter` state. "This week" is Sunday–Saturday of the current week, not the next seven days. Composes with search and the dedicated toggle; the predicate is `venueHasShowInRange()` in `js/services/venues.js`. Deliberately not in the URL — the spans are relative to "now"
+- **Date filter** (#215): All / This Week / Today, held in `mapDateFilter` state. "This week" is Sunday–Saturday of the current week, not the next seven days. The predicate is `venueHasShowInRange()` in `js/services/venues.js`. Deliberately not in the URL — the spans are relative to "now"
+- **The map filters by time, not text** (#217). Its two filters are the date buttons and the dedicated toggle; `MapView` does not subscribe to `searchQuery` and `getVenuesWithCoordinates()` takes no such option. The nav bar holding the search input is hidden in immersive mode, so a carried-over query used to narrow the map invisibly
 - Leaflet loads from a CDN *after* render, so `MapView.destroyed` gates the async `initMap()`. Skip that guard and a destroyed instance claims the live one's container, which leaves a map nothing is subscribed to — see functional spec §4
 
 ### Search Feature
-- Navigation updates `searchQuery` state; the views subscribe to that key. State is the only change channel — never `setState` and then `emit` the same change (#157)
+- Navigation updates `searchQuery` state; **WeeklyView and AlphabeticalView** subscribe to that key. MapView does not — the map filters by time (#217). State is the only change channel — never `setState` and then `emit` the same change (#157)
 - `venues.js` → `venueMatchesSearch()` matches: venue name, city, venue-level host name/affiliation, per-show host name/affiliation, and tags (ID + label)
 - It does **not** match event names. This file claimed otherwise for months; `venueMatchesSearch` never reads `entry.eventName`. Adding it is a one-line change tracked on #37 — until that lands, the omission is the truth
 - Empty results collapse day cards to header-only (`.day-card--empty`)

--- a/css/views.css
+++ b/css/views.css
@@ -764,6 +764,9 @@ body.view--map .app-layout__detail {
     left: 60px; /* Offset to avoid Leaflet's +/- zoom controls */
     display: flex;
     flex-direction: column;
+    align-items: flex-start; /* each control keeps its own width — without this
+                                the stretch default widens "Hide Dedicated" to
+                                match the date filter pill below it */
     gap: var(--spacing-sm);
     z-index: var(--z-map-ui);
 }
@@ -802,6 +805,44 @@ body.view--map .app-layout__detail {
     background: var(--color-primary);
     color: var(--color-white);
     border-color: var(--color-primary);
+}
+
+/* Date-range filter — segmented pill at the head of the control stack (#215).
+   Shares the view switcher's treatment: one card-coloured container, transparent
+   segments, the active one filled. */
+.map-date-filter {
+    display: flex;
+    gap: var(--spacing-xs);
+    background: var(--bg-card);
+    padding: var(--spacing-xs);
+    border-radius: var(--border-radius-lg);
+    box-shadow: var(--shadow-lg);
+    border: 1px solid var(--border-color);
+}
+
+.map-date-filter__btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: var(--size-icon-lg); /* 44px touch target */
+    padding: var(--spacing-sm) var(--spacing-md);
+    border-radius: var(--border-radius);
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: var(--font-size-sm);
+    font-weight: 500;
+    white-space: nowrap;
+    transition: all var(--transition-fast);
+}
+
+.map-date-filter__btn:hover {
+    background: var(--color-gray-700);
+    color: var(--text-primary);
+}
+
+.map-date-filter__btn--active {
+    background: var(--color-primary);
+    color: var(--color-white);
 }
 
 /* Floating view switcher (right side) */
@@ -980,6 +1021,14 @@ body.view--map .app-layout__detail {
     .map-controls {
         top: var(--spacing-sm);
         left: 50px; /* Offset to avoid Leaflet's +/- zoom controls */
+    }
+
+    /* The date filter and the view switcher share the top band on a phone, and
+       the switcher is icon-only here. Tightening the segments keeps all three
+       labels on one line without the two colliding at 360px. */
+    .map-date-filter__btn {
+        padding: var(--spacing-sm);
+        font-size: var(--font-size-xs);
     }
 
     .map-view-switcher {

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -287,8 +287,46 @@ The map isn't date-scoped, so "today" (`new Date()`) is the reference date. `Map
 
 | Control | Position | Contents |
 |---------|----------|----------|
+| `.map-date-filter` | Top-left, above the rest of the stack | All / This Week / Today date filter |
 | `.map-controls` | Top-left | "Show/Hide Dedicated" toggle button |
 | `.map-view-switcher` | Top-right | Calendar and A-Z buttons to exit map view |
+
+### Date Filter
+
+Three segmented buttons decide which slice of the schedule the map plots. The map
+is otherwise the one view with no date dimension, which made "where's karaoke
+tonight?" a question only the calendar could answer.
+
+| Button | Plots venues with a show… | Span |
+|--------|---------------------------|------|
+| **All** (default) | at any point from today on | `startOfToday()` → open-ended |
+| **This Week** | on any day of the week we are in | Sunday 00:00 → Saturday 23:59 (`getWeekRange`) |
+| **Today** | on the current date | today → today |
+
+- **"This week" is the calendar week, not the next seven days.** Asked on a
+  Thursday, it still includes Sunday through Wednesday — the same framing the
+  weekly view uses.
+- **"All" is not "everything".** A venue whose only listing is a one-time event
+  that has already happened drops off the map; before this filter existed it was
+  plotted forever. Recurring entries always qualify, since they keep recurring.
+- **Closures still count.** A show excluded on a date (see [Exclusion Dates on
+  the Map](#exclusion-dates-on-the-map)) keeps its venue in the result — the
+  dimmed marker and "Closed Today" banner exist to announce that, and filtering
+  the venue out would suppress the announcement.
+- **The three filters compose.** Date filter, search, and the dedicated toggle
+  are separate gates in `updateMarkers()`; narrowing one leaves the others alone.
+- Selecting a filter repaints markers **in place** — the Leaflet instance is not
+  rebuilt, matching the dedicated toggle's contract (see §21, #157).
+- If the selected venue falls out of the plotted set, its floating card closes
+  rather than describing a pin that is no longer on the map.
+- State lives in `mapDateFilter` (`'all' | 'week' | 'today'`). It is deliberately
+  **not** in the URL — the spans are relative to "now", so a shared `?date=today`
+  link would mean something different tomorrow. It persists for the session, the
+  way `showDedicated` does.
+- The predicate is `venueHasShowInRange(venue, start, end)` in
+  `js/services/venues.js`, reached through `getVenuesWithCoordinates({ dateRange })`.
+  Bounded spans walk each date through `scheduleMatchesDate`, so the map and the
+  weekly calendar always agree about what happens on a given day.
 
 ### Escape Key
 
@@ -301,9 +339,22 @@ Displays "X of Y venues have map coordinates" at the bottom. If some venues lack
 
 ### Filtering
 
+- Respects the date filter — All / This Week / Today, see above
 - Respects the "Show dedicated" toggle — re-renders markers when changed
 - Respects the search query — only matching venues with coordinates shown
 - Only venues with valid `coordinates.lat` and `coordinates.lng` appear on the map
+
+> **Implementation note — the deep-link guard.** Leaflet is loaded from a CDN
+> after the view renders, so a MapView can be destroyed while its load is still
+> in flight. `app.js` boots `?view=map` with two `renderView()` calls (the
+> `setState` notification plus the explicit call), which is exactly that case.
+> Until #215 the dead instance still ran `initMap()` and claimed the live
+> instance's container; the survivor threw "Map container is already
+> initialized", kept `this.map` null, and every `updateMarkers()` returned early.
+> The map on screen belonged to a destroyed component with no subscriptions, so
+> the date filter, the dedicated toggle, and search all silently did nothing —
+> but only when the map was entered by URL, which is how shared links arrive.
+> `MapView.destroyed` is set in `onDestroy()` and checked before `initMap()`.
 
 ---
 
@@ -1257,6 +1308,7 @@ second notification renders every listening view a second time.
 | `view` | string | `'weekly'` | Base view: `weekly`, `alphabetical`, or `map`. What is actually on screen also depends on `hostFilter` — `router.resolveView()` combines the two |
 | `weekStart` | Date | Today | Start date for weekly view |
 | `showDedicated` | boolean | `true` | Whether dedicated venues are shown |
+| `mapDateFilter` | string | `'all'` | Which date span the map plots: `all`, `week`, or `today` ([Section 4](#4-map-view)). Map-only, and kept out of the URL because the spans are relative to "now" |
 | `searchQuery` | string | `''` | Current search text |
 | `hostFilter` | string | `''` | KJ/host filter, URL-driven via `?kj=`. `all` and `none` are route sentinels, not host names (ADR-011) |
 | `selectedVenue` | object/null | `null` | Currently selected venue |
@@ -1268,7 +1320,7 @@ Which view subscribes to which key:
 |---|---|
 | `WeeklyView` | `weekStart`, `showDedicated`, `searchQuery` |
 | `AlphabeticalView` | `showDedicated`, `searchQuery` |
-| `MapView` | `showDedicated`, `searchQuery` |
+| `MapView` | `showDedicated`, `searchQuery`, `mapDateFilter` |
 | `KJDossierView` | *(nothing)* — its only input is `hostFilter`, and a `hostFilter` change replaces the view instance outright |
 | `KJIndexView` | *(nothing)* — static listing |
 | `Navigation` | `view`, `weekStart`, `showDedicated`, `hostFilter`. Deliberately **not** `searchQuery`, which would re-render the input and lose focus mid-typing |

--- a/docs/functional-spec.md
+++ b/docs/functional-spec.md
@@ -313,8 +313,9 @@ tonight?" a question only the calendar could answer.
   the Map](#exclusion-dates-on-the-map)) keeps its venue in the result — the
   dimmed marker and "Closed Today" banner exist to announce that, and filtering
   the venue out would suppress the announcement.
-- **The three filters compose.** Date filter, search, and the dedicated toggle
-  are separate gates in `updateMarkers()`; narrowing one leaves the others alone.
+- **The map has exactly two filters** — this one and the dedicated toggle. They
+  are separate gates in `updateMarkers()`, so narrowing one leaves the other
+  alone. Text search is not among them ([Section 9](#9-search)).
 - Selecting a filter repaints markers **in place** — the Leaflet instance is not
   rebuilt, matching the dedicated toggle's contract (see §21, #157).
 - If the selected venue falls out of the plotted set, its floating card closes
@@ -341,7 +342,11 @@ Displays "X of Y venues have map coordinates" at the bottom. If some venues lack
 
 - Respects the date filter — All / This Week / Today, see above
 - Respects the "Show dedicated" toggle — re-renders markers when changed
-- Respects the search query — only matching venues with coordinates shown
+- **Ignores the search query.** The map filters by time, not text (#217). Its
+  date buttons are its search; the text box belongs to the Calendar and A-Z
+  views, and the navigation bar holding it is hidden in immersive map mode
+  anyway — a query carried over from the calendar used to narrow the map with
+  nothing on screen to explain it or clear it
 - Only venues with valid `coordinates.lat` and `coordinates.lng` appear on the map
 
 > **Implementation note — the deep-link guard.** Leaflet is loaded from a CDN
@@ -550,7 +555,10 @@ A `VENUE_DETAIL_SHOWN` emit was removed in #157 - nothing listened for it. Card 
 
 ## 9 Search
 
-The app includes a global search bar that filters venues across all views.
+A search bar in the navigation filters venues in the two list views — Weekly and
+Alphabetical. The Map is not one of them: it filters by time instead ([Section
+4](#date-filter)), and its immersive mode hides the navigation bar the input
+lives in.
 
 ### Search Input
 
@@ -578,7 +586,7 @@ Search is case-insensitive substring matching. A venue matches if the query appe
 
 - **Weekly:** Day cards with no matching venues collapse to `.day-card--empty`. Days with matches show only matching venues. Extended sections also filter to show only matching venues (see [Section 2: Extended Sections](#extended-sections)).
 - **Alphabetical:** Letter groups only show matching venues. Letters with no matches disappear. Empty results show "No venues match your search."
-- **Map:** Only matching venues with coordinates appear as markers.
+- **Map:** Not filtered by search at all (#217). `MapView` does not subscribe to `searchQuery`, and `getVenuesWithCoordinates()` takes no such option — the option was removed rather than left accepted-and-ignored, so wiring search back in has to be a deliberate change in the service, not a silent one at a call site. The map's filters are the date buttons and the dedicated toggle.
 
 ### Extended Sections and Search
 
@@ -1320,7 +1328,7 @@ Which view subscribes to which key:
 |---|---|
 | `WeeklyView` | `weekStart`, `showDedicated`, `searchQuery` |
 | `AlphabeticalView` | `showDedicated`, `searchQuery` |
-| `MapView` | `showDedicated`, `searchQuery`, `mapDateFilter` |
+| `MapView` | `showDedicated`, `mapDateFilter`. Deliberately **not** `searchQuery` — the map filters by time (#217) |
 | `KJDossierView` | *(nothing)* — its only input is `hostFilter`, and a `hostFilter` change replaces the view instance outright |
 | `KJIndexView` | *(nothing)* — static listing |
 | `Navigation` | `view`, `weekStart`, `showDedicated`, `hostFilter`. Deliberately **not** `searchQuery`, which would re-render the input and lose focus mid-typing |

--- a/e2e/map-view.spec.js
+++ b/e2e/map-view.spec.js
@@ -64,4 +64,60 @@ test.describe('Map view — immersive mode & controls', () => {
     await expect(dedicatedBtn).toBeVisible();
   });
 
+  // Date filter (#215). These assert the control, not the marker set: which
+  // venues get plotted is decided by venueHasShowInRange, which the unit suite
+  // covers date by date without waiting on the Leaflet CDN.
+  test('date filter offers All, This Week and Today', async ({ page }) => {
+    const filter = page.locator('.map-date-filter');
+    await expect(filter).toBeVisible();
+
+    await expect(filter.locator('[data-date-filter]')).toHaveCount(3);
+    await expect(filter.locator('[data-date-filter="all"]')).toHaveText('All');
+    await expect(filter.locator('[data-date-filter="week"]')).toHaveText('This Week');
+    await expect(filter.locator('[data-date-filter="today"]')).toHaveText('Today');
+  });
+
+  test('date filter starts on All', async ({ page }) => {
+    const all = page.locator('[data-date-filter="all"]');
+    await expect(all).toHaveClass(/map-date-filter__btn--active/);
+    await expect(all).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('[data-date-filter="today"]')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  test('clicking a date filter moves the active state', async ({ page }) => {
+    await page.locator('[data-date-filter="today"]').click();
+
+    await expect(page.locator('[data-date-filter="today"]')).toHaveClass(/map-date-filter__btn--active/);
+    await expect(page.locator('[data-date-filter="all"]')).not.toHaveClass(/map-date-filter__btn--active/);
+    await expect(page.locator('[data-date-filter="all"]')).toHaveAttribute('aria-pressed', 'false');
+
+    await page.locator('[data-date-filter="week"]').click();
+
+    await expect(page.locator('[data-date-filter="week"]')).toHaveClass(/map-date-filter__btn--active/);
+    await expect(page.locator('[data-date-filter="today"]')).not.toHaveClass(/map-date-filter__btn--active/);
+  });
+
+  test('date filter does not tear the map down', async ({ page }) => {
+    // The dedicated toggle stopped re-rendering in #157 because a re-render
+    // rebuilds the Leaflet instance from scratch. The date filter follows the
+    // same contract: patch the buttons, repaint the markers, keep the map.
+    const mapContainer = page.locator('.map-view__container');
+    await expect(mapContainer).toBeVisible();
+
+    await page.locator('[data-date-filter="today"]').click();
+    await page.locator('[data-date-filter="all"]').click();
+
+    await expect(mapContainer).toBeVisible();
+    await expect(page.locator('.map-view')).toHaveCount(1);
+  });
+
+  test('date filter and dedicated toggle are independent', async ({ page }) => {
+    await page.locator('[data-date-filter="today"]').click();
+    await page.locator('[data-action="toggle-dedicated"]').click();
+
+    // Toggling one must not reset the other — they compose in updateMarkers().
+    await expect(page.locator('[data-date-filter="today"]')).toHaveClass(/map-date-filter__btn--active/);
+    await expect(page.locator('[data-action="toggle-dedicated"]')).toHaveText('Show Dedicated');
+  });
+
 });

--- a/e2e/map-view.spec.js
+++ b/e2e/map-view.spec.js
@@ -111,6 +111,34 @@ test.describe('Map view — immersive mode & controls', () => {
     await expect(page.locator('.map-view')).toHaveCount(1);
   });
 
+  // #217: the map filters by time, not text. A query typed on the calendar must
+  // not follow the user onto the map, where the input that set it is hidden.
+  test('a search carried over from the calendar does not filter the map', async ({ page }) => {
+    await page.goto('/');
+    await page.locator('[data-search="query"]').fill('ego');
+    await page.locator('.nav-btn[data-view="map"]').click();
+    await expect(page.locator('.map-view')).toBeVisible({ timeout: 15000 });
+
+    // The service is what MapView plots through; ask it the same question the
+    // view does. Counting markers would put the Leaflet CDN on the gate's
+    // critical path for an assertion that is really about the filter set.
+    const counts = await page.evaluate(async () => {
+      const { getVenuesWithCoordinates } = await import('/js/services/venues.js');
+      return {
+        plotted: getVenuesWithCoordinates().length,
+        matchingTheQuery: getVenuesWithCoordinates().filter(v => /ego/i.test(v.name)).length,
+      };
+    });
+
+    expect(counts.matchingTheQuery).toBeGreaterThan(0);
+    expect(counts.plotted).toBeGreaterThan(counts.matchingTheQuery);
+  });
+
+  test('the search input is not reachable on the map', async ({ page }) => {
+    await expect(page.locator('.navigation-container')).not.toBeVisible();
+    await expect(page.locator('[data-search="query"]')).not.toBeVisible();
+  });
+
   test('date filter and dedicated toggle are independent', async ({ page }) => {
     await page.locator('[data-date-filter="today"]').click();
     await page.locator('[data-action="toggle-dedicated"]').click();

--- a/js/core/state.js
+++ b/js/core/state.js
@@ -11,6 +11,8 @@
  *   on screen also depends on hostFilter; router.resolveView() combines them.
  * - weekStart: Date for current week in weekly view
  * - showDedicated: Whether to show dedicated karaoke venues
+ * - mapDateFilter: Which date span the map plots — 'all' | 'week' | 'today'.
+ *   Map-only, so it stays out of the URL; entering the map always starts at 'all'.
  * - searchQuery: Global search filter text
  * - hostFilter: KJ/host name filter, URL-driven via ?kj= (substring match against host name/company only)
  * - selectedVenue: Currently selected venue object (for modal/detail pane)
@@ -28,6 +30,7 @@ const state = {
     view: 'weekly',
     weekStart: new Date(),
     showDedicated: true,
+    mapDateFilter: 'all',
     searchQuery: '',
     hostFilter: '',
     selectedVenue: null,

--- a/js/services/venues.js
+++ b/js/services/venues.js
@@ -6,6 +6,10 @@
  * - venuePasses(venue, ctx): the dedicated + search + activePeriod gate
  * - byName(a, b): alphabetical, leading articles ignored
  *
+ * One more predicate sits alongside rather than inside those, because only the
+ * map asks it:
+ * - venueHasShowInRange(venue, start, end): does the schedule reach this span
+ *
  * Entry points:
  * - initVenues(data): Initialize from js/data.json (resolves host refs)
  * - getAllVenues() / getVenueById(id)
@@ -27,7 +31,7 @@
  * second implementation waiting to disagree with the first.
  */
 
-import { scheduleMatchesDate, isDateInRange } from '../utils/date.js';
+import { scheduleMatchesDate, isDateInRange, getDateRange, parseLocalDate } from '../utils/date.js';
 import { getSortableName, containsIgnoreCase } from '../utils/string.js';
 import { getTagConfig } from '../utils/tags.js';
 import { getVenueHosts } from '../utils/render.js';
@@ -86,6 +90,52 @@ export function venuePasses(venue, { date = null, includeDedicated = true, searc
     if (searchQuery && !venueMatchesSearch(venue, searchQuery)) return false;
     if (!isVenueActiveOn(venue, date || new Date())) return false;
     return true;
+}
+
+/**
+ * Does this venue have at least one show inside a date range?
+ *
+ * A schedule-only question. It does not consider `active`, `activePeriod`,
+ * search, or the dedicated toggle — callers compose it with `venuePasses`, which
+ * owns those. Used by the map's date filter (#215).
+ *
+ * Two modes, because "all future shows" is not a finite span:
+ *
+ *   - **Open-ended** (`end` is null) — a recurring entry qualifies on sight,
+ *     since it keeps recurring; only `once` entries have a date to fall behind.
+ *     This is what separates "All" from today's unfiltered map: a venue whose
+ *     sole listing is last month's special event drops off.
+ *   - **Bounded** — walks each date in the span and asks `scheduleMatchesDate`,
+ *     the same matcher the weekly calendar uses, so the two views agree about
+ *     what happens on a given day.
+ *
+ * Exclusions are deliberately not consulted. A closed occurrence is still an
+ * occurrence: the weekly view lists it with a closure banner and the map dims
+ * its marker, and filtering it out would hide the very thing those cues exist to
+ * announce.
+ *
+ * @param {Object} venue - Venue object (needs .schedule)
+ * @param {Date} start - First date in the span
+ * @param {Date|null} [end=null] - Last date, or null for open-ended
+ * @returns {boolean}
+ */
+export function venueHasShowInRange(venue, start, end = null) {
+    const entries = venue?.schedule || [];
+    if (!entries.length) return false;
+    if (!start && !end) return true;
+
+    if (!end) {
+        const from = new Date(start);
+        from.setHours(0, 0, 0, 0);
+        return entries.some(entry => {
+            if (entry.frequency !== 'once') return true;
+            return entry.date ? parseLocalDate(entry.date) >= from : false;
+        });
+    }
+
+    return getDateRange(start, end).some(date =>
+        entries.some(entry => scheduleMatchesDate(entry, date))
+    );
 }
 
 /**
@@ -377,13 +427,19 @@ function venueMatchesDedicated(venue, query) {
  * Get active venues with coordinates (for map view).
  * Also filters out venues outside their activePeriod for today.
  * @param {Object} options - Filter options
+ * @param {boolean} [options.includeDedicated=true]
+ * @param {string} [options.searchQuery='']
+ * @param {{start: Date, end: Date|null}|null} [options.dateRange=null] - Only
+ *   venues with a show in this span (see venueHasShowInRange). Null = no date
+ *   constraint, which is the whole directory rather than the map's "All".
  * @returns {Object[]} Active venues with valid coordinates
  */
 export function getVenuesWithCoordinates(options = {}) {
-    const { includeDedicated = true, searchQuery = '' } = options;
+    const { includeDedicated = true, searchQuery = '', dateRange = null } = options;
     return getActiveVenues().filter(v =>
         v.coordinates?.lat && v.coordinates?.lng &&
-        venuePasses(v, { includeDedicated, searchQuery })
+        venuePasses(v, { includeDedicated, searchQuery }) &&
+        (!dateRange || venueHasShowInRange(v, dateRange.start, dateRange.end))
     );
 }
 

--- a/js/services/venues.js
+++ b/js/services/venues.js
@@ -426,19 +426,25 @@ function venueMatchesDedicated(venue, query) {
 /**
  * Get active venues with coordinates (for map view).
  * Also filters out venues outside their activePeriod for today.
+ *
+ * Takes no `searchQuery` (#217). The map filters by time, not text — its date
+ * buttons are its search, and the text box belongs to the calendar and A-Z
+ * views. The option is removed rather than accepted-and-ignored so that wiring
+ * search back in has to be a deliberate change here, not a silent one at a call
+ * site.
+ *
  * @param {Object} options - Filter options
  * @param {boolean} [options.includeDedicated=true]
- * @param {string} [options.searchQuery='']
  * @param {{start: Date, end: Date|null}|null} [options.dateRange=null] - Only
  *   venues with a show in this span (see venueHasShowInRange). Null = no date
  *   constraint, which is the whole directory rather than the map's "All".
  * @returns {Object[]} Active venues with valid coordinates
  */
 export function getVenuesWithCoordinates(options = {}) {
-    const { includeDedicated = true, searchQuery = '', dateRange = null } = options;
+    const { includeDedicated = true, dateRange = null } = options;
     return getActiveVenues().filter(v =>
         v.coordinates?.lat && v.coordinates?.lng &&
-        venuePasses(v, { includeDedicated, searchQuery }) &&
+        venuePasses(v, { includeDedicated }) &&
         (!dateRange || venueHasShowInRange(v, dateRange.start, dateRange.end))
     );
 }

--- a/js/utils/date.js
+++ b/js/utils/date.js
@@ -108,6 +108,36 @@ export function getWeekStart(date) {
 }
 
 /**
+ * Today at local midnight — the reference point for anything that asks
+ * "from now on". Written out rather than inlined because `new Date()` carries a
+ * time of day, and comparing that against a date-only schedule value silently
+ * drops today's own shows.
+ * @returns {Date} Today, 00:00:00.000 local
+ */
+export function startOfToday() {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+}
+
+/**
+ * The Sunday–Saturday span containing a date.
+ *
+ * The whole calendar week, not the rest of it: a week that started on Sunday is
+ * still "this week" on Thursday, and the map's This Week filter says so.
+ *
+ * @param {Date} [date] - Any date within the week (defaults to today)
+ * @returns {{ start: Date, end: Date }} Sunday 00:00 through Saturday 23:59:59.999
+ */
+export function getWeekRange(date = new Date()) {
+    const start = getWeekStart(date);
+    const end = new Date(start);
+    end.setDate(end.getDate() + 6);
+    end.setHours(23, 59, 59, 999);
+    return { start, end };
+}
+
+/**
  * Whether a given week is the one containing today.
  *
  * Previously implemented twice with two different algorithms — Navigation

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -54,11 +54,17 @@ export class MapView extends Component {
         // One subscription per key that affects which markers are shown.
         // `showDedicated` was previously covered twice — once here and once via
         // FILTER_CHANGED — so a single toggle ran updateMarkers three times.
+        //
+        // `searchQuery` is deliberately absent (#217). The map filters by time,
+        // not text: the date buttons are its search, and the text box belongs to
+        // the two list views. It also could not have worked honestly here — the
+        // navigation bar that holds the input is display:none in immersive map
+        // mode, so a query carried over from the calendar narrowed the map with
+        // nothing on screen to explain it or clear it.
         this.subscribe(subscribe('showDedicated', () => {
             this.syncDedicatedButton();
             this.updateMarkers();
         }));
-        this.subscribe(subscribe('searchQuery', () => this.updateMarkers()));
         this.subscribe(subscribe('mapDateFilter', () => {
             this.syncDateFilterButtons();
             this.updateMarkers();
@@ -382,12 +388,12 @@ export class MapView extends Component {
         this.markerMap.clear();
         this.selectedMarker = null;
 
-        // Get venues with coordinates, respecting filters. The three gates
-        // compose: a search under "Today" narrows to venues matching both.
+        // Get venues with coordinates, respecting the map's own two filters —
+        // the date span and the dedicated toggle. Text search is not one of
+        // them (#217).
         const showDedicated = getState('showDedicated');
-        const searchQuery = getState('searchQuery');
         const dateRange = dateFilterRange(getState('mapDateFilter'));
-        const venues = getVenuesWithCoordinates({ includeDedicated: showDedicated, searchQuery, dateRange });
+        const venues = getVenuesWithCoordinates({ includeDedicated: showDedicated, dateRange });
 
         // A selected venue can drop out of the plotted set — switch to "Today"
         // while a Friday-only venue's card is open and the card is left

--- a/js/views/MapView.js
+++ b/js/views/MapView.js
@@ -13,7 +13,30 @@ import { escapeHtml } from '../utils/string.js';
 import { buildDirectionsUrl, shareVenue } from '../utils/url.js';
 import { renderTags } from '../utils/tags.js';
 import { renderScheduleCompact, renderVenueDetailSections } from '../utils/render.js';
-import { getVenueExclusionForDate, isPastOnceEvent } from '../utils/date.js';
+import { getVenueExclusionForDate, isPastOnceEvent, getWeekRange, startOfToday } from '../utils/date.js';
+
+/**
+ * The map's date filter (#215). One row per button: the id state carries, the
+ * label, and the span it plots.
+ *
+ * `range` is a function, not a value, so it is computed per click — a tab left
+ * open past midnight answers with the new day rather than the day it was opened.
+ * An open-ended `end: null` means "everything from here on"; see
+ * venueHasShowInRange for what that does to recurring vs one-time entries.
+ *
+ * Adding a span (This Month, say) is a new row here plus nothing else.
+ */
+const DATE_FILTERS = [
+    { id: 'all', label: 'All', range: () => ({ start: startOfToday(), end: null }) },
+    { id: 'week', label: 'This Week', range: () => getWeekRange() },
+    { id: 'today', label: 'Today', range: () => ({ start: startOfToday(), end: startOfToday() }) },
+];
+
+/** Resolve a filter id to its span, falling back to the first row. */
+function dateFilterRange(id) {
+    const filter = DATE_FILTERS.find(f => f.id === id) || DATE_FILTERS[0];
+    return filter.range();
+}
 
 export class MapView extends Component {
     init() {
@@ -23,6 +46,10 @@ export class MapView extends Component {
         this.clusterGroup = null;
         this.selectedVenue = null;
         this.selectedMarker = null;
+        // Set by onDestroy so the in-flight loadLeaflet() promise knows not to
+        // build a map for an instance nobody is listening to any more. See
+        // afterRender.
+        this.destroyed = false;
 
         // One subscription per key that affects which markers are shown.
         // `showDedicated` was previously covered twice — once here and once via
@@ -32,6 +59,10 @@ export class MapView extends Component {
             this.updateMarkers();
         }));
         this.subscribe(subscribe('searchQuery', () => this.updateMarkers()));
+        this.subscribe(subscribe('mapDateFilter', () => {
+            this.syncDateFilterButtons();
+            this.updateMarkers();
+        }));
 
         this.bindEscape();
     }
@@ -47,6 +78,19 @@ export class MapView extends Component {
         const showDedicated = getState('showDedicated');
         btn.classList.toggle('map-controls__btn--active', showDedicated);
         btn.textContent = showDedicated ? 'Hide Dedicated' : 'Show Dedicated';
+    }
+
+    /**
+     * Mark the active date-filter button. Patched in place for the same reason
+     * the dedicated label is: a re-render would rebuild the Leaflet map.
+     */
+    syncDateFilterButtons() {
+        const active = getState('mapDateFilter');
+        this.$$('[data-date-filter]').forEach(btn => {
+            const isActive = btn.dataset.dateFilter === active;
+            btn.classList.toggle('map-date-filter__btn--active', isActive);
+            btn.setAttribute('aria-pressed', String(isActive));
+        });
     }
 
     /**
@@ -78,6 +122,7 @@ export class MapView extends Component {
         const venuesWithCoords = getVenuesWithCoordinates();
         const totalVenues = getAllVenues().length;
         const showDedicated = getState('showDedicated');
+        const activeDateFilter = getState('mapDateFilter');
 
         return `
             <div class="map-view">
@@ -96,6 +141,16 @@ export class MapView extends Component {
 
                 <!-- Floating Controls (left side) -->
                 <div class="map-controls">
+                    <div class="map-date-filter" role="group" aria-label="Filter venues by date">
+                        ${DATE_FILTERS.map(f => `
+                            <button
+                                class="map-date-filter__btn ${f.id === activeDateFilter ? 'map-date-filter__btn--active' : ''}"
+                                data-date-filter="${f.id}"
+                                aria-pressed="${f.id === activeDateFilter}"
+                                type="button"
+                            >${f.label}</button>
+                        `).join('')}
+                    </div>
                     <button
                         class="map-controls__btn map-controls__btn--text ${showDedicated ? 'map-controls__btn--active' : ''}"
                         data-action="toggle-dedicated"
@@ -126,8 +181,21 @@ export class MapView extends Component {
     }
 
     afterRender() {
-        // Load Leaflet if not already loaded
+        // Load Leaflet if not already loaded.
+        //
+        // The destroyed check is what keeps the map alive on a `?view=map` deep
+        // link. app.js boots that path with two renderView() calls — setState
+        // notifies the `view` subscriber AND the explicit call runs — so a first
+        // MapView is built and destroyed before its CDN load resolves. Without
+        // this guard that dead instance still ran initMap(), claiming the live
+        // instance's container: the survivor then threw "Map container is
+        // already initialized", left this.map null, and every updateMarkers()
+        // returned early. The map on screen belonged to a destroyed component
+        // with no subscriptions, so the date filter, the dedicated toggle and
+        // search all silently did nothing — only on that entry path, which is
+        // the one shared links use.
         this.loadLeaflet().then(() => {
+            if (this.destroyed) return;
             this.initMap();
         });
 
@@ -149,6 +217,13 @@ export class MapView extends Component {
         // unchanged here.
         this.delegate('click', '[data-action="toggle-dedicated"]', () => {
             setState({ showDedicated: !getState('showDedicated') });
+        });
+
+        // Date filter. Same contract as the dedicated toggle — setState and
+        // stop; the `mapDateFilter` subscriber repaints the markers and the
+        // button states.
+        this.delegate('click', '[data-date-filter]', (e, target) => {
+            setState({ mapDateFilter: target.dataset.dateFilter });
         });
 
         // Close venue card
@@ -307,10 +382,19 @@ export class MapView extends Component {
         this.markerMap.clear();
         this.selectedMarker = null;
 
-        // Get venues with coordinates, respecting filters
+        // Get venues with coordinates, respecting filters. The three gates
+        // compose: a search under "Today" narrows to venues matching both.
         const showDedicated = getState('showDedicated');
         const searchQuery = getState('searchQuery');
-        const venues = getVenuesWithCoordinates({ includeDedicated: showDedicated, searchQuery });
+        const dateRange = dateFilterRange(getState('mapDateFilter'));
+        const venues = getVenuesWithCoordinates({ includeDedicated: showDedicated, searchQuery, dateRange });
+
+        // A selected venue can drop out of the plotted set — switch to "Today"
+        // while a Friday-only venue's card is open and the card is left
+        // describing a pin that is no longer on the map. Close it.
+        if (this.selectedVenue && !venues.some(v => v.id === this.selectedVenue.id)) {
+            this.hideVenueCard();
+        }
 
         // Create cluster group
         this.clusterGroup = L.markerClusterGroup({
@@ -518,6 +602,9 @@ export class MapView extends Component {
     onDestroy() {
         // The keydown listener is not unbound here — it went through
         // this.addEventListener, so Component.destroy() has already removed it.
+
+        // Anything still in flight (the Leaflet CDN load) must not act.
+        this.destroyed = true;
 
         // Clean up cluster group
         if (this.clusterGroup) {

--- a/test/date.test.mjs
+++ b/test/date.test.mjs
@@ -28,6 +28,8 @@ import {
   formatTime12,
   formatTime24,
   formatTimeRange,
+  getWeekRange,
+  startOfToday,
 } from '../js/utils/date.js';
 
 // January 2026 has five Fridays: 2, 9, 16, 23, 30.
@@ -51,6 +53,41 @@ describe('date fixtures are what the tests assume', () => {
     }
     assert.equal(FEB(28).getDate(), 28);
     assert.notEqual(getDayName(FEB(28)), 'friday');
+  });
+});
+
+describe('getWeekRange / startOfToday — the map date filter spans (#215)', () => {
+  // Jan 2026: the 4th is a Sunday, the 10th the Saturday that closes that week.
+  it('spans Sunday 00:00 to Saturday 23:59 around a midweek date', () => {
+    const { start, end } = getWeekRange(new Date(2026, 0, 7, 15, 30));
+    assert.equal(getDayName(start), 'sunday');
+    assert.equal(start.getDate(), 4);
+    assert.equal(getDayName(end), 'saturday');
+    assert.equal(end.getDate(), 10);
+    assert.equal(start.getHours(), 0);
+    assert.equal(end.getHours(), 23);
+  });
+
+  it('includes days already past — a week is the whole week', () => {
+    // Asked on Thursday, Sunday is still in range. This is the behaviour the
+    // "This Week" button promises, as opposed to "the next seven days".
+    const { start } = getWeekRange(JAN(8));
+    assert.equal(start.getDate(), 4);
+  });
+
+  it('a Sunday is its own week start; a Saturday closes its own week', () => {
+    assert.equal(getWeekRange(JAN(4)).start.getDate(), 4);
+    assert.equal(getWeekRange(JAN(10)).end.getDate(), 10);
+    assert.equal(getWeekRange(JAN(11)).start.getDate(), 11);
+  });
+
+  it('startOfToday strips the time of day', () => {
+    const d = startOfToday();
+    assert.equal(d.getHours(), 0);
+    assert.equal(d.getMinutes(), 0);
+    assert.equal(d.getSeconds(), 0);
+    assert.equal(d.getMilliseconds(), 0);
+    assert.equal(d.toDateString(), new Date().toDateString());
   });
 });
 

--- a/test/venues.test.mjs
+++ b/test/venues.test.mjs
@@ -11,7 +11,7 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { venuePasses, venueMatchesSearch, venueMatchesHost, byName, initVenues, hostMatches, resolveHostLabel } from '../js/services/venues.js';
+import { venuePasses, venueHasShowInRange, venueMatchesSearch, venueMatchesHost, byName, initVenues, hostMatches, resolveHostLabel } from '../js/services/venues.js';
 import { hydrateVenues, isHostRef, resolveHostRef } from '../js/utils/hosts.js';
 
 const JAN = (d) => new Date(2026, 0, d);
@@ -67,6 +67,89 @@ describe('venuePasses', () => {
     const v = venue({ activePeriod: { start: '2026-01-02', end: '2026-01-02' } });
     assert.equal(venuePasses(v, { date: JAN(2) }), true);
     assert.equal(venuePasses(v, { date: JAN(3) }), false);
+  });
+});
+
+describe('venueHasShowInRange — the map date filter (#215)', () => {
+  // Jan 2026: Sun 4 through Sat 10 is a whole week; the 9th is its Friday.
+  const WEEK = { start: JAN(4), end: JAN(10) };
+
+  it('bounded: matches a recurring show whose day falls in the span', () => {
+    assert.equal(venueHasShowInRange(venue(), WEEK.start, WEEK.end), true);
+  });
+
+  it('bounded: rejects a recurring show whose day does not fall in the span', () => {
+    // Friday the 9th is in the week, but a single Saturday (the 10th) is not.
+    const v = venue();
+    assert.equal(venueHasShowInRange(v, JAN(10), JAN(10)), false);
+    assert.equal(venueHasShowInRange(v, JAN(9), JAN(9)), true);
+  });
+
+  it('bounded: honours ordinal frequencies via scheduleMatchesDate', () => {
+    // First Friday of Jan 2026 is the 2nd, so it misses the Jan 4-10 week.
+    const v = venue({ schedule: [{ frequency: 'first', day: 'Friday' }] });
+    assert.equal(venueHasShowInRange(v, WEEK.start, WEEK.end), false);
+    assert.equal(venueHasShowInRange(v, JAN(2), JAN(2)), true);
+  });
+
+  it('bounded: matches a one-time event dated inside the span', () => {
+    const v = venue({ schedule: [{ frequency: 'once', date: '2026-01-07' }] });
+    assert.equal(venueHasShowInRange(v, WEEK.start, WEEK.end), true);
+    assert.equal(venueHasShowInRange(v, JAN(11), JAN(17)), false);
+  });
+
+  it('open-ended: a recurring show always qualifies', () => {
+    // No end date means "from here on", and a recurring entry keeps recurring —
+    // there is nothing to walk.
+    assert.equal(venueHasShowInRange(venue(), JAN(4), null), true);
+  });
+
+  it('open-ended: a past one-time event does not, a future one does', () => {
+    // This is the whole difference between the map's "All" and the unfiltered
+    // map it replaced: a venue whose sole listing already happened drops off.
+    const past = venue({ schedule: [{ frequency: 'once', date: '2026-01-01' }] });
+    const future = venue({ schedule: [{ frequency: 'once', date: '2026-02-14' }] });
+    assert.equal(venueHasShowInRange(past, JAN(4), null), false);
+    assert.equal(venueHasShowInRange(future, JAN(4), null), true);
+  });
+
+  it('open-ended: today counts as future', () => {
+    const v = venue({ schedule: [{ frequency: 'once', date: '2026-01-04' }] });
+    assert.equal(venueHasShowInRange(v, JAN(4), null), true);
+  });
+
+  it('open-ended: a mixed schedule qualifies on its recurring entry alone', () => {
+    const v = venue({
+      schedule: [
+        { frequency: 'once', date: '2026-01-01' },
+        { frequency: 'every', day: 'Friday' },
+      ],
+    });
+    assert.equal(venueHasShowInRange(v, JAN(4), null), true);
+  });
+
+  it('an excluded occurrence still counts — closures are shown, not hidden', () => {
+    // The weekly view lists a closed night with a banner and the map dims its
+    // marker. Filtering it out would suppress the cue.
+    const v = venue({
+      schedule: [{
+        frequency: 'every',
+        day: 'Friday',
+        exclusions: [{ date: '2026-01-09', reason: 'Holiday' }],
+      }],
+    });
+    assert.equal(venueHasShowInRange(v, JAN(9), JAN(9)), true);
+  });
+
+  it('an empty or missing schedule never matches', () => {
+    assert.equal(venueHasShowInRange(venue({ schedule: [] }), JAN(4), JAN(10)), false);
+    assert.equal(venueHasShowInRange(venue({ schedule: [] }), JAN(4), null), false);
+    assert.equal(venueHasShowInRange({}, JAN(4), null), false);
+    assert.equal(venueHasShowInRange(null, JAN(4), null), false);
+  });
+
+  it('no span at all is no constraint', () => {
+    assert.equal(venueHasShowInRange(venue(), null, null), true);
   });
 });
 


### PR DESCRIPTION
Closes #215. Closes #217.

## What

Three segmented buttons at the head of the map's floating control stack:

| Button | Plots venues with a show… | Against today's data |
|---|---|---|
| **All** (default) | at any point from today on | 71 of 75 pinned venues |
| **This Week** | any day of the current Sunday–Saturday week | 66 |
| **Today** | on the current date | 21 |

"This Week" is the *calendar* week, not the next seven days — asked on a
Thursday it still includes Sunday, matching how the weekly view frames a week.

"All" is not "everything": the four venues it drops are the ones whose only
listing is a one-time event that already happened — the same four tracked on
#135. Before this, the map plotted them forever.

The map's two filters — the date span and the dedicated toggle — compose: Today +
Hide Dedicated gives 15 of the 21.

## Search is off the map (#217)

The map filters by time. The date buttons are its search; the text box belongs to
the Calendar and A-Z views.

It could not have worked honestly here anyway — `.navigation-container`, which
holds the input, is `display: none` in immersive map mode, so a query typed on
the calendar followed you onto the map and narrowed it with nothing on screen to
explain or clear it:

```
before:  search "ego" on calendar -> click MAP -> 1 pin,  searchVisible: false
after:   search "ego" on calendar -> click MAP -> 71 pins, searchVisible: false
```

`MapView` no longer subscribes to `searchQuery`, and the option is **removed**
from `getVenuesWithCoordinates()` rather than accepted-and-ignored — wiring
search back in now has to be a deliberate change in the service, not a silent one
at a call site. Calendar and A-Z are untouched.

## Two decisions worth flagging

**Closures still count.** A show excluded on a date keeps its venue on the map.
The weekly view lists a closed night with a banner and the map dims its marker —
filtering the venue out would suppress the cue those exist to raise.

**The filter is not in the URL.** The spans are relative to "now", so a shared
`?date=today` link would mean something different tomorrow. It sits in
`mapDateFilter` and persists for the session, the way `showDedicated` does.

## The bug this uncovered

The feature did not work on `/?view=map` — and neither, it turns out, did the
dedicated toggle or search.

Leaflet loads from a CDN *after* the view renders. `app.js` boots that path with
two `renderView()` calls (the `setState` notification plus the explicit call), so
the first MapView is destroyed while its load is still in flight. That dead
instance still ran `initMap()` and claimed the live instance's container. The
survivor threw `Map container is already initialized`, kept `this.map` null, and
returned early from every `updateMarkers()`. The map on screen belonged to a
destroyed component with no subscriptions — frozen, but only when the map was
entered by URL, which is how shared links arrive.

`MapView.destroyed` is now set in `onDestroy()` and checked before `initMap()`.

Measured on both entry paths, clicking "Today":

```
before:  ?view=map  26 -> 26 marker icons   errors=["Map container is already initialized."]
         nav click  26 -> 12                errors=[]
after:   ?view=map  26 -> 12                errors=[]
         nav click  26 -> 12                errors=[]
```

## Testing

- `npm run test:unit` — 221 pass (13 new: 9 on `venueHasShowInRange`, 4 on
  `getWeekRange`/`startOfToday`)
- `npm test` — 84 pass (7 new in `map-view.spec.js`)
- `npm run validate:all` — clean

The e2e additions assert the control, not the marker set: which venues get
plotted is decided by `venueHasShowInRange`, which the unit suite covers date by
date without waiting on the Leaflet CDN. Marker counts were verified live
instead — the numbers in the table above are measured from the running app at
1280×800 and 360×740.

## Screenshots

Desktop and phone were both checked for collision between the new pill and the
top-right view switcher; `.map-controls` gained `align-items: flex-start` so
"Hide Dedicated" keeps its own width instead of stretching to the pill's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
